### PR TITLE
Use _WIN32 everywhere

### DIFF
--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -61,7 +61,7 @@ extern "C"
  * No op since Windows doesn't support providing branch prediction information.
  */
 # define RCUTILS_UNLIKELY(x) (x)
-#endif
+#endif  // _WIN32
 
 /**
  * \def RCUTILS_LOGGING_AUTOINIT

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -39,7 +39,7 @@ extern "C"
 #endif
 
 // Provide the compiler with branch prediction information
-#ifndef WIN32
+#ifndef _WIN32
 /**
  * \def RCUTILS_LIKELY
  * Instruct the compiler to optimize for the case where the argument equals 1.

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -21,11 +21,11 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <direct.h>
-#endif
+#endif  // _WIN32
 #include "rcutils/concat.h"
 #include "rcutils/filesystem.h"
 
@@ -35,7 +35,7 @@ rcutils_get_cwd(char * buffer, size_t max_length)
   if (!buffer) {
     return false;
   }
-#ifdef WIN32
+#ifdef _WIN32
   if (!_getcwd(buffer, (int)max_length)) {
     return false;
   }
@@ -43,7 +43,7 @@ rcutils_get_cwd(char * buffer, size_t max_length)
   if (!getcwd(buffer, max_length)) {
     return false;
   }
-#endif
+#endif  // _WIN32
   return true;
 }
 
@@ -54,11 +54,11 @@ rcutils_is_directory(const char * abs_path)
   if (stat(abs_path, &buf) < 0) {
     return false;
   }
-#ifdef WIN32
+#ifdef _WIN32
   return (buf.st_mode & S_IFDIR) == S_IFDIR;
 #else
   return S_ISDIR(buf.st_mode);
-#endif
+#endif  // _WIN32
 }
 
 bool
@@ -68,11 +68,11 @@ rcutils_is_file(const char * abs_path)
   if (stat(abs_path, &buf) < 0) {
     return false;
   }
-#ifdef WIN32
+#ifdef _WIN32
   return (buf.st_mode & S_IFREG) == S_IFREG;
 #else
   return S_ISREG(buf.st_mode);
-#endif
+#endif  // _WIN32
 }
 
 bool
@@ -93,11 +93,11 @@ rcutils_is_readable(const char * abs_path)
     return false;
   }
   stat(abs_path, &buf);
-#ifdef WIN32
+#ifdef _WIN32
   if (!(buf.st_mode & _S_IREAD)) {
 #else
   if (!(buf.st_mode & S_IRUSR)) {
-#endif
+#endif  // _WIN32
     return false;
   }
   return true;
@@ -111,11 +111,11 @@ rcutils_is_writable(const char * abs_path)
     return false;
   }
   stat(abs_path, &buf);
-#ifdef WIN32
+#ifdef _WIN32
   if (!(buf.st_mode & _S_IWRITE)) {
 #else
   if (!(buf.st_mode & S_IWUSR)) {
-#endif
+#endif  // _WIN32
     return false;
   }
   return true;
@@ -129,13 +129,13 @@ rcutils_is_readable_and_writable(const char * abs_path)
     return false;
   }
   stat(abs_path, &buf);
-#ifdef WIN32
+#ifdef _WIN32
   // NOTE(marguedas) on windows all writable files are readable
   // hence the following check is equivalent to "& _S_IWRITE"
   if (!((buf.st_mode & _S_IWRITE) && (buf.st_mode & _S_IREAD))) {
 #else
   if (!((buf.st_mode & S_IWUSR) && (buf.st_mode & S_IRUSR))) {
-#endif
+#endif  // _WIN32
     return false;
   }
   return true;
@@ -151,11 +151,11 @@ rcutils_join_path(const char * left_hand_path, const char * right_hand_path)
     return NULL;
   }
 
-#ifdef  WIN32
+#ifdef  _WIN32
   const char * delimiter = "\\";
 #else
   const char * delimiter = "/";
-#endif
+#endif  // _WIN32
 
   return rcutils_concat(left_hand_path, right_hand_path, delimiter);
 }

--- a/src/get_env.c
+++ b/src/get_env.c
@@ -22,10 +22,10 @@ extern "C"
 
 #include "rcutils/get_env.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 # define WINDOWS_ENV_BUFFER_SIZE 2048
 static char __env_buffer[WINDOWS_ENV_BUFFER_SIZE];
-#endif  // WIN32
+#endif  // _WIN32
 
 
 const char *
@@ -38,7 +38,7 @@ rcutils_get_env(const char * env_name, const char ** env_value)
     return "argument env_value is null";
   }
   *env_value = NULL;
-#ifdef WIN32
+#ifdef _WIN32
   size_t required_size;
   errno_t ret = getenv_s(&required_size, __env_buffer, sizeof(__env_buffer), env_name);
   if (ret != 0) {
@@ -51,7 +51,7 @@ rcutils_get_env(const char * env_name, const char ** env_value)
   if (NULL == *env_value) {
     *env_value = "";
   }
-#endif  // WIN32
+#endif  // _WIN32
   return NULL;
 }
 

--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if defined(WIN32)
+#if defined(_WIN32)
 # error time_unix.c is not intended to be used with win32 based systems
-#endif  // defined(WIN32)
+#endif  // defined(_WIN32)
 
 #if __cplusplus
 extern "C"

--- a/src/time_win32.c
+++ b/src/time_win32.c
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef WIN32
+#ifndef _WIN32
 # error time_win32.c is only intended to be used with win32 based systems
-#endif
+#endif  // _WIN32
 
 #if __cplusplus
 extern "C"

--- a/test/memory_tools/memory_tools.cpp
+++ b/test/memory_tools/memory_tools.cpp
@@ -94,7 +94,7 @@ void stop_memory_checking()
 /******************************************************************************
  * End Apple
  *****************************************************************************/
-// #elif defined(WIN32)
+// #elif defined(_WIN32)
 /******************************************************************************
  * Begin Windows
  *****************************************************************************/
@@ -140,4 +140,4 @@ void set_on_unexpected_free_callback(UnexpectedCallbackType callback) {}
 
 void memory_checking_thread_init() {}
 
-#endif  // if defined(__linux__) elif defined(__APPLE__) elif defined(WIN32) else ...
+#endif  // if defined(__linux__) elif defined(__APPLE__) elif defined(_WIN32) else ...

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -25,7 +25,7 @@ TEST(test_filesystem, join_path) {
   const char * ref_str = "foo\\bar";
 #else
   const char * ref_str = "foo/bar";
-#endif
+#endif  // _WIN32
   EXPECT_FALSE(NULL == path);
   EXPECT_STREQ(ref_str, path);
 }

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -21,7 +21,7 @@ static char cwd[1024];
 
 TEST(test_filesystem, join_path) {
   const char * path = rcutils_join_path("foo", "bar");
-#ifdef WIN32
+#ifdef _WIN32
   const char * ref_str = "foo\\bar";
 #else
   const char * ref_str = "foo/bar";


### PR DESCRIPTION
Some files use the "non-safe" `WIN32` while others use the reserved  `_WIN32`

This PR and the referenced ones homogenize all packages to use `_WIN32`

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2914)](http://ci.ros2.org/job/ci_linux/2914/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=392)](http://ci.ros2.org/job/ci_linux-aarch64/392/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2357)](http://ci.ros2.org/job/ci_osx/2357/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3038)](http://ci.ros2.org/job/ci_windows/3038/) (test failure unrelated)