### PR TITLE
Don't try to interrupt exiting test_logging_long_messages process

### DIFF
--- a/test/test_logging_long_messages.py
+++ b/test/test_logging_long_messages.py
@@ -19,16 +19,14 @@ from launch.exit_handler import ignore_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-from launch_testing import get_default_filtered_prefixes
 
 
 def test_logging_long_messages():
     launch_descriptor = LaunchDescriptor()
 
     output_file = os.path.join(os.path.dirname(__file__), 'test_logging_long_messages')
-    filtered = get_default_filtered_prefixes()
     handler = create_handler(
-        'test_logging_long_messages', launch_descriptor, output_file, filtered_prefixes=filtered)
+        'test_logging_long_messages', launch_descriptor, output_file)
     assert handler, 'Cannot find appropriate handler for %s' % output_file
 
     executable = os.path.join(os.getcwd(), 'test_logging_long_messages')

--- a/test/test_logging_long_messages.py
+++ b/test/test_logging_long_messages.py
@@ -15,7 +15,7 @@
 import os
 
 from launch import LaunchDescriptor
-from launch.exit_handler import default_exit_handler
+from launch.exit_handler import ignore_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
@@ -37,7 +37,7 @@ def test_logging_long_messages():
     launch_descriptor.add_process(
         cmd=[executable],
         name='test_logging_long_messages',
-        exit_handler=default_exit_handler,
+        exit_handler=ignore_exit_handler,  # The process will automatically exit after printing.
         output_handlers=[ConsoleOutput(), handler],
     )
 


### PR DESCRIPTION
It will automatically exit after printing its message, so don't try to interrupt it when the output matches.

Without this PR the test is flaky: http://ci.ros2.org/view/nightly/job/nightly_linux_repeated/800/testReport/junit/(root)/projectroot/test_logging_long_messages/
With this PR it passes 100 times (same machine): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3302)](http://ci.ros2.org/job/ci_linux/3302/) 

Also I removed what seems to be unnecessary usage of `get_default_filtered_prefixes` in https://github.com/ros2/rcutils/commit/0b753c9d7a02db598f47934d6d35eb79edbe5cb8 but it's not otherwise related.