### PR TITLE
Shorter default console output format

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -48,12 +48,12 @@ extern bool g_rcutils_logging_initialized;
  * The `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable can be used to set
  * the output format of messages logged to the console.
  * Available tokens are:
- *   - file_name
- *   - function_name
- *   - line_number
- *   - message
- *   - name
- *   - severity
+ *   - `file_name`, the full file name of the caller including the path
+ *   - `function_name`, the function name of the caller
+ *   - `line_number`, the line number of the caller
+ *   - `message`, the message string after it has been formatted
+ *   - `name`, the full logger name
+ *   - `severity`, the name of the severity level, e.g. `INFO`
  *
  * The format string can use these tokens by referencing them in curly brackets,
  * e.g. `"[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"`.

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -45,6 +45,21 @@ extern bool g_rcutils_logging_initialized;
  *
  * If multiple errors occur, the error code of the last error will be returned.
  *
+ * The `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable can be used to set
+ * the output format of messages logged to the console.
+ * Available tokens are:
+ *   - file_name
+ *   - function_name
+ *   - line_number
+ *   - message
+ *   - name
+ *   - severity
+ *
+ * The format string can use these tokens by referencing them in curly brackets,
+ * e.g. `"[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"`.
+ * Any number of tokens can be used.
+ * The limit of the format string is 2048 characters.
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/src/logging.c
+++ b/src/logging.c
@@ -42,8 +42,7 @@ const char * g_rcutils_log_severity_names[] = {
 bool g_rcutils_logging_initialized = false;
 
 char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
-static const char * g_rcutils_logging_default_output_format =
-  "[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})";
+static const char * g_rcutils_logging_default_output_format = "[{severity}] [{name}]: {message}";
 
 static rcutils_allocator_t g_rcutils_logging_allocator;
 

--- a/test/test_logging_long_messages.py
+++ b/test/test_logging_long_messages.py
@@ -29,6 +29,9 @@ def test_logging_long_messages():
         'test_logging_long_messages', launch_descriptor, output_file)
     assert handler, 'Cannot find appropriate handler for %s' % output_file
 
+    # Set the output format to a "verbose" format that is expected by the executable output
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = \
+        '[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})'
     executable = os.path.join(os.getcwd(), 'test_logging_long_messages')
     if os.name == 'nt':
         executable += '.exe'


### PR DESCRIPTION
Just severity, name and message.

The reasoning is that most of the time our demo output is too verbose. If someone is debugging something specific, they can see the caller location information by setting the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable to e.g. `"[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"` (it can't currently be changed at runtime).


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3551)](http://ci.ros2.org/job/ci_linux/3551/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=754)](http://ci.ros2.org/job/ci_linux-aarch64/754/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2893)](http://ci.ros2.org/job/ci_osx/2893/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3633)](http://ci.ros2.org/job/ci_windows/3633/)