### PR TITLE
Have rcutils_join_path return a char *.

### DIFF
--- a/include/rcutils/concat.h
+++ b/include/rcutils/concat.h
@@ -22,6 +22,15 @@ extern "C"
 
 #include "rcutils/visibility_control.h"
 
+/// Return a newly allocated string that contains lhs, followed by delimiter, followed by rhs.
+/**
+ * This function allocates memory and returns it to the caller.  It is up to the
+ * caller to release the memory once it is done with it by calling `free`.
+ *
+ * \return char * concatenated string on success
+ *         NULL on invalid arguments
+ *         NULL on failure
+ */
 RCUTILS_PUBLIC
 char *
 rcutils_concat(const char * lhs, const char * rhs, const char * delimiter);

--- a/include/rcutils/concat.h
+++ b/include/rcutils/concat.h
@@ -24,8 +24,8 @@ extern "C"
 
 /// Return a newly allocated string that contains lhs, followed by delimiter, followed by rhs.
 /**
- * This function allocates memory and returns it to the caller.  It is up to the
- * caller to release the memory once it is done with it by calling `free`.
+ * This function allocates memory and returns it to the caller.
+ * It is up to the caller to release the memory once it is done with it by calling `free`.
  *
  * \return char * concatenated string on success
  *         NULL on invalid arguments

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -105,11 +105,15 @@ RCUTILS_PUBLIC
 bool
 rcutils_is_readable_and_writable(const char * abs_path);
 
-/// Concatenate path adding the right delimiter according to the platform.
+/// Return a newly allocated string that contains left_hand_path, followed by
+/// the correct delimiter for the platform, followed by right_hand_path.
 /**
+ * This function allocates memory and returns it to the caller.  It is up to the
+ * caller to release the memory once it is done with it by calling `free`.
+ *
  * \param[in] left_hand_path
  * \param[in] right_hand_path
- * \return const char * concatenated path on success
+ * \return char * concatenated path on success
  *         NULL on invalid arguments
  *         NULL on failure
  */

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -105,11 +105,10 @@ RCUTILS_PUBLIC
 bool
 rcutils_is_readable_and_writable(const char * abs_path);
 
-/// Return a newly allocated string that contains left_hand_path, followed by
-/// the correct delimiter for the platform, followed by right_hand_path.
+/// Return newly allocated string with arguments separated by correct delimiter for the platform.
 /**
- * This function allocates memory and returns it to the caller.  It is up to the
- * caller to release the memory once it is done with it by calling `free`.
+ * This function allocates memory and returns it to the caller.
+ * It is up to the caller to release the memory once it is done with it by calling `free`.
  *
  * \param[in] left_hand_path
  * \param[in] right_hand_path

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -114,7 +114,7 @@ rcutils_is_readable_and_writable(const char * abs_path);
  *         NULL on failure
  */
 RCUTILS_PUBLIC
-const char *
+char *
 rcutils_join_path(const char * left_hand_path, const char * right_hand_path);
 
 #if __cplusplus

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -141,7 +141,7 @@ rcutils_is_readable_and_writable(const char * abs_path)
   return true;
 }
 
-const char *
+char *
 rcutils_join_path(const char * left_hand_path, const char * right_hand_path)
 {
   if (!left_hand_path) {

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -20,7 +20,7 @@
 static char cwd[1024];
 
 TEST(test_filesystem, join_path) {
-  const char * path = rcutils_join_path("foo", "bar");
+  char * path = rcutils_join_path("foo", "bar");
 #ifdef _WIN32
   const char * ref_str = "foo\\bar";
 #else
@@ -33,7 +33,7 @@ TEST(test_filesystem, join_path) {
 TEST(test_filesystem, exists) {
   EXPECT_FALSE(rcutils_get_cwd(NULL, 1024));
   EXPECT_TRUE(rcutils_get_cwd(cwd, 1024));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_readable_file.txt");
   EXPECT_TRUE(rcutils_exists(path));
   path = rcutils_join_path(cwd, "test");
@@ -43,7 +43,7 @@ TEST(test_filesystem, exists) {
 
 TEST(test_filesystem, is_directory) {
   EXPECT_TRUE(rcutils_get_cwd(cwd, 1024));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_readable_file.txt");
   EXPECT_FALSE(rcutils_is_directory(path));
   path = rcutils_join_path(cwd, "test");
@@ -53,7 +53,7 @@ TEST(test_filesystem, is_directory) {
 
 TEST(test_filesystem, is_file) {
   EXPECT_TRUE(rcutils_get_cwd(cwd, 1024));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_readable_file.txt");
   EXPECT_TRUE(rcutils_is_file(path));
   path = rcutils_join_path(cwd, "test");
@@ -63,7 +63,7 @@ TEST(test_filesystem, is_file) {
 
 TEST(test_filesystem, is_readable) {
   EXPECT_TRUE(rcutils_get_cwd(cwd, 1024));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_readable_file.txt");
   EXPECT_TRUE(rcutils_is_readable(path));
   path = rcutils_join_path(cwd, "test");
@@ -82,7 +82,7 @@ TEST(test_filesystem, is_writable) {
   // path = std::string(cwd) + delimiter + std::string("test") + delimiter + std::string(
   //   "dummy_readable_file.txt");
   // EXPECT_FALSE(rcutils_is_writable(path.c_str()));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_folder");
   EXPECT_TRUE(rcutils_is_writable(path));
   path = rcutils_join_path(cwd, "test");
@@ -97,7 +97,7 @@ TEST(test_filesystem, is_readable_and_writable) {
   EXPECT_TRUE(rcutils_get_cwd(cwd, 1024));
   // path = std::string(cwd) + std::string("/test/dummy_readable_file.txt");
   // EXPECT_FALSE(rcutils_is_readable_and_writable(path.c_str()));
-  const char * path = rcutils_join_path(cwd, "test");
+  char * path = rcutils_join_path(cwd, "test");
   path = rcutils_join_path(path, "dummy_folder");
   EXPECT_TRUE(rcutils_is_readable_and_writable(path));
   path = rcutils_join_path(cwd, "test");


### PR DESCRIPTION
It is returning malloc'ed memory, so const char * doesn't
make sense for it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#423