### PR TITLE
Undo mixing of once's and named's doc_lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,10 +50,14 @@ set_source_files_properties(
   ${rcutils_sources}
   PROPERTIES language "C")
 
-# "watch" template for changes
+# "watch" template/inputs for changes
 configure_file(
   "resource/logging_macros.h.em"
   "logging_macros.h.em.watch"
+  COPYONLY)
+configure_file(
+  "rcutils/logging.py"
+  "logging.py.watch"
   COPYONLY)
 # generate header with logging macros
 set(rcutils_module_path ${CMAKE_CURRENT_SOURCE_DIR})
@@ -64,7 +68,7 @@ string(REPLACE ";" "$<SEMICOLON>" python_code "${python_code}")
 add_custom_command(OUTPUT include/rcutils/logging_macros.h
   COMMAND ${CMAKE_COMMAND} -E make_directory "include/rcutils"
   COMMAND ${PYTHON_EXECUTABLE} ARGS -c "${python_code}"
-  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/logging_macros.h.em.watch"
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/logging_macros.h.em.watch" "${CMAKE_CURRENT_BINARY_DIR}/logging.py.watch"
   COMMENT "Expanding logging_macros.h.em"
   VERBATIM
 )

--- a/rcutils/logging.py
+++ b/rcutils/logging.py
@@ -26,10 +26,11 @@ name_params = OrderedDict((
     ('name', 'The name of the logger'),
 ))
 name_args = {'name': 'name'}
+name_doc_lines = []
 once_args = {
     'condition_before': 'RCUTILS_LOG_CONDITION_ONCE_BEFORE',
     'condition_after': 'RCUTILS_LOG_CONDITION_ONCE_AFTER'}
-name_doc_lines = [
+once_doc_lines = [
     'All subsequent log calls except the first one are being ignored.']
 expression_params = OrderedDict((
     ('expression', 'The expression determining if the message should be logged'),
@@ -102,15 +103,16 @@ feature_combinations = OrderedDict((
     ((), Feature()),
     (('named'), Feature(
         params=name_params,
-        args=name_args)),
+        args=name_args,
+        doc_lines=name_doc_lines)),
     (('once'), Feature(
         params=None,
         args=once_args,
-        doc_lines=name_doc_lines)),
+        doc_lines=once_doc_lines)),
     (('once', 'named'), Feature(
         params=name_params,
         args={**once_args, **name_args},
-        doc_lines=name_doc_lines)),
+        doc_lines=once_doc_lines + name_doc_lines)),
     (('expression'), Feature(
         params=expression_params,
         args=expression_args,
@@ -134,7 +136,7 @@ feature_combinations = OrderedDict((
     (('skip_first', 'named'), Feature(
         params=name_params,
         args={**skipfirst_args, **name_args},
-        doc_lines=skipfirst_doc_lines)),
+        doc_lines=skipfirst_doc_lines + name_doc_lines)),
     (('throttle'), Feature(
         params=throttle_params,
         args=throttle_args,
@@ -152,7 +154,7 @@ feature_combinations = OrderedDict((
     (('throttle', 'named'), Feature(
         params=OrderedDict((*throttle_params.items(), *name_params.items())),
         args={**throttle_args, **name_args},
-        doc_lines=throttle_doc_lines)),
+        doc_lines=throttle_doc_lines + name_doc_lines)),
     (('skip_first', 'throttle', 'named'), Feature(
         params=OrderedDict((*throttle_params.items(), *name_params.items())),
         args={
@@ -165,7 +167,7 @@ feature_combinations = OrderedDict((
                     skipfirst_args['condition_after']]),
             }, **name_args
         },
-        doc_lines=skipfirst_doc_lines + throttle_doc_lines)),
+        doc_lines=skipfirst_doc_lines + throttle_doc_lines + name_doc_lines)),
 ))
 
 


### PR DESCRIPTION
A couple of places have been accidentally referencing once's doc line (which was actually called `name_doc_line`) e.g. http://docs.ros2.org/beta3/api/rcutils/logging__macros_8h.html#a4fb4a0978ca7725899f98d4c0b064e44. 

https://github.com/ros2/rcutils/commit/26d7748305fa1dfb134a46a37a84a0ef2c7cf304 also adds a watch file for the python module so it triggers template rebuilding (not necessary, just came across it at the same time)

linux ci [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3516)](http://ci.ros2.org/job/ci_linux/3516/)