### PR TITLE
pointer illegal access to out-of-scope stack pointer

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -272,11 +272,11 @@ void rcutils_logging_console_output_handler(
     size_t token_len = chars_to_end_delim - 1;  // Not including delimiters.
     memcpy(token, str + i + 1, token_len);  // Skip the start delimiter.
     token[token_len] = '\0';
-    const char * token_expansion = NULL;
-    // Allow 9 digits for the expansion (otherwise, truncate). Even in the case of truncation
-    // the result will still be null-terminated.
-    char line_number_expansion[10];
+    // Expand known tokens into their content strings.
     // The resulting token_expansion string must always be null-terminated.
+    const char * token_expansion = NULL;
+    // Allow 9 digits for the expansion of the line number (otherwise, truncate).
+    char line_number_expansion[10];
     if (strcmp("severity", token) == 0) {
       token_expansion = severity_string;
     } else if (strcmp("name", token) == 0) {
@@ -289,6 +289,7 @@ void rcutils_logging_console_output_handler(
       token_expansion = location ? location->file_name : "\"\"";
     } else if (strcmp("line_number", token) == 0) {
       if (location) {
+        // Even in the case of truncation the result will still be null-terminated.
         written = rcutils_snprintf(
           line_number_expansion, sizeof(line_number_expansion), "%zu", location->line_number);
         if (written < 0) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -273,6 +273,9 @@ void rcutils_logging_console_output_handler(
     memcpy(token, str + i + 1, token_len);  // Skip the start delimiter.
     token[token_len] = '\0';
     const char * token_expansion = NULL;
+    // Allow 9 digits for the expansion (otherwise, truncate). Even in the case of truncation
+    // the result will still be null-terminated.
+    char line_number_expansion[10];
     // The resulting token_expansion string must always be null-terminated.
     if (strcmp("severity", token) == 0) {
       token_expansion = severity_string;
@@ -286,9 +289,6 @@ void rcutils_logging_console_output_handler(
       token_expansion = location ? location->file_name : "\"\"";
     } else if (strcmp("line_number", token) == 0) {
       if (location) {
-        // Allow 9 digits for the expansion (otherwise, truncate). Even in the case of truncation
-        // the result will still be null-terminated.
-        char line_number_expansion[10];
         written = rcutils_snprintf(
           line_number_expansion, sizeof(line_number_expansion), "%zu", location->line_number);
         if (written < 0) {


### PR DESCRIPTION
the following line_number_expansion is stack pointer:

`char line_number_expansion[10];
`

and it has already been out-of-scope in the following
access, which may cause unintended program behaviors:

```
size_t n = strlen(token_expansion);
...
memcpy(output_buffer + old_output_buffer_len, token_expansion, n + 1);

```
Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>