### PR TITLE
Explicitly set C11 via the CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,13 @@ find_package(ament_cmake REQUIRED)
 
 include_directories(include)
 
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
 if(NOT WIN32)
+  add_definitions(-D_POSIX_C_SOURCE=199309L)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
   # The warning flags are added per target, because otherwise the local
   # gmock library that is built will have compiler warnings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ find_package(ament_cmake REQUIRED)
 
 include_directories(include)
 
-# Default to C99
+# Default to C11
 if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD 11)
 endif()
 
 if(NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ if(NOT CMAKE_C_STANDARD)
 endif()
 
 if(NOT WIN32)
-  add_definitions(-D_POSIX_C_SOURCE=199309L)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
   # The warning flags are added per target, because otherwise the local
   # gmock library that is built will have compiler warnings.

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -57,7 +57,12 @@ extern "C"
   #endif
 #else
 // Some other non-Windows, non-cygwin, non-apple OS
-  #define RCUTILS_THREAD_LOCAL _Thread_local
+  #if  __STDC_VERSION__ >= 201112L
+// C11 enabled
+    #define RCUTILS_THREAD_LOCAL _Thread_local
+  #else
+    #define RCUTILS_THREAD_LOCAL __thread
+  #endif
 #endif
 
 #define RCUTILS_STRINGIFY_IMPL(x) #x


### PR DESCRIPTION
The version of C standard wasn't explicit, so I added `CMAKE_C_STANDARD` and set it to 99 (if I'm not mistaken that's the version that ROS2 is targeting).

I also added some logic that enables switching to C11 to enable `_Thread_local` instead of `__thread`