### PR TITLE
memory leak issues

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -117,14 +117,16 @@ rcutils_set_error_state(
  * \param[in] ... Arguments for the format string.
  */
 #define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, format_string, ...) \
+do {  
   char * output_msg = NULL; \
   output_msg = rcutils_format_string(allocator, format_string, __VA_ARGS__); \
   if (output_msg) { \
     RCUTILS_SET_ERROR_MSG(output_msg, allocator); \
     allocator.deallocate(output_msg, allocator.state); \
   } else { \
-    RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message"); \
+    RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message\n"); \
   }
+} while (0)
 
 /// Return `true` if the error is set, otherwise `false`.
 RCUTILS_PUBLIC

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -107,7 +107,7 @@ rcutils_set_error_state(
 #define RCUTILS_SET_ERROR_MSG(msg, allocator) \
   rcutils_set_error_state(msg, __FILE__, __LINE__, allocator);
 
-/// Set the error message using a format stirng and format arguments.
+/// Set the error message using a format string and format arguments.
 /**
  * This function sets the error message using the given format string and
  * then frees the memory allocated during the string formatting.

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -126,7 +126,7 @@ rcutils_set_error_state(
     } else { \
       RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message\n"); \
     } \
-  } while (0)
+  } while (false)
 
 /// Return `true` if the error is set, otherwise `false`.
 RCUTILS_PUBLIC

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -107,18 +107,18 @@ rcutils_set_error_state(
 #define RCUTILS_SET_ERROR_MSG(msg, allocator) \
   rcutils_set_error_state(msg, __FILE__, __LINE__, allocator);
 
-/// Set the error msg with the format specified
+/// Set the error message using a format stirng and format arguments.
 /**
- * This function sets the error msg with the format specified and free the
- * corresponding memory allocated from rcutils_format_string_limit() or its
- * macro rcutils_format_string to avoid memory leak unconsciously.
+ * This function sets the error message using the given format string and
+ * then frees the memory allocated during the string formatting.
  *
- * \param[in] fmt_str format string or msg with a certain format string inline
- * \param[in] allocator the allocator to use for allocation
+ * \param[in] allocator The allocator to be used when allocating space for the error state.
+ * \param[in] format_string The string to be used as the format of the error message.
+ * \param[in] ... Arguments for the format string.
  */
-#define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, fmt_str, ...) \
+#define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, format_string, ...) \
   char * output_msg = NULL; \
-  output_msg = rcutils_format_string(allocator, fmt_str, __VA_ARGS__); \
+  output_msg = rcutils_format_string(allocator, format_string, __VA_ARGS__); \
   if (output_msg) { \
     RCUTILS_SET_ERROR_MSG(output_msg, allocator); \
     allocator.deallocate(output_msg, allocator.state); \

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -23,9 +23,9 @@ extern "C"
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stddef.h>
 
 #include "rcutils/allocator.h"
 #include "rcutils/macros.h"
@@ -41,7 +41,7 @@ typedef struct rcutils_error_state_t
   rcutils_allocator_t allocator;
 } rcutils_error_state_t;
 
-#define SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
+#define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
 
 /// Copy an error state into a destination error state.
 /**
@@ -123,7 +123,7 @@ rcutils_set_error_state(
     RCUTILS_SET_ERROR_MSG(output_msg, allocator); \
     allocator.deallocate(output_msg, allocator.state); \
   } else { \
-    SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message"); \
+    RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message"); \
   }
 
 /// Return `true` if the error is set, otherwise `false`.

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -125,7 +125,7 @@ do {
     allocator.deallocate(output_msg, allocator.state); \
   } else { \
     RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message\n"); \
-  }
+  } \
 } while (0)
 
 /// Return `true` if the error is set, otherwise `false`.

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -117,16 +117,16 @@ rcutils_set_error_state(
  * \param[in] ... Arguments for the format string.
  */
 #define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, format_string, ...) \
-do { \
-  char * output_msg = NULL; \
-  output_msg = rcutils_format_string(allocator, format_string, __VA_ARGS__); \
-  if (output_msg) { \
-    RCUTILS_SET_ERROR_MSG(output_msg, allocator); \
-    allocator.deallocate(output_msg, allocator.state); \
-  } else { \
-    RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message\n"); \
-  } \
-} while (0)
+  do { \
+    char * output_msg = NULL; \
+    output_msg = rcutils_format_string(allocator, format_string, __VA_ARGS__); \
+    if (output_msg) { \
+      RCUTILS_SET_ERROR_MSG(output_msg, allocator); \
+      allocator.deallocate(output_msg, allocator.state); \
+    } else { \
+      RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for error message\n"); \
+    } \
+  } while (0)
 
 /// Return `true` if the error is set, otherwise `false`.
 RCUTILS_PUBLIC

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -103,6 +103,22 @@ rcutils_set_error_state(
 #define RCUTILS_SET_ERROR_MSG(msg, allocator) \
   rcutils_set_error_state(msg, __FILE__, __LINE__, allocator);
 
+/// Set the formatted error msg and free its memory allocated
+/**
+ * This function sets the error msg with the format specified and free the 
+ * corresponding memory allocated from function rcutils_format_string_limit() 
+ * or macro rcutils_format_string drived from it to avoid memory leak.
+ *
+ * \param[in] formatted_msg the output formatted with memory allocated
+ * \param[in] allocator the allocator to use for allocation
+ * \returns `false` if invalid memory allocation to format, otherwise `true` 
+ */
+RCUTILS_PUBLIC
+bool 
+rcutils_set_formatted_error(
+  char * formatted_msg,
+  rcutils_allocator_t allocator);
+
 /// Return `true` if the error is set, otherwise `false`.
 RCUTILS_PUBLIC
 bool

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -117,7 +117,7 @@ rcutils_set_error_state(
  * \param[in] ... Arguments for the format string.
  */
 #define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, format_string, ...) \
-do {  
+do { \
   char * output_msg = NULL; \
   output_msg = rcutils_format_string(allocator, format_string, __VA_ARGS__); \
   if (output_msg) { \

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -167,24 +167,6 @@ rcutils_set_error_state(
   __rcutils_reset_error_string(&__rcutils_error_string, __rcutils_error_state->allocator);
 }
 
-bool 
-rcutils_set_formatted_error(
-  char * formatted_msg,
-  rcutils_allocator_t allocator)
-{
-  if (!formatted_msg) {
-    RCUTILS_SET_ERROR_MSG("No invalid memory allocated to format string", allocator);
-    return false;
-  }
-
-  RCUTILS_SET_ERROR_MSG(formatted_msg, allocator);
-
-  allocator.deallocate(formatted_msg, allocator.state);
-  formatted_msg = nullptr;
-
-  return true;
-}
-
 const rcutils_error_state_t *
 rcutils_get_error_state()
 {

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -167,6 +167,24 @@ rcutils_set_error_state(
   __rcutils_reset_error_string(&__rcutils_error_string, __rcutils_error_state->allocator);
 }
 
+bool 
+rcutils_set_formatted_error(
+  char * formatted_msg,
+  rcutils_allocator_t allocator)
+{
+  if (!formatted_msg) {
+    RCUTILS_SET_ERROR_MSG("No invalid memory allocated to format string", allocator);
+    return false;
+  }
+
+  RCUTILS_SET_ERROR_MSG(formatted_msg, allocator);
+
+  allocator.deallocate(formatted_msg, allocator.state);
+  formatted_msg = nullptr;
+
+  return true;
+}
+
 const rcutils_error_state_t *
 rcutils_get_error_state()
 {

--- a/src/split.c
+++ b/src/split.c
@@ -87,6 +87,7 @@ rcutils_split(
         string_array->data[token_counter] =
           allocator.allocate((rhs - lhs + 2) * sizeof(char), allocator.state);
         if (!string_array->data[token_counter]) {
+          string_array->size = token_counter;
           goto fail;
         }
         snprintf(string_array->data[token_counter], (rhs - lhs + 1), "%s", str + lhs);
@@ -111,10 +112,8 @@ rcutils_split(
   return RCUTILS_RET_OK;
 
 fail:
-  error_msg = "unable to allocate memory for string array data";
-  if (rcutils_string_array_fini(string_array) != RCUTILS_RET_OK) {
-    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, "FATAL: %s. Leaking memory", error_msg);
-  }
+  RCUTILS_SET_ERROR_MSG("unable to allocate memory for string array data", allocator);
+  rcutils_string_array_fini(string_array);
   return RCUTILS_RET_ERROR;
 }
 

--- a/src/split.c
+++ b/src/split.c
@@ -113,9 +113,8 @@ rcutils_split(
 fail:
   error_msg = "unable to allocate memory for string array data";
   if (rcutils_string_array_fini(string_array) != RCUTILS_RET_OK) {
-    error_msg = rcutils_format_string(allocator, "FATAL: %s. Leaking memory", error_msg);
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, "FATAL: %s. Leaking memory", error_msg);
   }
-  rcutils_set_formatted_error(error_msg, allocator);
   return RCUTILS_RET_ERROR;
 }
 

--- a/src/split.c
+++ b/src/split.c
@@ -58,7 +58,6 @@ rcutils_split(
     rhs_offset = 1;
   }
 
-  const char * error_msg;
   string_array->size = 1;
   for (size_t i = lhs_offset; i < string_size - rhs_offset; ++i) {
     if (str[i] == delimiter) {

--- a/src/split.c
+++ b/src/split.c
@@ -115,7 +115,7 @@ fail:
   if (rcutils_string_array_fini(string_array) != RCUTILS_RET_OK) {
     error_msg = rcutils_format_string(allocator, "FATAL: %s. Leaking memory", error_msg);
   }
-  RCUTILS_SET_ERROR_MSG(error_msg, allocator);
+  rcutils_set_formatted_error(error_msg, allocator);
   return RCUTILS_RET_ERROR;
 }
 

--- a/src/split.c
+++ b/src/split.c
@@ -112,8 +112,14 @@ rcutils_split(
   return RCUTILS_RET_OK;
 
 fail:
+  if (rcutils_string_array_fini(string_array) != RCUTILS_RET_OK) {
+    RCUTILS_SAFE_FWRITE_TO_STDERR("failed to finalize string array during error handling: ");
+    RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string_safe());
+    RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
+    rcutils_reset_error();
+  }
+
   RCUTILS_SET_ERROR_MSG("unable to allocate memory for string array data", allocator);
-  rcutils_string_array_fini(string_array);
   return RCUTILS_RET_ERROR;
 }
 

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -353,8 +353,7 @@ rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key)
   rcutils_allocator_t allocator = string_map->impl->allocator;
   size_t key_index;
   if (!__get_index_of_key_if_exists(string_map->impl, key, strlen(key), &key_index)) {
-    char * msg = rcutils_format_string(allocator, "key '%s' not found", key);
-    rcutils_set_formatted_error(msg, allocator);
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, "key '%s' not found", key);
     return RCUTILS_RET_STRING_KEY_NOT_FOUND;
   }
   __remove_key_and_value_at_index(string_map->impl, key_index);

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -354,8 +354,7 @@ rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key)
   size_t key_index;
   if (!__get_index_of_key_if_exists(string_map->impl, key, strlen(key), &key_index)) {
     char * msg = rcutils_format_string(allocator, "key '%s' not found", key);
-    RCUTILS_SET_ERROR_MSG(msg, allocator)
-    allocator.deallocate(msg, allocator.state);
+    rcutils_set_formatted_error(msg, allocator);
     return RCUTILS_RET_STRING_KEY_NOT_FOUND;
   }
   __remove_key_and_value_at_index(string_map->impl, key_index);


### PR DESCRIPTION
memory allocated from `rcutils_format_string()` is relatively easy
easy to forget to free and this leaks system resource. A wrapper
API added to make it shared and centralized, then fix those mem
leak issues using that API.

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>