### PR TITLE
Namespace expansion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ set(rcutils_sources
   src/find.c
   src/get_env.c
   src/split.c
-  src/string_array.c)
+  src/strdup.c
+  src/string_array.c
+)
 set_source_files_properties(
   ${rcutils_sources}
   PROPERTIES language "C")
@@ -147,6 +149,13 @@ if(BUILD_TESTING)
   )
   if(TARGET test_filesystem)
     target_link_libraries(test_filesystem ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_strdup
+    test/test_strdup.cpp
+  )
+  if(TARGET test_strdup)
+    target_link_libraries(test_strdup ${PROJECT_NAME})
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(rcutils_sources
   src/error_handling.c
   src/filesystem.c
   src/find.c
+  src/format_string.c
   src/get_env.c
   src/split.c
   src/strdup.c
@@ -156,6 +157,13 @@ if(BUILD_TESTING)
   )
   if(TARGET test_strdup)
     target_link_libraries(test_strdup ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_format_string
+    test/test_format_string.cpp
+  )
+  if(TARGET test_format_string)
+    target_link_libraries(test_format_string ${PROJECT_NAME})
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(rcutils_sources
   src/split.c
   src/strdup.c
   src/string_array.c
+  src/string_map.c
 )
 set_source_files_properties(
   ${rcutils_sources}
@@ -164,6 +165,13 @@ if(BUILD_TESTING)
   )
   if(TARGET test_format_string)
     target_link_libraries(test_format_string ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_string_map
+    test/test_string_map.cpp
+  )
+  if(TARGET test_string_map)
+    target_link_libraries(test_string_map ${PROJECT_NAME})
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,13 @@ if(BUILD_TESTING)
     target_link_libraries(test_string_map ${PROJECT_NAME})
   endif()
 
+  rcutils_custom_add_gtest(test_isalnum_no_locale
+    test/test_isalnum_no_locale.cpp
+  )
+  if(TARGET test_isalnum_no_locale)
+    target_link_libraries(test_isalnum_no_locale ${PROJECT_NAME})
+  endif()
+
 endif()
 
 ament_export_dependencies(ament_cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(rcutils_sources
   src/find.c
   src/format_string.c
   src/get_env.c
+  src/repl_str.c
   src/split.c
   src/strdup.c
   src/string_array.c
@@ -179,6 +180,13 @@ if(BUILD_TESTING)
   )
   if(TARGET test_isalnum_no_locale)
     target_link_libraries(test_isalnum_no_locale ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_repl_str
+    test/test_repl_str.cpp
+  )
+  if(TARGET test_repl_str)
+    target_link_libraries(test_repl_str ${PROJECT_NAME})
   endif()
 
 endif()

--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -20,6 +20,7 @@ extern "C"
 {
 #endif
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "rcutils/macros.h"
@@ -85,6 +86,26 @@ RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_allocator_t
 rcutils_get_default_allocator(void);
+
+/// Return true if the given allocator has non-null function pointers.
+/**
+ * Will also return false if the allocator pointer is null.
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+bool
+rcutils_allocator_is_valid(const rcutils_allocator_t * allocator);
+
+#define RCUTILS_CHECK_ALLOCATOR(allocator, fail_statement) \
+  if (!rcutils_allocator_is_valid(allocator)) { \
+    fail_statement; \
+  }
+
+#define RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, msg, fail_statement) \
+  if (!rcutils_allocator_is_valid(allocator)) { \
+    RCUTILS_SET_ERROR_MSG(msg, rcutils_get_default_allocator()) \
+    fail_statement; \
+  }
 
 /// Emulate the behavior of [reallocf](https://linux.die.net/man/3/reallocf).
 /**

--- a/include/rcutils/format_string.h
+++ b/include/rcutils/format_string.h
@@ -1,0 +1,78 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__FORMAT_STRING_H_
+#define RCUTILS__FORMAT_STRING_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+/// Return a newly allocated string, created with a format string.
+/**
+ * This function is identical to rcutils_format_string_limit() except it has an
+ * implicit limit of 2048.
+ * For longer format strings, see rcutils_format_string_limit().
+ */
+#define rcutils_format_string(allocator, format_string, ...) \
+  rcutils_format_string_limit(allocator, 2048, format_string, __VA_ARGS__)
+
+/// Return a newly allocated string, created with a format string up to a limit.
+/**
+ * This function uses snprintf_s to determine the length of the resulting
+ * string and allocates storage for the resulting string, formats it, and
+ * then returns the result.
+ *
+ * This function can fail and therefore return null if the format_string is
+ * null or if memory allocation fails or if snprintf_s fails.
+ * An error message is not set in any case.
+ *
+ * Output strings that would be longer than the given limit are truncated.
+ *
+ * All returned strings are null terminated.
+ *
+ * The format string is passed to snprintf_s(), see its documentation for
+ * how to use the format string.
+ *
+ * The returned string must be deallocated using the same allocator given once
+ * it is no longer needed.
+ *
+ * \see rcutils_snprintf_s()
+ *
+ * \param[in] allocator the allocator to use for allocation
+ * \param[in] limit maximum length of the output string
+ * \param[in] format_string format of the output, must be null terminated
+ * \returns output string or null if there was an error
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+char *
+rcutils_format_string_limit(
+  rcutils_allocator_t allocator,
+  size_t limit,
+  const char * format_string,
+  ...);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__FORMAT_STRING_H_

--- a/include/rcutils/isalnum_no_locale.h
+++ b/include/rcutils/isalnum_no_locale.h
@@ -1,0 +1,47 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__ISALNUM_NO_LOCALE_H_
+#define RCUTILS__ISALNUM_NO_LOCALE_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+/// Custom isalnum() which is not affected by locale.
+static inline
+bool
+rcutils_isalnum_no_locale(char c)
+{
+  // if in '0', ..., '9', then ok
+  if (c >= 0x30 /*0*/ && c <= 0x39 /*9*/) {
+    return true;
+  }
+  // if in 'A', ..., 'Z', then ok
+  if (c >= 0x41 /*A*/ && c <= 0x5a /*Z*/) {
+    return true;
+  }
+  // if in 'a', ..., 'z', then ok
+  if (c >= 0x61 /*a*/ && c <= 0x7a /*z*/) {
+    return true;
+  }
+  return false;
+}
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__ISALNUM_NO_LOCALE_H_

--- a/include/rcutils/repl_str.h
+++ b/include/rcutils/repl_str.h
@@ -1,0 +1,140 @@
+// Copyright 2015-2016 Laird Shaw
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This function is based on the repl_str() from (on 2017-04-25):
+//
+//   http://creativeandcritical.net/str-replace-c
+//
+// It is released under the Public Domain, and has been placed additionally
+// under the Apache 2.0 license by me (William Woodall).
+//
+// It has been modified to take a custom allocator and to fit some of our
+// style standards.
+
+#ifndef RCUTILS__REPL_STR_H_
+#define RCUTILS__REPL_STR_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+/// Replace all the occurrences of one string for another in the given string.
+/**
+ * Documentation copied from the source with minor tweaks:
+ *
+ * ----
+ *
+ * **Description:**
+ *
+ * Replaces in the string `str` all the occurrences of the source string `from`
+ * with the destination string `to`.
+ * The lengths of the strings `from` and `to` may differ.
+ * The string `to` may be of any length, but the string `from` must be of
+ * non-zero length - the penalty for providing an empty string for the `from`
+ * parameter is an infinite loop.
+ * In addition, none of the three parameters may be NULL.
+ *
+ * **Returns:**
+ *
+ * The post-replacement string, or NULL if memory for the new string could not
+ * be allocated.
+ * Does not modify the original string.
+ * The memory for the returned post-replacement string may be deallocated with
+ * given allocator's deallocate function when it is no longer required.
+ *
+ * **Performance:**
+ *
+ * In case you are curious enough to want to compare this implementation with
+ * alternative implementations, you are welcome to compile and run the code in
+ * the benchmarking file,
+ * [replacebench.c](http://creativeandcritical.net/downloads/replacebench.c).
+ * In that file, the above function is included as `replace_cache`, and the
+ * functions originally published on this page as `replace_str2` and
+ * `replace_str` are included as `replace_opt2` and `replace_opt`.
+ * Code/functions are included from the comp.lang.c thread,
+ * [how to replace a substring in a string using C?]
+ * (https://groups.google.com/forum/#!msg/comp.lang.c/sgydS2lDgxc/v2MRxRrAQncJ),
+ * from answers to the stackoverflow question,
+ * [What is the function to replace string in C?]
+ * (http://stackoverflow.com/questions/779875/what-is-the-function-to-replace-string-in-c),
+ * and also from private correspondence.
+ * See the comments top of file for instructions on compiling and running it.
+ *
+ * In most scenarios, the fastest replacement function, by around 10-20%,
+ * is Albert Chan's `replace_smart`, followed by the above function:
+ * `repl_str` aka `replace_cache`.
+ * There are some scenarios, though, where `repl_str` is faster than
+ * `replace_smart`, sometimes by up to 200%.
+ * These scenarios involve long strings with few matches.
+ * Why, if Albert's function is generally slightly faster than the above
+ * `repl_str` function, is it not the focus of this page?
+ * Because it generally uses much more memory than `repl_str`.
+ *
+ * The third fastest implementation is typically `replace_str2` aka
+ * `replace_opt2`.
+ * For longer strings in the case in which the lengths of the "from" and "to"
+ * strings differ, `repl_str` aka `replace_cache` beats it by margins of up to
+ * about 80%.
+ * For smaller strings, and in the case where the lengths of the "from" and
+ * "to" strings are identical, `replace_str2` aka `replace_opt2` is faster,
+ * by a maximum margin of about 35%, sometimes in those scenarios beating
+ * `replace_smart` too.
+ * Some of the other functions are also faster for smaller strings.
+ * The even-match point between `replace_str2` and `repl_str`
+ * (assuming "from" and "to" string lengths differ) depends on how far into
+ * the string the final match occurs, how many matches there are, and the
+ * comparative lengths of the old and "to" strings, but roughly it occurs for
+ * strings of 700-800 bytes in length.
+ *
+ * This analysis is based on compiling with [GCC](https://gcc.gnu.org/) and
+ * testing on a 64-bit Intel platform running Linux, however brief testing with
+ * [Microsoft Visual C++ 2010 Express]
+ * (https://www.visualstudio.com/en-US/products/visual-studio-express-vs)
+ * (scroll down to "Additional information" at that link) on Windows 7 seemed
+ * to produce similar results.
+ *
+ * ----
+ *
+ * Here continues additional documentation added by OSRF.
+ *
+ * The allocator must not be NULL.
+ *
+ * \param[in] str string to have substrings found and replaced within
+ * \param[in] from string to match for replacement
+ * \param[in] to string to replace matched strings with
+ * \param[in] allocator structure defining functions to be used for allocation
+ * \return duplicated `str` with all matches of `from` replaced with `to`
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+char *
+rcutils_repl_str(
+  const char * str,
+  const char * from,
+  const char * to,
+  rcutils_allocator_t * allocator);
+
+// Implementation copied from above mentioned source continues in repl_str.c.
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__REPL_STR_H_

--- a/include/rcutils/snprintf.h
+++ b/include/rcutils/snprintf.h
@@ -1,0 +1,52 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__SNPRINTF_H_
+#define RCUTILS__SNPRINTF_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdio.h>
+
+/// Format a string.
+/**
+ * This function just wraps snprintf() as defined in C11 in a portable way.
+ *
+ * On Windows this defaults to the _TRUNCATE behavior of _snprintf_s().
+ *
+ * \see snprintf()
+ */
+#ifndef _WIN32
+#define rcutils_snprintf snprintf
+#else
+#define rcutils_snprintf(buffer, buffer_size, format, ...) \
+  _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
+#endif
+
+/// Format a string with va_list for arguments, see rcutils_snprintf().
+#ifndef _WIN32
+  #define rcutils_vsnprintf vsnprintf
+#else
+  #define rcutils_vsnprintf(buffer, buffer_size, format, ...) \
+  _vsnprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__SNPRINTF_H_

--- a/include/rcutils/strdup.h
+++ b/include/rcutils/strdup.h
@@ -1,0 +1,74 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__STRDUP_H_
+#define RCUTILS__STRDUP_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+/// Return a duplicated string with an allocator, or null if an error occurs.
+/**
+ * This function is identical to rcutils_strndup() except the length of the
+ * c string does not have to be given and therefore the c string must be
+ * null terminated.
+ *
+ * \see rcutils_strndup()
+ *
+ * \param[in] str null terminated c string to be duplicated
+ * \param[in] allocator the allocator to use for allocation
+ * \returns duplicated string or null if there is an error
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+char *
+rcutils_strdup(const char * str, rcutils_allocator_t allocator);
+
+/// Return a duplicated string with an allocator, or null if an error occurs.
+/**
+ * This function can fail and return null if memory cannot be allocated or
+ * if the input c string pointer is null.
+ * In both cases no error message is set.
+ * The returned string should be deallocated using the given allocator when
+ * it is no longer needed.
+ *
+ * The string_length given does not include the null terminating character.
+ * Therefore a string_length of 0 will still result in a duplicated string, but
+ * the string will be an empty string of strlen 0, but it still must be
+ * deallocated.
+ * All returned strings are null terminated.
+ *
+ * \param[in] str null terminated c string to be duplicated
+ * \param[in] string_length length of the string to duplicate
+ * \param[in] allocator the allocator to use for allocation
+ * \returns duplicated string or null if there is an error
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+char *
+rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allocator);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__STRDUP_H_

--- a/include/rcutils/types.h
+++ b/include/rcutils/types.h
@@ -21,6 +21,7 @@ extern "C"
 #endif
 
 #include "rcutils/types/string_array.h"
+#include "rcutils/types/string_map.h"
 #include "rcutils/types/rcutils_ret.h"
 
 #if __cplusplus

--- a/include/rcutils/types/rcutils_ret.h
+++ b/include/rcutils/types/rcutils_ret.h
@@ -25,6 +25,20 @@ typedef int rcutils_ret_t;
 #define RCUTILS_RET_WARN 1
 #define RCUTILS_RET_ERROR 2
 
+/// Failed to allocate memory return code.
+#define RCUTILS_RET_BAD_ALLOC 10
+/// Invalid argument return code.
+#define RCUTILS_RET_INVALID_ARGUMENT 11
+/// Not enough storage to do operation.
+#define RCUTILS_RET_NOT_ENOUGH_SPACE 12
+
+/// Given string map was either already initialized or was not zero initialized.
+#define RCUTILS_RET_STRING_MAP_ALREADY_INIT 30
+/// Given string map is invalid, perhaps not initialized yet.
+#define RCUTILS_RET_STRING_MAP_INVALID 31
+/// Given key not found in given string map.
+#define RCUTILS_RET_STRING_KEY_NOT_FOUND 32
+
 #if __cplusplus
 }
 #endif

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -1,0 +1,308 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__TYPES__STRING_MAP_H_
+#define RCUTILS__TYPES__STRING_MAP_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+
+#include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+struct rcutils_string_map_impl_t;
+
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_map_t
+{
+  struct rcutils_string_map_impl_t * impl;
+} rcutils_string_map_t;
+
+/// Return an empty string map struct.
+/*
+ * This function returns an empty and zero initialized string map struct.
+ *
+ * Example:
+ *
+ * ```c
+ * // Do not do this:
+ * // rcutils_string_map_t foo;
+ * // rcutils_string_map_fini(&foo); // undefined behavior!
+ *
+ * // Do this instead:
+ * rcutils_string_map_t bar = rcutils_get_zero_initialized_string_array();
+ * rcutils_string_array_fini(&bar); // ok
+ * ```
+ * */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_string_map_t
+rcutils_get_zero_initialized_string_map();
+
+/// Initialize a rcutils_string_map_t, allocating space for given capacity.
+/**
+ * This function initializes the rcutils_string_map_t with a given initial
+ * capacity for entries.
+ * Note this does not allocate space for keys or values in the map, just the
+ * arrays of pointers to the keys and values.
+ * rcutils_string_map_set() should still be used when assigning values.
+ *
+ * The string_map argument should point to allocated memory and should have
+ * been zero initialized with rcutils_get_zero_initialized_string_map().
+ * For example:
+ *
+ * ```c
+ * rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+ * rcutils_ret_t ret =
+ *   rcutils_string_map_init(&string_map, 10, rcutils_get_default_allocator());
+ * if (ret != RCUTILS_RET_OK) {
+ *   // ... do error handling
+ * }
+ * // ... use the string map and when done:
+ * ret = rcutils_string_map_fini(&string_map);
+ * if (ret != RCUTILS_RET_OK) {
+ *   // ... do error handling
+ * }
+ * ```
+ *
+ * \param[inout] string_map rcutils_string_map_t to be initialized
+ * \param[in] initial_capacity the amount of initial capacity for the string map
+ * \param[in] allocator the allocator to use through out the lifetime of the map
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_STRING_MAP_ALREADY_INIT` if already initialized, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_init(
+  rcutils_string_map_t * string_map,
+  size_t initial_capacity,
+  rcutils_allocator_t allocator);
+
+/// Finalize the previously initialized string map struct.
+/**
+ * This function will free any resources which were created when initializing
+ * or when calling rcutils_string_map_set().
+ *
+ * \param[inout] string_map rcutils_string_map_t to be finalized
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_fini(rcutils_string_map_t * string_map);
+
+/// Get the current capacity of the string map.
+/**
+ * This function will return the internal capacity of the map, which is the
+ * maximum number of key value pairs the map could hold.
+ * The capacity can be set initially with rcutils_string_map_init() or
+ * with rcutils_string_map_reserve().
+ * The capacity does not indicate how many key value paris are stored in the
+ * map, the rcutils_string_map_get_size() function can provide that.
+ *
+ * \param[in] string_map rcutils_string_map_t to be queried
+ * \param[out] capacity capacity of the string map
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_get_capacity(const rcutils_string_map_t * string_map, size_t * capacity);
+
+/// Get the current size of the string map.
+/**
+ * This function will return the internal size of the map, which is the
+ * current number of key value pairs in the map.
+ * The size is changed when calling rcutils_string_map_set_no_resize(),
+ * rcutils_string_map_set(), or rcutils_string_map_unset().
+ *
+ * \param[in] string_map rcutils_string_map_t to be queried
+ * \param[out] size size of the string map
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_get_size(const rcutils_string_map_t * string_map, size_t * size);
+
+/// Reserve a given amount of capacity in the map.
+/**
+ * Increases the capacity of the map to at least the given size.
+ *
+ * If the current capacity is less than requested capacity then the capacity
+ * is increased using the allocator given during initialization of the map in
+ * rcutils_string_map_init().
+ * If the requested capacity is less than the current capacity, the capacity
+ * may be reduced, but no existing key value pairs will be truncated to do so.
+ * In effect, the capacity will be shrunk to fit the number of items in map or
+ * the requested capacity, which ever is larger.
+ *
+ * If recovering all resources is desired first call rcutils_string_map_clear()
+ * and then this function with a capacity of 0.
+ *
+ * \param[inout] string_map rcutils_string_map_t to have space reserved in
+ * \param[in] capacity requested size to reserve in the map
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_reserve(rcutils_string_map_t * string_map, size_t capacity);
+
+/// Remove all key value pairs from the map.
+/**
+ * This function will remove all key value pairs from the map, and it will
+ * reclaim all resources allocated as a result of setting key value pairs.
+ * rcutils_string_map_fini() should still be called after this.
+ *
+ * \param[inout] string_map rcutils_string_map_t to have space reserved in
+ * \param[in] capacity requested size to reserve in the map
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_clear(rcutils_string_map_t * string_map);
+
+/// Set a key value pair in the map, increasing capacity if necessary.
+/**
+ * The capacity will be increased if needed using rcutils_string_map_reserve().
+ * Otherwise it is the same as rcutils_string_map_set_no_resize().
+ *
+ * \see rcutils_string_map_set_no_resize()
+ *
+ * \param[inout] string_map rcutils_string_map_t to be updated
+ * \param[in] key map key, must be null terminated c string
+ * \param[in] value value for given map key, must be null terminated c string
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_set(rcutils_string_map_t * string_map, const char * key, const char * value);
+
+/// Set a key value pair in the map but only if the map has enough capacity.
+/**
+ * If the map already contains the given key, the existing value will be
+ * replaced with the given value.
+ * If the map does not contain the given key, and the map has additional
+ * unused capacity, then it will store the given key and value in the map.
+ * If there is no unused capacity in the map, then RCUTILS_RET_NOT_ENOUGH_SPACE
+ * is returned.
+ *
+ * The given key and value c strings are copied into the map, and so storage is
+ * allocated for them in the map when this function is called if necessary.
+ * The storage allocated for this purpose is reclaimed either when
+ * rcutils_string_map_fini() is called on this map or when using this function
+ * or rcutils_string_map_unset().
+ *
+ * Any allocation that occurs in this functions uses the allocator of the map,
+ * which is given when the map is initialized in rcutils_string_map_init().
+ *
+ * \param[inout] string_map rcutils_string_map_t to be updated
+ * \param[in] key map key, must be null terminated c string
+ * \param[in] value value for given map key, must be null terminated c string
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_NOT_ENOUGH_SPACE` if map is full, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_set_no_resize(
+  rcutils_string_map_t * string_map,
+  const char * key,
+  const char * value);
+
+/// Unset a key value pair in the map.
+/**
+ * The key needs to be a null terminated c string.
+ * If the given key is not found, RCUTILS_RET_STRING_KEY_NOT_FOUND is returned.
+ *
+ * \param[inout] string_map rcutils_string_map_t to be updated
+ * \param[in] key map key, must be null terminated c string
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_STRING_KEY_NOT_FOUND` if key not found, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key);
+
+/// Get value given a key.
+/**
+ * The key needs to be a null terminated c string.
+ *
+ * This function can fail, and therefore return NULL, if the key is not found,
+ * or the string_map is NULL or invalid, or if the key is NULL.
+ * In all cases no error message is set.
+ *
+ * The returned value string is still owned by the map, and it should not be
+ * modified or free'd.
+ * This also means that the value pointer becomes invalid if either
+ * rcutils_string_map_clear() or rcutils_string_map_fini() are called or if
+ * the key value pair is updated or removed with one of rcutils_string_map_set()
+ * or rcutils_string_map_set_no_resize() or rcutils_string_map_unset().
+ *
+ * \param[inout] string_map rcutils_string_map_t to be searched
+ * \param[in] key map key, must be null terminated c string
+ * \return value for the given key if successful, or
+ * \return `NULL` for invalid arguments, or
+ * \return `NULL` if the string map is invalid, or
+ * \return `NULL` if key not found, or
+ * \return `NULL` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+const char *
+rcutils_string_map_get(const rcutils_string_map_t * string_map, const char * key);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__TYPES__STRING_MAP_H_

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -301,6 +301,27 @@ RCUTILS_PUBLIC
 const char *
 rcutils_string_map_get(const rcutils_string_map_t * string_map, const char * key);
 
+/// Get value given a key and key length.
+/**
+ * Identical to rcutils_string_map_get() but without relying on key to be a
+ * null terminated c string.
+ *
+ * \param[in] string_map rcutils_string_map_t to be searched
+ * \param[in] key map key
+ * \param[in] key_length map key length
+ * \return value for the given key if successful, or
+ * \return `NULL` for invalid arguments, or
+ * \return `NULL` if the string map is invalid, or
+ * \return `NULL` if key not found, or
+ * \return `NULL` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+const char *
+rcutils_string_map_getn(
+  const rcutils_string_map_t * string_map,
+  const char * key,
+  size_t key_length);
+
 #if __cplusplus
 }
 #endif

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -322,6 +322,78 @@ rcutils_string_map_getn(
   const char * key,
   size_t key_length);
 
+/// Get the next key in the map, unless NULL is given, then get the first key.
+/**
+ * This function allows you iteratively get each key in the map.
+ *
+ * If NULL is given for the key, then the first key in the map is returned.
+ * If that returned key if given to the this function, then the next key in the
+ * map is returned.
+ * If there are no more keys in the map or if the given key is not in the map,
+ * NULL is returned.
+ *
+ * The order of the keys in the map is arbitrary and if the map is modified
+ * between calls to this function the behavior is undefined.
+ * If the map is modifeid then iteration should begin again by passing NULL to
+ * get the first key again.
+ *
+ * This function operates based on the address of the pointer, you cannot pass
+ * a copy of a key to get the next key.
+ *
+ * Example:
+ *
+ * ```c
+ * printf("keys in the map:\n");
+ * const char * current_key = rcutils_string_map_get_next_key(&map, NULL);
+ * while (current_key) {
+ *   printf("  - %s\n", current_key);
+ *   current_key = rcutils_string_map_get_next_key(&map, current_key);
+ * }
+ * ```
+ *
+ * NULL can also be returned if NULL is given for the string_map or if the
+ * string_map is invalid.
+ *
+ * \param[in] string_map rcutils_string_map_t to be queried
+ * \param[in] key NULL to get the first key or the previous key to get the next
+ * \return value for the given key if successful, or
+ * \return `NULL` for invalid arguments, or
+ * \return `NULL` if the string map is invalid, or
+ * \return `NULL` if key not found, or
+ * \return `NULL` if there are no more keys in the map, or
+ * \return `NULL` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+const char *
+rcutils_string_map_get_next_key(
+  const rcutils_string_map_t * string_map,
+  const char * key);
+
+/// Copy all the key value pairs from one map into another, overwritting and resizing if needed.
+/**
+ * If the destination string map does not have enough storage, then it is will
+ * be resized.
+ * If a key value pair exists in the destination map, its value will be
+ * replaced with the source map's value.
+ *
+ * It is possible for only some of the values to be copied if an error happens
+ * during the copying process, e.g. if memory allocation fails.
+ *
+ * \param[in] src_string_map rcutils_string_map_t to be copied from
+ * \param[inout] dst_string_map rcutils_string_map_t to be copied to
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_map_copy(
+  const rcutils_string_map_t * src_string_map,
+  rcutils_string_map_t * dst_string_map);
+
 #if __cplusplus
 }
 #endif

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -289,7 +289,7 @@ rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key);
  * the key value pair is updated or removed with one of rcutils_string_map_set()
  * or rcutils_string_map_set_no_resize() or rcutils_string_map_unset().
  *
- * \param[inout] string_map rcutils_string_map_t to be searched
+ * \param[in] string_map rcutils_string_map_t to be searched
  * \param[in] key map key, must be null terminated c string
  * \return value for the given key if successful, or
  * \return `NULL` for invalid arguments, or

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -51,6 +51,15 @@ rcutils_get_default_allocator()
   return default_allocator;
 }
 
+bool
+rcutils_allocator_is_valid(const rcutils_allocator_t * allocator)
+{
+  if (!allocator || !allocator->allocate || !allocator->deallocate || !allocator->reallocate) {
+    return false;
+  }
+  return true;
+}
+
 void *
 rcutils_reallocf(void * pointer, size_t size, rcutils_allocator_t * allocator)
 {

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,39 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMMON_H_
+#define COMMON_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/error_handling.h"
+
+#define RCUTILS_CHECK_ARGUMENT_FOR_NULL(argument, error_return_type, allocator) \
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(argument, #argument " argument is null", \
+    return error_return_type, allocator)
+
+#define RCUTILS_CHECK_FOR_NULL_WITH_MSG(value, msg, error_statement, allocator) \
+  if (!(value)) { \
+    RCUTILS_SET_ERROR_MSG(msg, allocator); \
+    error_statement; \
+  }
+
+#if __cplusplus
+}
+#endif
+
+#endif  // COMMON_H_

--- a/src/format_string.c
+++ b/src/format_string.c
@@ -1,0 +1,64 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/format_string.h"
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "rcutils/snprintf.h"
+
+char *
+rcutils_format_string_limit(
+  rcutils_allocator_t allocator,
+  size_t limit,
+  const char * format_string,
+  ...)
+{
+  if (!format_string) {
+    return NULL;
+  }
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
+  // extract the variadic arguments twice, once for length calculatio and once for formatting.
+  va_list args1;
+  va_start(args1, format_string);
+  va_list args2;
+  va_copy(args2, args1);
+  // first calculate the output string
+  size_t bytes_to_be_written = rcutils_vsnprintf(NULL, 0, format_string, args1);
+  va_end(args1);
+  // allocate space for the return string
+  if (bytes_to_be_written + 1 > limit) {
+    bytes_to_be_written = limit;
+  }
+  char * output_string = allocator.allocate(bytes_to_be_written + 1, allocator.state);
+  if (!output_string) {
+    va_end(args2);
+    return NULL;
+  }
+  // formate the string
+  rcutils_vsnprintf(output_string, limit, format_string, args2);
+  va_end(args2);
+  return output_string;
+}
+
+#if __cplusplus
+}
+#endif

--- a/src/format_string.c
+++ b/src/format_string.c
@@ -61,8 +61,7 @@ rcutils_format_string_limit(
     return NULL;
   }
   // formate the string
-  size_t bytes_written =
-    rcutils_vsnprintf(output_string, bytes_to_be_written + 1, format_string, args2);
+  rcutils_vsnprintf(output_string, bytes_to_be_written + 1, format_string, args2);
   output_string[bytes_to_be_written] = '\0';
   va_end(args2);
   return output_string;

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -49,7 +49,6 @@ rcutils_repl_str(
   const char * to,
   rcutils_allocator_t * allocator)
 {
-
   /* Adjust each of the below values to suit your needs. */
 
   /* Increment positions cache size initially by this number. */
@@ -82,7 +81,9 @@ rcutils_repl_str(
         allocator->reallocate(pos_cache, sizeof(*pos_cache) * cache_sz, allocator->state);
       if (pos_cache_tmp == NULL) {
         goto end_repl_str;
-      } else pos_cache = pos_cache_tmp;
+      } else {
+        pos_cache = pos_cache_tmp;
+      }
       cache_sz_inc *= cache_sz_inc_factor;
       if (cache_sz_inc > cache_sz_inc_max) {
         cache_sz_inc = cache_sz_inc_max;
@@ -99,7 +100,9 @@ rcutils_repl_str(
   if (count > 0) {
     tolen = strlen(to);
     retlen = orglen + (tolen - fromlen) * count;
-  } else  retlen = orglen;
+  } else {
+    retlen = orglen;
+  }
   ret = allocator->allocate(retlen + 1, allocator->state);
   if (ret == NULL) {
     goto end_repl_str;
@@ -107,7 +110,7 @@ rcutils_repl_str(
 
   if (count == 0) {
     /* If no matches, then just duplicate the string. */
-    strcpy(ret, str);
+    strcpy(ret, str);  // NOLINT
   } else {
     /* Otherwise, duplicate the string whilst performing
      * the replacements using the position cache. */

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -1,0 +1,139 @@
+// Copyright 2015-2016 Laird Shaw
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This function is based on the repl_str() from (on 2017-04-25):
+//
+//   http://creativeandcritical.net/str-replace-c
+//
+// It is released under the Public Domain, and has been placed additionally
+// under the Apache 2.0 license by me (William Woodall).
+//
+// It has been modified to take a custom allocator and to fit some of our
+// style standards.
+
+// Note: the "tuning" values at the beginning of the function have been left as-is.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+#if (__STDC_VERSION__ >= 199901L)
+#include <stdint.h>
+#endif
+
+#include "rcutils/repl_str.h"
+
+// *INDENT-OFF* (prevent uncrustify from messing with the original style)
+
+char *
+rcutils_repl_str(
+  const char * str,
+  const char * from,
+  const char * to,
+  rcutils_allocator_t * allocator)
+{
+
+  /* Adjust each of the below values to suit your needs. */
+
+  /* Increment positions cache size initially by this number. */
+  size_t cache_sz_inc = 16;
+  /* Thereafter, each time capacity needs to be increased,
+   * multiply the increment by this factor. */
+  const size_t cache_sz_inc_factor = 3;
+  /* But never increment capacity by more than this number. */
+  const size_t cache_sz_inc_max = 1048576;
+
+  char *pret, *ret = NULL;
+  const char *pstr2, *pstr = str;
+  size_t i, count = 0;
+  #if (__STDC_VERSION__ >= 199901L)
+  uintptr_t *pos_cache_tmp, *pos_cache = NULL;
+  #else
+  ptrdiff_t *pos_cache_tmp, *pos_cache = NULL;
+  #endif
+  size_t cache_sz = 0;
+  size_t cpylen, orglen, retlen, tolen, fromlen = strlen(from);
+
+  /* Find all matches and cache their positions. */
+  while ((pstr2 = strstr(pstr, from)) != NULL) {
+    count++;
+
+    /* Increase the cache size when necessary. */
+    if (cache_sz < count) {
+      cache_sz += cache_sz_inc;
+      pos_cache_tmp =
+        allocator->reallocate(pos_cache, sizeof(*pos_cache) * cache_sz, allocator->state);
+      if (pos_cache_tmp == NULL) {
+        goto end_repl_str;
+      } else pos_cache = pos_cache_tmp;
+      cache_sz_inc *= cache_sz_inc_factor;
+      if (cache_sz_inc > cache_sz_inc_max) {
+        cache_sz_inc = cache_sz_inc_max;
+      }
+    }
+
+    pos_cache[count-1] = pstr2 - str;
+    pstr = pstr2 + fromlen;
+  }
+
+  orglen = pstr - str + strlen(pstr);
+
+  /* Allocate memory for the post-replacement string. */
+  if (count > 0) {
+    tolen = strlen(to);
+    retlen = orglen + (tolen - fromlen) * count;
+  } else  retlen = orglen;
+  ret = allocator->allocate(retlen + 1, allocator->state);
+  if (ret == NULL) {
+    goto end_repl_str;
+  }
+
+  if (count == 0) {
+    /* If no matches, then just duplicate the string. */
+    strcpy(ret, str);
+  } else {
+    /* Otherwise, duplicate the string whilst performing
+     * the replacements using the position cache. */
+    pret = ret;
+    memcpy(pret, str, pos_cache[0]);
+    pret += pos_cache[0];
+    for (i = 0; i < count; i++) {
+      memcpy(pret, to, tolen);
+      pret += tolen;
+      pstr = str + pos_cache[i] + fromlen;
+      cpylen = (i == count-1 ? orglen : pos_cache[i+1]) - pos_cache[i] - fromlen;
+      memcpy(pret, pstr, cpylen);
+      pret += cpylen;
+    }
+    ret[retlen] = '\0';
+  }
+
+end_repl_str:
+  /* Free the cache and return the post-replacement string,
+   * which will be NULL in the event of an error. */
+  allocator->deallocate(pos_cache, allocator->state);
+  return ret;
+}
+
+// *INDENT-ON*
+
+#if __cplusplus
+}
+#endif

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -110,7 +110,14 @@ rcutils_repl_str(
 
   if (count == 0) {
     /* If no matches, then just duplicate the string. */
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4996)  // strcpy may be unsafe
+#endif
     strcpy(ret, str);  // NOLINT
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
   } else {
     /* Otherwise, duplicate the string whilst performing
      * the replacements using the position cache. */

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -1,0 +1,53 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/strdup.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "./common.h"
+
+char *
+rcutils_strdup(const char * str, rcutils_allocator_t allocator)
+{
+  if (!str) {
+    return NULL;
+  }
+  return rcutils_strndup(str, strlen(str), allocator);
+}
+
+char *
+rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allocator)
+{
+  if (!str) {
+    return NULL;
+  }
+  char * new_string = allocator.allocate(string_length + 1, allocator.state);
+  if (!new_string) {
+    return NULL;
+  }
+  memcpy(new_string, str, string_length + 1);
+  new_string[string_length] = '\0';
+  return new_string;
+}
+
+#if __cplusplus
+}
+#endif

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -111,8 +111,10 @@ rcutils_string_map_get_capacity(const rcutils_string_map_t * string_map, size_t 
     string_map->impl, "invalid string map",
     return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(
-    capacity, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator()) *
-  capacity = string_map->impl->capacity;
+    capacity, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  // *INDENT-OFF* (prevent uncrustify getting this wrong)
+  *capacity = string_map->impl->capacity;
+  // *INDENT-ON*
   return RCUTILS_RET_OK;
 }
 
@@ -412,7 +414,7 @@ rcutils_string_map_get_next_key(
   }
   // iterate through the storage and look for another non-NULL key to return
   size_t i = start_index;
-  for(; i < string_map->impl->capacity; ++i) {
+  for (; i < string_map->impl->capacity; ++i) {
     if (string_map->impl->keys[i]) {
       // next key found, return it
       return string_map->impl->keys[i];

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -395,10 +395,10 @@ rcutils_string_map_get_next_key(
   if (string_map->impl->size == 0) {
     return NULL;
   }
-  bool given_key_found = false;
   size_t start_index = 0;
   if (key) {
     // if given a key, try to find it
+    bool given_key_found = false;
     size_t i = 0;
     for (; i < string_map->impl->capacity; ++i) {
       if (string_map->impl->keys[i] == key) {

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -111,8 +111,8 @@ rcutils_string_map_get_capacity(const rcutils_string_map_t * string_map, size_t 
     string_map->impl, "invalid string map",
     return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(
-    capacity, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
-  *capacity = string_map->impl->capacity;
+    capacity, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator()) *
+  capacity = string_map->impl->capacity;
   return RCUTILS_RET_OK;
 }
 
@@ -125,8 +125,8 @@ rcutils_string_map_get_size(const rcutils_string_map_t * string_map, size_t * si
     string_map->impl, "invalid string map",
     return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(
-    size, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
-  *size = string_map->impl->size;
+    size, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator()) *
+  size = string_map->impl->size;
   return RCUTILS_RET_OK;
 }
 

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -1,0 +1,374 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/types/string_map.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "./common.h"
+#include "rcutils/strdup.h"
+#include "rcutils/format_string.h"
+#include "rcutils/types/rcutils_ret.h"
+
+typedef struct rcutils_string_map_impl_t
+{
+  char ** keys;
+  char ** values;
+  size_t capacity;
+  size_t size;
+  rcutils_allocator_t allocator;
+} rcutils_string_map_impl_t;
+
+rcutils_string_map_t
+rcutils_get_zero_initialized_string_map()
+{
+  static rcutils_string_map_t zero_initialized_string_map;
+  zero_initialized_string_map.impl = NULL;
+  return zero_initialized_string_map;
+}
+
+rcutils_ret_t
+rcutils_string_map_init(
+  rcutils_string_map_t * string_map,
+  size_t initial_capacity,
+  rcutils_allocator_t allocator)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(string_map, RCUTILS_RET_INVALID_ARGUMENT, allocator)
+  if (string_map->impl) {
+    RCUTILS_SET_ERROR_MSG("string_map already initialized", allocator)
+    return RCUTILS_RET_STRING_MAP_ALREADY_INIT;
+  }
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "invalid allocator", return RCUTILS_RET_INVALID_ARGUMENT)
+  string_map->impl = allocator.allocate(sizeof(rcutils_string_map_impl_t), allocator.state);
+  if (!string_map->impl) {
+    RCUTILS_SET_ERROR_MSG(
+      "failed to allocate memory for string map impl struct",
+      // try default allocator, assuming given allocator is not able to allocate memory
+      rcutils_get_default_allocator())
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  string_map->impl->keys = NULL;
+  string_map->impl->values = NULL;
+  string_map->impl->capacity = 0;
+  string_map->impl->size = 0;
+  string_map->impl->allocator = allocator;
+  rcutils_ret_t ret = rcutils_string_map_reserve(string_map, initial_capacity);
+  if (ret != RCUTILS_RET_OK) {
+    // error mesage is already set, clean up and return the ret
+    allocator.deallocate(string_map->impl, allocator.state);
+    string_map->impl = NULL;
+    return ret;
+  }
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_fini(rcutils_string_map_t * string_map)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  if (!string_map->impl) {
+    return RCUTILS_RET_OK;
+  }
+  rcutils_ret_t ret = rcutils_string_map_clear(string_map);
+  if (ret != RCUTILS_RET_OK) {
+    // error message already set
+    return ret;
+  }
+  ret = rcutils_string_map_reserve(string_map, 0);
+  if (ret != RCUTILS_RET_OK) {
+    // error message already set
+    return ret;
+  }
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_get_capacity(const rcutils_string_map_t * string_map, size_t * capacity)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    capacity, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  *capacity = string_map->impl->capacity;
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_get_size(const rcutils_string_map_t * string_map, size_t * size)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    size, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  *size = string_map->impl->size;
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_reserve(rcutils_string_map_t * string_map, size_t capacity)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  rcutils_allocator_t allocator = string_map->impl->allocator;
+  // short circuit, if requested capacity is less than the size of the map
+  if (capacity < string_map->impl->size) {
+    // set the capacity to the current size instead
+    return rcutils_string_map_reserve(string_map, string_map->impl->size);
+  }
+  if (capacity == string_map->impl->capacity) {
+    // if requested capacity is equal to the current capacity, nothing to do
+    return RCUTILS_RET_OK;
+  } else if (capacity == 0) {
+    // if the requested capacity is zero, then make sure the existing keys and values are free'd
+    allocator.deallocate(string_map->impl->keys, allocator.state);
+    string_map->impl->keys = NULL;
+    allocator.deallocate(string_map->impl->values, allocator.state);
+    string_map->impl->values = NULL;
+    // falls through to normal function end
+  } else {
+    // if the capacity non-zero and different, use realloc to increase/shrink the size
+    // note that realloc when the pointer is NULL is the same as malloc
+    // note also that realloc will shrink the space if needed
+
+    // resize the keys, assigning the result only if it succeeds
+    char ** new_keys =
+      allocator.reallocate(string_map->impl->keys, capacity * sizeof(char *), allocator.state);
+    if (!new_keys) {
+      RCUTILS_SET_ERROR_MSG("failed to allocate memory for string_map keys", allocator)
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+    string_map->impl->keys = new_keys;
+
+    // resize the values, assigning the result only if it succeeds
+    char ** new_values =
+      allocator.reallocate(string_map->impl->values, capacity * sizeof(char *), allocator.state);
+    if (!new_values) {
+      RCUTILS_SET_ERROR_MSG("failed to allocate memory for string_map values", allocator)
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+    string_map->impl->values = new_values;
+
+    // zero out the new memory, if there is any (expanded instead of shrunk)
+    if (capacity > string_map->impl->capacity) {
+      size_t i = string_map->impl->capacity;
+      for (; i < capacity; ++i) {
+        string_map->impl->keys[i] = NULL;
+        string_map->impl->values[i] = NULL;
+      }
+    }
+    // falls through to normal function end
+  }
+  string_map->impl->capacity = capacity;
+  return RCUTILS_RET_OK;
+}
+
+RCUTILS_LOCAL
+static void
+__remove_key_and_value_at_index(rcutils_string_map_impl_t * string_map_impl, size_t index)
+{
+  rcutils_allocator_t allocator = string_map_impl->allocator;
+  allocator.deallocate(string_map_impl->keys[index], allocator.state);
+  string_map_impl->keys[index] = NULL;
+  allocator.deallocate(string_map_impl->values[index], allocator.state);
+  string_map_impl->values[index] = NULL;
+  string_map_impl->size--;
+}
+
+rcutils_ret_t
+rcutils_string_map_clear(rcutils_string_map_t * string_map)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  size_t i = 0;
+  for (; i < string_map->impl->capacity; ++i) {
+    if (string_map->impl->keys[i]) {
+      __remove_key_and_value_at_index(string_map->impl, i);
+    }
+  }
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_set(rcutils_string_map_t * string_map, const char * key, const char * value)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    key, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    value, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  rcutils_ret_t ret = rcutils_string_map_set_no_resize(string_map, key, value);
+  // if it fails due to not enough space, resize and try again
+  if (ret == RCUTILS_RET_NOT_ENOUGH_SPACE) {
+    rcutils_reset_error();
+    // default to doubling the size of the map's capacity
+    rcutils_ret_t ret = rcutils_string_map_reserve(string_map, 2 * string_map->impl->capacity);
+    if (ret != RCUTILS_RET_OK) {
+      // error message is already set
+      return ret;
+    }
+    // try again
+    return rcutils_string_map_set_no_resize(string_map, key, value);
+  }
+  return ret;
+}
+
+RCUTILS_LOCAL
+static bool
+__get_index_of_key_if_exists(
+  rcutils_string_map_impl_t * string_map_impl,
+  const char * key,
+  size_t * index)
+{
+  size_t i = 0;
+  size_t key_length = strlen(key);
+  for (; i < string_map_impl->capacity; ++i) {
+    if (!string_map_impl->keys[i]) {
+      continue;
+    }
+    size_t cmp_count = strlen(string_map_impl->keys[i]);
+    if (key_length > cmp_count) {
+      cmp_count = key_length;
+    }
+    if (strncmp(key, string_map_impl->keys[i], cmp_count) == 0) {
+      *index = i;
+      return true;
+    }
+  }
+  return false;
+}
+
+rcutils_ret_t
+rcutils_string_map_set_no_resize(
+  rcutils_string_map_t * string_map,
+  const char * key,
+  const char * value)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    key, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    value, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  rcutils_allocator_t allocator = string_map->impl->allocator;
+  size_t key_index;
+  bool should_free_key_on_error = false;
+  bool key_exists = __get_index_of_key_if_exists(string_map->impl, key, &key_index);
+  if (!key_exists) {
+    // create space for, and store the key if it doesn't exist yet
+    assert(string_map->impl->size <= string_map->impl->capacity);  // defensive, should not happen
+    if (string_map->impl->size == string_map->impl->capacity) {
+      return RCUTILS_RET_NOT_ENOUGH_SPACE;
+    }
+    for (key_index = 0; key_index < string_map->impl->capacity; ++key_index) {
+      if (!string_map->impl->keys[key_index]) {
+        break;
+      }
+    }
+    assert(key_index < string_map->impl->capacity);  // defensive, this should not happen
+    string_map->impl->keys[key_index] = rcutils_strdup(key, allocator);
+    if (!string_map->impl->keys[key_index]) {
+      RCUTILS_SET_ERROR_MSG("failed to allocate memory for key", rcutils_get_default_allocator())
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+    should_free_key_on_error = true;
+  }
+  // at this point the key is in the map, waiting for the value to set/overwritten
+  char * original_value = string_map->impl->values[key_index];
+  char * new_value = rcutils_strdup(value, allocator);
+  if (!new_value) {
+    RCUTILS_SET_ERROR_MSG("failed to allocate memory for key", allocator)
+    if (should_free_key_on_error) {
+      allocator.deallocate(string_map->impl->keys[key_index], allocator.state);
+      string_map->impl->keys[key_index] = NULL;
+    }
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  string_map->impl->values[key_index] = new_value;
+  if (original_value) {
+    // clean up the old value if not NULL
+    allocator.deallocate(original_value, allocator.state);
+  }
+  if (!key_exists) {
+    // if the key didn't exist, then we had to add it, so increase the size
+    string_map->impl->size++;
+  }
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    string_map, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    string_map->impl, "invalid string map",
+    return RCUTILS_RET_STRING_MAP_INVALID, rcutils_get_default_allocator())
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(
+    key, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator())
+  rcutils_allocator_t allocator = string_map->impl->allocator;
+  size_t key_index;
+  if (!__get_index_of_key_if_exists(string_map->impl, key, &key_index)) {
+    char * msg = rcutils_format_string(allocator, "key '%s' not found", key);
+    RCUTILS_SET_ERROR_MSG(msg, allocator)
+    allocator.deallocate(msg, allocator.state);
+    return RCUTILS_RET_STRING_KEY_NOT_FOUND;
+  }
+  __remove_key_and_value_at_index(string_map->impl, key_index);
+  return RCUTILS_RET_OK;
+}
+
+const char *
+rcutils_string_map_get(const rcutils_string_map_t * string_map, const char * key)
+{
+  if (!string_map || !string_map->impl || !key) {
+    return NULL;
+  }
+  size_t key_index;
+  if (__get_index_of_key_if_exists(string_map->impl, key, &key_index)) {
+    return string_map->impl->values[key_index];
+  }
+  return NULL;
+}
+
+#if __cplusplus
+}
+#endif

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -193,7 +193,6 @@ rcutils_string_map_reserve(rcutils_string_map_t * string_map, size_t capacity)
   return RCUTILS_RET_OK;
 }
 
-RCUTILS_LOCAL
 static void
 __remove_key_and_value_at_index(rcutils_string_map_impl_t * string_map_impl, size_t index)
 {
@@ -251,7 +250,6 @@ rcutils_string_map_set(rcutils_string_map_t * string_map, const char * key, cons
   return ret;
 }
 
-RCUTILS_LOCAL
 static bool
 __get_index_of_key_if_exists(
   rcutils_string_map_impl_t * string_map_impl,

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -237,7 +237,8 @@ rcutils_string_map_set(rcutils_string_map_t * string_map, const char * key, cons
   if (ret == RCUTILS_RET_NOT_ENOUGH_SPACE) {
     rcutils_reset_error();
     // default to doubling the size of the map's capacity
-    rcutils_ret_t ret = rcutils_string_map_reserve(string_map, 2 * string_map->impl->capacity);
+    size_t new_capacity = (string_map->impl->capacity) ? 2 * string_map->impl->capacity : 1;
+    rcutils_ret_t ret = rcutils_string_map_reserve(string_map, new_capacity);
     if (ret != RCUTILS_RET_OK) {
       // error message is already set
       return ret;

--- a/test/allocator_testing_utils.h
+++ b/test/allocator_testing_utils.h
@@ -1,0 +1,83 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ALLOCATOR_TESTING_UTILS_H_
+#define ALLOCATOR_TESTING_UTILS_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>
+
+#include "rcutils/allocator.h"
+
+typedef struct __failing_allocator_state
+{
+  bool is_failing;
+} __failing_allocator_state;
+
+void *
+failing_malloc(size_t size, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().allocate(size, rcutils_get_default_allocator().state);
+}
+
+void *
+failing_realloc(void * pointer, size_t size, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().reallocate(
+    pointer, size, rcutils_get_default_allocator().state);
+}
+
+void
+failing_free(void * pointer, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return;
+  }
+  rcutils_get_default_allocator().deallocate(pointer, rcutils_get_default_allocator().state);
+}
+
+static inline rcutils_allocator_t
+get_failing_allocator(void)
+{
+  static __failing_allocator_state state;
+  state.is_failing = true;
+  auto failing_allocator = rcutils_get_default_allocator();
+  failing_allocator.allocate = failing_malloc;
+  failing_allocator.deallocate = failing_free;
+  failing_allocator.reallocate = failing_realloc;
+  failing_allocator.state = &state;
+  return failing_allocator;
+}
+
+static inline void
+set_failing_allocator_is_failing(rcutils_allocator_t & failing_allocator, bool state)
+{
+  ((__failing_allocator_state *)failing_allocator.state)->is_failing = state;
+}
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ALLOCATOR_TESTING_UTILS_H_

--- a/test/memory_tools/memory_tools.hpp
+++ b/test/memory_tools/memory_tools.hpp
@@ -104,29 +104,4 @@ RCL_MEMORY_TOOLS_PUBLIC
 void
 memory_checking_thread_init();
 
-// What follows is a set of failing allocator functions, used for testing.
-void *
-failing_malloc(size_t size, void * state)
-{
-  (void)size;
-  (void)state;
-  return nullptr;
-}
-
-void *
-failing_realloc(void * pointer, size_t size, void * state)
-{
-  (void)pointer;
-  (void)size;
-  (void)state;
-  return nullptr;
-}
-
-void
-failing_free(void * pointer, void * state)
-{
-  (void)pointer;
-  (void)state;
-}
-
 #endif  // MEMORY_TOOLS__MEMORY_TOOLS_HPP_

--- a/test/test_format_string.cpp
+++ b/test/test_format_string.cpp
@@ -1,0 +1,52 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "./allocator_testing_utils.h"
+#include "rcutils/allocator.h"
+#include "rcutils/format_string.h"
+
+TEST(test_format_string_limit, nominal) {
+  {
+    auto allocator = rcutils_get_default_allocator();
+    char * formatted = rcutils_format_string_limit(allocator, 10, "%s", "test");
+    EXPECT_STREQ("test", formatted);
+    if (formatted) {
+      allocator.deallocate(formatted, allocator.state);
+    }
+  }
+
+  {
+    auto allocator = rcutils_get_default_allocator();
+    char * formatted = rcutils_format_string_limit(allocator, 3, "%s", "test");
+    EXPECT_STREQ("te", formatted);
+    if (formatted) {
+      allocator.deallocate(formatted, allocator.state);
+    }
+  }
+}
+
+TEST(test_format_string_limit, invalid_arguments) {
+  auto allocator = rcutils_get_default_allocator();
+  auto failing_allocator = get_failing_allocator();
+
+  char * formatted = rcutils_format_string_limit(allocator, 10, NULL, "test");
+  EXPECT_STREQ(NULL, formatted);
+
+  formatted = rcutils_format_string_limit(failing_allocator, 10, "%s", "test");
+  EXPECT_STREQ(NULL, formatted);
+}

--- a/test/test_isalnum_no_locale.cpp
+++ b/test/test_isalnum_no_locale.cpp
@@ -1,0 +1,33 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "gmock/gmock.h"
+
+#include "rcutils/isalnum_no_locale.h"
+
+TEST(test_isalnum_no_locale, valid_characters_ok) {
+  std::string valid("0123456789" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "abcdefghijklmnopqrstuvwxyz");
+  for (auto & c : valid) {
+    ASSERT_TRUE(rcutils_isalnum_no_locale(c));
+  }
+}
+
+TEST(test_isalnum_no_locale, invalid_characters_fail) {
+  std::string invalid("/" /*0-9*/ ":;<=>?@" /*A-Z*/ "[\\]^_`" /*a-z*/);
+  for (auto & c : invalid) {
+    ASSERT_FALSE(rcutils_isalnum_no_locale(c));
+  }
+}

--- a/test/test_isalnum_no_locale.cpp
+++ b/test/test_isalnum_no_locale.cpp
@@ -14,7 +14,7 @@
 
 #include <string>
 
-#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "rcutils/isalnum_no_locale.h"
 

--- a/test/test_repl_str.cpp
+++ b/test/test_repl_str.cpp
@@ -1,0 +1,56 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "rcutils/allocator.h"
+#include "rcutils/repl_str.h"
+
+TEST(test_repl_str, nominal) {
+  auto allocator = rcutils_get_default_allocator();
+
+  // replace with a string of the exact length
+  {
+    std::string typical = "foo/{bar}/baz";
+    char * out = rcutils_repl_str(typical.c_str(), "{bar}", "bbarr", &allocator);
+    EXPECT_STREQ("foo/bbarr/baz", out);
+    allocator.deallocate(out, allocator.state);
+  }
+
+  // replace with a string of a smaller length
+  {
+    std::string typical = "foo/{bar}/baz";
+    char * out = rcutils_repl_str(typical.c_str(), "{bar}", "bar", &allocator);
+    EXPECT_STREQ("foo/bar/baz", out);
+    allocator.deallocate(out, allocator.state);
+  }
+
+  // replace with a string of a longer length
+  {
+    std::string typical = "foo/{bar}/baz";
+    char * out = rcutils_repl_str(typical.c_str(), "{bar}", "barbar", &allocator);
+    EXPECT_STREQ("foo/barbar/baz", out);
+    allocator.deallocate(out, allocator.state);
+  }
+
+  // replace with an empty string
+  {
+    std::string typical = "foo/{bar}/baz";
+    char * out = rcutils_repl_str(typical.c_str(), "{bar}", "", &allocator);
+    EXPECT_STREQ("foo//baz", out);
+    allocator.deallocate(out, allocator.state);
+  }
+}

--- a/test/test_strdup.cpp
+++ b/test/test_strdup.cpp
@@ -1,0 +1,73 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "./allocator_testing_utils.h"
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
+
+TEST(test_strdup, nominal) {
+  {
+    std::string typical = "typical";
+    auto allocator = rcutils_get_default_allocator();
+    char * duped = rcutils_strdup(typical.c_str(), allocator);
+    EXPECT_STREQ(typical.c_str(), duped);
+    allocator.deallocate(duped, allocator.state);
+  }
+
+  {
+    std::string empty = "";
+    auto allocator = rcutils_get_default_allocator();
+    char * duped = rcutils_strdup(empty.c_str(), allocator);
+    EXPECT_STREQ(empty.c_str(), duped);
+    allocator.deallocate(duped, allocator.state);
+  }
+}
+
+TEST(test_strndup, nominal) {
+  {
+    std::string typical = "typical";
+    auto allocator = rcutils_get_default_allocator();
+    char * duped = rcutils_strndup(typical.c_str(), 3, allocator);
+    EXPECT_STREQ(typical.substr(0, 3).c_str(), duped);
+    allocator.deallocate(duped, allocator.state);
+  }
+
+  {
+    std::string typical = "typical";
+    auto allocator = rcutils_get_default_allocator();
+    char * duped = rcutils_strndup(typical.c_str(), 0, allocator);
+    EXPECT_EQ(0, strlen(duped));
+    EXPECT_STREQ("", duped);
+    allocator.deallocate(duped, allocator.state);
+  }
+
+  {
+    std::string empty = "";
+    auto allocator = rcutils_get_default_allocator();
+    char * duped = rcutils_strdup(empty.c_str(), allocator);
+    EXPECT_STREQ(empty.c_str(), duped);
+    allocator.deallocate(duped, allocator.state);
+  }
+}
+
+TEST(test_strdup, invalid_arguments) {
+  auto allocator = rcutils_get_default_allocator();
+  auto failing_allocator = get_failing_allocator();
+  EXPECT_EQ(NULL, rcutils_strdup(NULL, allocator));
+  EXPECT_EQ(NULL, rcutils_strdup("something", failing_allocator));
+}

--- a/test/test_strdup.cpp
+++ b/test/test_strdup.cpp
@@ -51,7 +51,8 @@ TEST(test_strndup, nominal) {
     std::string typical = "typical";
     auto allocator = rcutils_get_default_allocator();
     char * duped = rcutils_strndup(typical.c_str(), 0, allocator);
-    EXPECT_EQ(0, strlen(duped));
+    size_t expected = 0;
+    EXPECT_EQ(expected, strlen(duped));
     EXPECT_STREQ("", duped);
     allocator.deallocate(duped, allocator.state);
   }

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -1,0 +1,1112 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "./allocator_testing_utils.h"
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types/string_map.h"
+
+TEST(test_string_map, lifecycle) {
+  auto allocator = rcutils_get_default_allocator();
+  auto failing_allocator = get_failing_allocator();
+  rcutils_ret_t ret;
+
+  // fini a zero initialized string_map
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_fini(&string_map);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+  }
+
+  // init and then fini and then fini again
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_fini(&string_map);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_fini(&string_map);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+  }
+
+  // init and then fini with 0 capacity
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_fini(&string_map);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+  }
+
+  // init on non-zero initialized
+  {
+    rcutils_string_map_t string_map;
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    EXPECT_EQ(RCUTILS_RET_STRING_MAP_ALREADY_INIT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // double init
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    EXPECT_EQ(RCUTILS_RET_STRING_MAP_ALREADY_INIT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+    ret = rcutils_string_map_fini(&string_map);
+    EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+  }
+
+  // null for string map pointer to init
+  {
+    ret = rcutils_string_map_init(NULL, 10, allocator);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // failing allocator to init
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, failing_allocator);
+    EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // null for string map to fini
+  {
+    ret = rcutils_string_map_fini(NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+}
+
+TEST(test_string_map, getters) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // null for string_map
+  {
+    size_t capacity, size;
+    ret = rcutils_string_map_get_capacity(NULL, &capacity);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+    ret = rcutils_string_map_get_size(NULL, &size);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // null for capacity/size
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_get_capacity(&string_map, NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+    ret = rcutils_string_map_get_size(&string_map, NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // initialize to 0
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    size_t expected = 0;
+    size_t capacity = 42;
+    ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    EXPECT_EQ(expected, capacity);
+
+    size_t size = 42;
+    ret = rcutils_string_map_get_size(&string_map, &size);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    EXPECT_EQ(expected, size);
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}
+
+TEST(test_string_map, reserve_and_clear) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // initialize to 10 (implicit reserve)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    size_t expected = 10;
+    size_t capacity = 42;
+    ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    EXPECT_EQ(expected, capacity);
+
+    expected = 0;
+    size_t size = 42;
+    ret = rcutils_string_map_get_size(&string_map, &size);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    EXPECT_EQ(expected, size);
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 0, reserve to 10
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_reserve(&string_map, 10);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 10, set, set, clear, reserve 0
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_clear(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_reserve(&string_map, 0);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 0, clear
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_clear(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 0, reserve 10, clear
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_reserve(&string_map, 10);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_clear(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 10;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // null for string_map to reserve
+  {
+    ret = rcutils_string_map_reserve(NULL, 42);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // null for string_map to clear
+  {
+    ret = rcutils_string_map_clear(NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+}
+
+TEST(test_string_map, set_no_resize) {
+  auto allocator = rcutils_get_default_allocator();
+  auto failing_allocator = get_failing_allocator();
+  rcutils_ret_t ret;
+
+  // initialize to 1, set key1, set key2 (should fail)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 1, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 1;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 1;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_NOT_ENOUGH_SPACE, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 2, set key1, set key1 again, set key2
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "val1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("val1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // use failing allocator
+  {
+    set_failing_allocator_is_failing(failing_allocator, false);
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 1, failing_allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    set_failing_allocator_is_failing(failing_allocator, true);
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "value1");
+    EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // pass NULL for string_map
+  {
+    ret = rcutils_string_map_set_no_resize(NULL, "key1", "value1");
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // pass NULL for key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set_no_resize(&string_map, NULL, "value1");
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // pass NULL for value
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}
+
+TEST(test_string_map, set) {
+  auto allocator = rcutils_get_default_allocator();
+  auto failing_allocator = get_failing_allocator();
+  rcutils_ret_t ret;
+
+  // initialize to 1, set key1, set key2 (capacity -> 2), set key3 (capacity -> 4)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 1, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 1;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 1;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key3", "value3");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 4;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 3;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value3", rcutils_string_map_get(&string_map, "key3"));
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // initialize to 2, set key1, set key1 again, set key2
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key1", "val1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("val1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 2;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // use failing allocator
+  {
+    set_failing_allocator_is_failing(failing_allocator, false);
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 1, failing_allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    set_failing_allocator_is_failing(failing_allocator, true);
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // pass NULL for string_map
+  {
+    ret = rcutils_string_map_set(NULL, "key1", "value1");
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // pass NULL for key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, NULL, "value1");
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // pass NULL for value
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}
+
+TEST(test_string_map, unset) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // initialize to 3, set key1, set key2, set key3, unset key2, set key3, set key2
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 3, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 3;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set_no_resize(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_set_no_resize(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_set_no_resize(&string_map, "key3", "value3");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 3;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 3;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+      EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+      EXPECT_STREQ("value3", rcutils_string_map_get(&string_map, "key3"));
+    }
+
+    ret = rcutils_string_map_unset(&string_map, "key2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 3;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+      EXPECT_STREQ("value3", rcutils_string_map_get(&string_map, "key3"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key3", "value3.1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 3;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 2;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+      EXPECT_STREQ("value3.1", rcutils_string_map_get(&string_map, "key3"));
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 3;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 3;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+      EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+      EXPECT_STREQ("value3.1", rcutils_string_map_get(&string_map, "key3"));
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // unset with string_map as null
+  {
+    ret = rcutils_string_map_unset(NULL, "key");
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+  }
+
+  // unset with key as null
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 10, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_unset(&string_map, NULL);
+    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // unset on empty map
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_unset(&string_map, "missing");
+    EXPECT_EQ(RCUTILS_RET_STRING_KEY_NOT_FOUND, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // unset on missing key in non-empty map
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    ret = rcutils_string_map_unset(&string_map, "missing");
+    EXPECT_EQ(RCUTILS_RET_STRING_KEY_NOT_FOUND, ret) << rcutils_get_error_string_safe();
+    rcutils_reset_error();
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}
+
+TEST(test_string_map, get) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // get normal key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    EXPECT_STREQ("value2", rcutils_string_map_get(&string_map, "key2"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get missing key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get on empty map (capacity but no pairs in it)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get on map with no capacity (also empty)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get with string_map null
+  {
+    EXPECT_EQ(NULL, rcutils_string_map_get(NULL, "some_key"));
+  }
+
+  // get with key null
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, NULL));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+}
+
+TEST(test_string_map, strange_keys) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // empty string key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, ""));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // key with spaces
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key with spaces", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key with spaces"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -1073,7 +1073,6 @@ TEST(test_string_map, get) {
     ret = rcutils_string_map_fini(&string_map);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
   }
-
 }
 
 TEST(test_string_map, strange_keys) {

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -610,6 +610,49 @@ TEST(test_string_map, set) {
   auto failing_allocator = get_failing_allocator();
   rcutils_ret_t ret;
 
+  // initialize to 0, set key1
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    {
+      size_t expected = 0;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 0;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+    }
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    {
+      size_t expected = 1;
+      size_t capacity = 42;
+      ret = rcutils_string_map_get_capacity(&string_map, &capacity);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, capacity);
+
+      expected = 1;
+      size_t size = 42;
+      ret = rcutils_string_map_get_size(&string_map, &size);
+      EXPECT_EQ(RCUTILS_RET_OK, ret);
+      EXPECT_EQ(expected, size);
+
+      EXPECT_STREQ("value1", rcutils_string_map_get(&string_map, "key1"));
+    }
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
   // initialize to 1, set key1, set key2 (capacity -> 2), set key3 (capacity -> 4)
   {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -56,6 +56,8 @@ TEST(test_string_map, lifecycle) {
   // init on non-zero initialized
   {
     rcutils_string_map_t string_map;
+    // dirty the memory, otherwise this is flaky (sometimes the junk memory is null)
+    memset(&string_map, 0x7, sizeof(rcutils_string_map_t));
     ret = rcutils_string_map_init(&string_map, 10, allocator);
     EXPECT_EQ(RCUTILS_RET_STRING_MAP_ALREADY_INIT, ret) << rcutils_get_error_string_safe();
     rcutils_reset_error();

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -1075,6 +1075,88 @@ TEST(test_string_map, get) {
   }
 }
 
+TEST(test_string_map, getn) {
+  auto allocator = rcutils_get_default_allocator();
+  rcutils_ret_t ret;
+
+  // get normal key, which is longer than compared
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+    ret = rcutils_string_map_set(&string_map, "key2", "value2");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_STREQ("value1", rcutils_string_map_getn(&string_map, "key1andsome", 4));
+    EXPECT_STREQ("value2", rcutils_string_map_getn(&string_map, "key2andsome", 4));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get missing key
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get on empty map (capacity but no pairs in it)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get on map with no capacity (also empty)
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, "some_key"));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+
+  // get with string_map null
+  {
+    EXPECT_EQ(NULL, rcutils_string_map_get(NULL, "some_key"));
+  }
+
+  // get with key null
+  {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 2, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+    ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string_safe();
+
+    EXPECT_EQ(NULL, rcutils_string_map_get(&string_map, NULL));
+
+    ret = rcutils_string_map_fini(&string_map);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+  }
+}
+
 TEST(test_string_map, strange_keys) {
   auto allocator = rcutils_get_default_allocator();
   rcutils_ret_t ret;


### PR DESCRIPTION
This pull request is in support of implementing namespace expansion in rcl. It adds two string utility functions (`rcutils_strdup` and `rcutils_format_string`). It also adds a new data structure which is a map where both the keys and values are c strings.

This is still a work in progress along with the changes in rcl that are needed to expand topic strings.

Connects to ros2/rcl#132