### PR TITLE
Don't require logging users to manually initialise before setting severity

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -211,6 +211,42 @@ void rcutils_logging_console_output_handler(
   rcutils_log_location_t * location,
   int severity, const char * name, const char * format, va_list * args);
 
+// Provide the compiler with branch prediction information
+#ifndef _WIN32
+/**
+ * \def RCUTILS_LIKELY
+ * Instruct the compiler to optimize for the case where the argument equals 1.
+ */
+# define RCUTILS_LIKELY(x) __builtin_expect((x), 1)
+/**
+ * \def RCUTILS_UNLIKELY
+ * Instruct the compiler to optimize for the case where the argument equals 0.
+ */
+# define RCUTILS_UNLIKELY(x) __builtin_expect((x), 0)
+#else
+/**
+ * \def RCUTILS_LIKELY
+ * No op since Windows doesn't support providing branch prediction information.
+ */
+# define RCUTILS_LIKELY(x) (x)
+/**
+ * \def RCUTILS_UNLIKELY
+ * No op since Windows doesn't support providing branch prediction information.
+ */
+# define RCUTILS_UNLIKELY(x) (x)
+#endif  // _WIN32
+
+/**
+ * \def RCUTILS_LOGGING_AUTOINIT
+ * \brief Initialize the rcl logging library.
+ * Usually it is unnecessary to call the macro directly.
+ * All logging macros ensure that this has been called once.
+ */
+#define RCUTILS_LOGGING_AUTOINIT \
+  if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
+    rcutils_logging_initialize(); \
+  }
+
 #if __cplusplus
 }
 #endif

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -38,42 +38,6 @@ extern "C"
 #define RCUTILS_LOG_MIN_SEVERITY RCUTILS_LOG_SEVERITY_DEBUG
 #endif
 
-// Provide the compiler with branch prediction information
-#ifndef _WIN32
-/**
- * \def RCUTILS_LIKELY
- * Instruct the compiler to optimize for the case where the argument equals 1.
- */
-# define RCUTILS_LIKELY(x) __builtin_expect((x), 1)
-/**
- * \def RCUTILS_UNLIKELY
- * Instruct the compiler to optimize for the case where the argument equals 0.
- */
-# define RCUTILS_UNLIKELY(x) __builtin_expect((x), 0)
-#else
-/**
- * \def RCUTILS_LIKELY
- * No op since Windows doesn't support providing branch prediction information.
- */
-# define RCUTILS_LIKELY(x) (x)
-/**
- * \def RCUTILS_UNLIKELY
- * No op since Windows doesn't support providing branch prediction information.
- */
-# define RCUTILS_UNLIKELY(x) (x)
-#endif  // _WIN32
-
-/**
- * \def RCUTILS_LOGGING_AUTOINIT
- * \brief Initialize the rcl logging library.
- * Usually it is unnecessary to call the macro directly.
- * All logging macros ensure that this has been called once.
- */
-#define RCUTILS_LOGGING_AUTOINIT \
-  if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
-    rcutils_logging_initialize(); \
-  }
-
 /**
  * \def RCUTILS_LOG_COND_NAMED
  * The logging macro all other logging macros call directly or indirectly.

--- a/src/logging.c
+++ b/src/logging.c
@@ -52,7 +52,8 @@ int rcutils_logging_get_severity_threshold()
 
 void rcutils_logging_set_severity_threshold(int severity)
 {
-  g_rcutils_logging_severity_threshold = severity;
+  RCUTILS_LOGGING_AUTOINIT
+    g_rcutils_logging_severity_threshold = severity;
 }
 
 void rcutils_log(


### PR DESCRIPTION
If this is appropriate, does it also belong on the getter so you don't get the uninitialised value?