### PR TITLE
Declare C standard explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(ament_cmake REQUIRED)
 include_directories(include)
 
 if(NOT WIN32)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
   # The warning flags are added per target, because otherwise the local
   # gmock library that is built will have compiler warnings.
   set(rcutils_extra_warning_flags "-Wall -Wextra -Wpedantic")


### PR DESCRIPTION
Failed to compile on my system without explicitly declaring the std=gnu99

(`_Thread_local` is not in ISO C99, but *is* in GNU99)