### PR TITLE
remove target specific warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,7 @@ include_directories(include)
 
 if(NOT WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
-  # The warning flags are added per target, because otherwise the local
-  # gmock library that is built will have compiler warnings.
-  set(rcutils_extra_warning_flags "-Wall -Wextra -Wpedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 endif()
 
 if(WIN32)
@@ -65,10 +63,6 @@ add_library(
   ${PROJECT_NAME}
   SHARED
   ${rcutils_sources})
-if(rcutils_extra_warning_flags)
-  set_target_properties(${PROJECT_NAME}
-    PROPERTIES COMPILE_FLAGS ${rcutils_extra_warning_flags})
-endif()
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -146,16 +140,10 @@ if(BUILD_TESTING)
 
   macro(rcutils_custom_add_gtest target)
     ament_add_gtest(${target} ${ARGN})
-    if(TARGET ${target} AND rcutils_extra_warning_flags)
-      set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${rcutils_extra_warning_flags})
-    endif()
   endmacro()
 
   macro(rcutils_custom_add_gmock target)
     ament_add_gmock(${target} ${ARGN})
-    if(TARGET ${target} AND rcutils_extra_warning_flags)
-      set_target_properties(${target} PROPERTIES COMPILE_FLAGS ${rcutils_extra_warning_flags})
-    endif()
   endmacro()
 
   # Gtests

--- a/test/memory_tools/CMakeLists.txt
+++ b/test/memory_tools/CMakeLists.txt
@@ -1,5 +1,11 @@
 # Create the memory_tools library which is used by the tests.
 add_library(${PROJECT_NAME}_memory_tools SHARED memory_tools.cpp)
+if(NOT WIN32)
+  # otherwise the compiler will error since the allocator functions have
+  # different exception specifiers
+  set_target_properties(${PROJECT_NAME}_memory_tools
+    PROPERTIES COMPILE_FLAGS "-Wno-pedantic")
+endif()
 if(APPLE)
   # Create an OS X specific version of the memory tools that does interposing.
   # See: http://toves.freeshell.org/interpose/
@@ -31,10 +37,6 @@ ament_add_gmock(test_memory_tools test_memory_tools.cpp
 )
 if(TARGET test_memory_tools)
   target_link_libraries(test_memory_tools ${extra_test_libraries})
-  if(rcutils_extra_warning_flags)
-    set_target_properties(test_memory_tools
-      PROPERTIES COMPILE_FLAGS ${rcutils_extra_warning_flags})
-  endif()
 endif()
 
 set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)


### PR DESCRIPTION
The previous warning has been addressed a while ago: https://github.com/ament/ament_cmake/commit/bfc5c505ba5305dadf62c8c6cafd5e8d3b4e2eff

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2749)](http://ci.ros2.org/job/ci_linux/2749/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=281)](http://ci.ros2.org/job/ci_linux-aarch64/281/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2219)](http://ci.ros2.org/job/ci_osx/2219/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2877)](http://ci.ros2.org/job/ci_windows/2877/)

Note that the memory tools can't be compiled with `-Wpedantic` at the moment. So for that target the warning level is different.