### PR TITLE
fix rcutils_snprintf function name

### DIFF
--- a/include/rcutils/format_string.h
+++ b/include/rcutils/format_string.h
@@ -55,7 +55,7 @@ extern "C"
  * The returned string must be deallocated using the same allocator given once
  * it is no longer needed.
  *
- * \see rcutils_snprintf_s()
+ * \see rcutils_snprintf()
  *
  * \param[in] allocator the allocator to use for allocation
  * \param[in] limit maximum length of the output string


### PR DESCRIPTION
as defined in https://github.com/ros2/rcutils/blob/aef3d6170c8f9d60e0f4c93f426f8d11e6ce8c2c/include/rcutils/snprintf.h#L34