### PR TITLE
Remove static keyword on duration arg in throttle logging feature

### DIFF
--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -19,10 +19,11 @@
 #ifndef RCUTILS__LOGGING_MACROS_H_
 #define RCUTILS__LOGGING_MACROS_H_
 
-#include "rcutils/logging.h"
-
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "rcutils/logging.h"
+#include "rcutils/time.h"
 
 #if __cplusplus
 extern "C"
@@ -194,7 +195,7 @@ typedef bool (* RclLogFilter)();
  * A macro initializing and checking the `throttle` condition.
  */
 #define RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(time_source_type, duration) { \
-    static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS((rcutils_duration_value_t)duration); \
+    rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS((rcutils_duration_value_t)duration); \
     static rcutils_time_point_value_t __rcutils_logging_last_logged = 0; \
     rcutils_time_point_value_t __rcutils_logging_now = 0; \
     bool __rcutils_logging_condition = true; \

--- a/test/test_logging_macros.c
+++ b/test/test_logging_macros.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "rcutils/logging_macros.h"
+#include "rcutils/time.h"
 
 size_t g_log_calls = 0;
 
@@ -71,7 +72,7 @@ int main(int argc, char ** argv)
   if (strcmp(g_last_log_event.location->function_name, "main")) {
     return 5;
   }
-  if (g_last_log_event.location->line_number != 64u) {
+  if (g_last_log_event.location->line_number != 65u) {
     return 6;
   }
   if (g_last_log_event.severity != RCUTILS_LOG_SEVERITY_INFO) {
@@ -94,7 +95,7 @@ int main(int argc, char ** argv)
   if (strcmp(g_last_log_event.location->function_name, "main")) {
     return 12;
   }
-  if (g_last_log_event.location->line_number != 87u) {
+  if (g_last_log_event.location->line_number != 88u) {
     return 13;
   }
   if (g_last_log_event.severity != RCUTILS_LOG_SEVERITY_INFO) {
@@ -106,6 +107,10 @@ int main(int argc, char ** argv)
   if (strcmp(g_last_log_event.message, "message foo")) {
     return 16;
   }
+
+  // Check throttling calls work from within C when passing variable as duration
+  rcutils_duration_value_t duration_ms = 50;
+  RCUTILS_LOG_ERROR_THROTTLE(RCUTILS_STEADY_TIME, duration_ms, "throttled message")
 
   rcutils_logging_set_output_handler(previous_output_handler);
   if (g_last_log_event.message) {


### PR DESCRIPTION
I'm having issues using  the throttle logging feature from within C. First commit https://github.com/ros2/rcutils/commit/5cf5c9efbedf0c4c96a21bd18d48fd8094b866b2 adds a regression test that causes the following output at build time:

```
Scanning dependencies of target test_logging_macros_c
[ 72%] Building C object CMakeFiles/test_logging_macros_c.dir/test/test_logging_macros.c.o
In file included from /home/dhood/ros2_ws/src/ros2/rcutils/test/test_logging_macros.c:17:0:
/home/dhood/ros2_ws/src/ros2/rcutils/test/test_logging_macros.c: In function ‘main’:
/home/dhood/ros2_ws/src/ros2/rcutils/include/rcutils/time.h:32:40: error: initializer element is not constant
 #define RCUTILS_MS_TO_NS(milliseconds) (milliseconds * (1000 * 1000))
                                        ^
/home/dhood/ros2_ws/build_isolated/rcutils/include/rcutils/logging_macros.h:91:5: note: in definition of macro ‘RCUTILS_LOG_COND_NAMED’
     condition_before \
     ^
/home/dhood/ros2_ws/build_isolated/rcutils/include/rcutils/logging_macros.h:198:66: note: in expansion of macro ‘RCUTILS_MS_TO_NS’
     static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS((rcutils_duration_value_t)duration); \
                                                                  ^
/home/dhood/ros2_ws/build_isolated/rcutils/include/rcutils/logging_macros.h:1026:5: note: in expansion of macro ‘RCUTILS_LOG_CONDITION_THROTTLE_BEFORE’
     RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(time_source_type, duration), RCUTILS_LOG_CONDITION_THROTTLE_AFTER, "", \
     ^
/home/dhood/ros2_ws/src/ros2/rcutils/test/test_logging_macros.c:113:3: note: in expansion of macro ‘RCUTILS_LOG_ERROR_THROTTLE’
   RCUTILS_LOG_ERROR_THROTTLE(RCUTILS_STEADY_TIME, duration_ms, "throttled message")
   ^
CMakeFiles/test_logging_macros_c.dir/build.make:62: recipe for target 'CMakeFiles/test_logging_macros_c.dir/test/test_logging_macros.c.o' failed
```

FWIU, the int64 can be used as const in C++ but not in C, which is why the C++ equivalent test is passing. I removed the static keyword in https://github.com/ros2/rcutils/commit/8afe8d2403194340df9bedcb98d5b4d27215b82f since I don't think it's necessary for the feature to function correctly. If another approach is more appropriate please advise

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3097)](http://ci.ros2.org/job/ci_linux/3097/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=476)](http://ci.ros2.org/job/ci_linux-aarch64/476/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2482)](http://ci.ros2.org/job/ci_osx/2482/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3169)](http://ci.ros2.org/job/ci_windows/3169/) (unrelated flaky test)