### PR TITLE
Rcutils check allocator follow-up

### DIFF
--- a/src/allocator.c
+++ b/src/allocator.c
@@ -92,10 +92,10 @@ rcutils_allocator_is_valid(const rcutils_allocator_t * allocator)
 void *
 rcutils_reallocf(void * pointer, size_t size, rcutils_allocator_t * allocator)
 {
-  if (!allocator || !allocator->reallocate || !allocator->deallocate) {
+  if (!rcutils_allocator_is_valid(allocator)) {
     // cannot deallocate pointer, so print message to stderr and return NULL
     RCUTILS_SAFE_FWRITE_TO_STDERR(
-      "[c_utilties|allocator.c:" RCUTILS_STRINGIFY(__LINE__) "] rcutils_reallocf(): "
+      "[rcutils|allocator.c:" RCUTILS_STRINGIFY(__LINE__) "] rcutils_reallocf(): "
       "invalid allocator or allocator function pointers, memory leaked\n");
     return NULL;
   }

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -20,6 +20,14 @@
 #include "rcutils/error_handling.h"
 #include "rcutils/macros.h"
 
+// When this define evaluates to true (default), then messages will printed to
+// stderr when an error is encoutered while setting the error state.
+// For example, when memory cannot be allocated or a previous error state is
+// being overwritten.
+#ifndef RCUTILS_REPORT_ERROR_HANDLING_ERRORS
+#define RCUTILS_REPORT_ERROR_HANDLING_ERRORS 1
+#endif
+
 static void *
 __default_allocate(size_t size, void * state)
 {
@@ -94,9 +102,11 @@ rcutils_reallocf(void * pointer, size_t size, rcutils_allocator_t * allocator)
 {
   if (!rcutils_allocator_is_valid(allocator)) {
     // cannot deallocate pointer, so print message to stderr and return NULL
+#if RCUTILS_REPORT_ERROR_HANDLING_ERRORS
     RCUTILS_SAFE_FWRITE_TO_STDERR(
       "[rcutils|allocator.c:" RCUTILS_STRINGIFY(__LINE__) "] rcutils_reallocf(): "
       "invalid allocator or allocator function pointers, memory leaked\n");
+#endif
     return NULL;
   }
   void * new_pointer = allocator->reallocate(pointer, size, allocator->state);

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -81,6 +81,15 @@ rcutils_set_error_state(
   size_t line_number,
   rcutils_allocator_t allocator)
 {
+  if (!rcutils_allocator_is_valid(&allocator)) {
+#if RCUTILS_REPORT_ERROR_HANDLING_ERRORS
+    // rcutils_allocator is invalid, logging to stderr instead
+    SAFE_FWRITE_TO_STDERR(
+      "[rcutils|error_handling.c:" RCUTILS_STRINGIFY(__LINE__)
+      "] provided allocator is invalid, error state not updated\n");
+#endif
+    return;
+  }
 #ifdef RCUTILS_THREAD_LOCAL_PTHREAD
   rcutils_error_state_t * __rcutils_error_state =
     (rcutils_error_state_t *)pthread_getspecific(__rcutils_error_state_key);
@@ -260,12 +269,13 @@ __rcutils_reset_error_string(char ** error_string_ptr, rcutils_allocator_t alloc
   if (!error_string_ptr) {
     return;
   }
+
   rcutils_allocator_t local_allocator = allocator;
-  if (!local_allocator.deallocate) {
+  if (!rcutils_allocator_is_valid(&allocator)) {
 #if RCUTILS_REPORT_ERROR_HANDLING_ERRORS
     RCUTILS_SAFE_FWRITE_TO_STDERR(
       "[rcutils|error_handling.c:" RCUTILS_STRINGIFY(__LINE__) "]: "
-      "invalid allocator, deallocate function pointer is null\n");
+      "invalid allocator\n");
 #endif
     local_allocator = rcutils_get_default_allocator();
   }

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -84,7 +84,7 @@ rcutils_set_error_state(
   if (!rcutils_allocator_is_valid(&allocator)) {
 #if RCUTILS_REPORT_ERROR_HANDLING_ERRORS
     // rcutils_allocator is invalid, logging to stderr instead
-    SAFE_FWRITE_TO_STDERR(
+    RCUTILS_SAFE_FWRITE_TO_STDERR(
       "[rcutils|error_handling.c:" RCUTILS_STRINGIFY(__LINE__)
       "] provided allocator is invalid, error state not updated\n");
 #endif


### PR DESCRIPTION
addresses https://github.com/ros2/rcutils/pull/66#discussion_r150364173

Note: I didnt replace `fwrite(...)` with `SAFE_FWRITE_TO_STDERR` as this macro has not been made public yet

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3577)](http://ci.ros2.org/job/ci_linux/3577/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=774)](http://ci.ros2.org/job/ci_linux-aarch64/774/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2916)](http://ci.ros2.org/job/ci_osx/2916/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3670)](http://ci.ros2.org/job/ci_windows/3670/)