### PR TITLE
Make key to feature_combinations a tuple instead of suffix

### DIFF
--- a/rcutils/logging.py
+++ b/rcutils/logging.py
@@ -97,47 +97,47 @@ class Feature:
 
 
 feature_combinations = OrderedDict((
-    (get_suffix_from_features([]), Feature()),
-    (get_suffix_from_features(['named']), Feature(
+    ((), Feature()),
+    (('named'), Feature(
         params=name_params,
         args=name_args)),
-    (get_suffix_from_features(['once']), Feature(
+    (('once'), Feature(
         params=None,
         args=once_args,
         doc_lines=name_doc_lines)),
-    (get_suffix_from_features(['once', 'named']), Feature(
+    (('once', 'named'), Feature(
         params=name_params,
         args={**once_args, **name_args},
         doc_lines=name_doc_lines)),
-    (get_suffix_from_features(['expression']), Feature(
+    (('expression'), Feature(
         params=expression_params,
         args=expression_args,
         doc_lines=expression_doc_lines)),
-    (get_suffix_from_features(['expression', 'named']), Feature(
+    (('expression', 'named'), Feature(
         params=OrderedDict((*expression_params.items(), *name_params.items())),
         args={**expression_args, **name_args},
         doc_lines=expression_doc_lines + name_doc_lines)),
-    (get_suffix_from_features(['function']), Feature(
+    (('function'), Feature(
         params=function_params,
         args=function_args,
         doc_lines=function_doc_lines)),
-    (get_suffix_from_features(['function', 'named']), Feature(
+    (('function', 'named'), Feature(
         params=OrderedDict((*function_params.items(), *name_params.items())),
         args={**function_args, **name_args},
         doc_lines=function_doc_lines + name_doc_lines)),
-    (get_suffix_from_features(['skip_first']), Feature(
+    (('skip_first'), Feature(
         params=None,
         args=skipfirst_args,
         doc_lines=skipfirst_doc_lines)),
-    (get_suffix_from_features(['skip_first', 'named']), Feature(
+    (('skip_first', 'named'), Feature(
         params=name_params,
         args={**skipfirst_args, **name_args},
         doc_lines=skipfirst_doc_lines)),
-    (get_suffix_from_features(['throttle']), Feature(
+    (('throttle'), Feature(
         params=throttle_params,
         args=throttle_args,
         doc_lines=throttle_doc_lines)),
-    (get_suffix_from_features(['skip_first', 'throttle']), Feature(
+    (('skip_first', 'throttle'), Feature(
         params=throttle_params,
         args={
             'condition_before': ' '.join([
@@ -147,11 +147,11 @@ feature_combinations = OrderedDict((
                 throttle_args['condition_after'], skipfirst_args['condition_after']]),
         },
         doc_lines=skipfirst_doc_lines + throttle_doc_lines)),
-    (get_suffix_from_features(['throttle', 'named']), Feature(
+    (('throttle', 'named'), Feature(
         params=OrderedDict((*throttle_params.items(), *name_params.items())),
         args={**throttle_args, **name_args},
         doc_lines=throttle_doc_lines)),
-    (get_suffix_from_features(['skip_first', 'throttle', 'named']), Feature(
+    (('skip_first', 'throttle', 'named'), Feature(
         params=OrderedDict((*throttle_params.items(), *name_params.items())),
         args={
             **{
@@ -167,13 +167,13 @@ feature_combinations = OrderedDict((
 ))
 
 
-def get_macro_parameters(suffix):
-    return feature_combinations[suffix].params
+def get_macro_parameters(feature_combination):
+    return feature_combinations[feature_combination].params
 
 
-def get_macro_arguments(suffix):
+def get_macro_arguments(feature_combination):
     args = []
     for k, default_value in default_args.items():
-        value = feature_combinations[suffix].args.get(k, default_value)
+        value = feature_combinations[feature_combination].args.get(k, default_value)
         args.append(value)
     return args

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -188,6 +188,7 @@ sys.path.insert(0, rcutils_module_path)
 from rcutils.logging import feature_combinations
 from rcutils.logging import get_macro_arguments
 from rcutils.logging import get_macro_parameters
+from rcutils.logging import get_suffix_from_features
 from rcutils.logging import severities
 }@
 @[for severity in severities]@
@@ -196,33 +197,35 @@ from rcutils.logging import severities
 ///@@{
 #if (RCUTILS_LOG_MIN_SEVERITY > RCUTILS_LOG_SEVERITY_@(severity))
 // empty logging macros for severity @(severity) when being disabled at compile time
-@[ for suffix in feature_combinations]@
+@[ for feature_combination in feature_combinations]@
+@{suffix = get_suffix_from_features(feature_combination)}@
 /// Empty logging macro due to the preprocessor definition of RCUTILS_LOG_MIN_SEVERITY.
-# define RCUTILS_LOG_@(severity)@(suffix)(@(''.join([p + ', ' for p in get_macro_parameters(suffix).keys()]))format, ...)
+# define RCUTILS_LOG_@(severity)@(suffix)(@(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))format, ...)
 @[ end for]@
 
 #else
-@[ for suffix in feature_combinations]@
+@[ for feature_combination in feature_combinations]@
+@{suffix = get_suffix_from_features(feature_combination)}@
 /**
  * \def RCUTILS_LOG_@(severity)@(suffix)
  * Log a message with severity @(severity)@
-@[ if feature_combinations[suffix].doc_lines]@
+@[ if feature_combinations[feature_combination].doc_lines]@
  with the following conditions:
 @[ else]@
 .
 @[ end if]@
-@[ for doc_line in feature_combinations[suffix].doc_lines]@
+@[ for doc_line in feature_combinations[feature_combination].doc_lines]@
  * @(doc_line)
 @[ end for]@
-@[ for param_name, doc_line in feature_combinations[suffix].params.items()]@
+@[ for param_name, doc_line in feature_combinations[feature_combination].params.items()]@
  * \param @(param_name) @(doc_line)
 @[ end for]@
  * \param ... The format string, followed by the variable arguments for the format string
  */
-# define RCUTILS_LOG_@(severity)@(suffix)(@(''.join([p + ', ' for p in get_macro_parameters(suffix).keys()]))...) \
+# define RCUTILS_LOG_@(severity)@(suffix)(@(''.join([p + ', ' for p in get_macro_parameters(feature_combination).keys()]))...) \
   RCUTILS_LOG_COND_NAMED( \
     RCUTILS_LOG_SEVERITY_@(severity), \
-    @(''.join([str(a) + ', ' for a in get_macro_arguments(suffix)]))\
+    @(''.join([str(a) + ', ' for a in get_macro_arguments(feature_combination)]))\
     __VA_ARGS__)
 @[ end for]@
 #endif


### PR DESCRIPTION
connects to ros2/rclcpp#389

The suffix is quite specific to logging_macros.h and other consumers might want to iterate through combinations more generically

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3384)](http://ci.ros2.org/job/ci_linux/3384/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=632)](http://ci.ros2.org/job/ci_linux-aarch64/632/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2716)](http://ci.ros2.org/job/ci_osx/2716/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3434)](http://ci.ros2.org/job/ci_windows/3434/)