### PR TITLE
using precise time on windows

### DIFF
--- a/src/time_win32.c
+++ b/src/time_win32.c
@@ -35,7 +35,7 @@ rcutils_system_time_now(rcutils_time_point_value_t * now)
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(
     now, RCUTILS_RET_INVALID_ARGUMENT, rcutils_get_default_allocator());
   FILETIME ft;
-  GetSystemTimeAsFileTime(&ft);
+  GetSystemTimePreciseAsFileTime(&ft);
   ULARGE_INTEGER uli;
   uli.LowPart = ft.dwLowDateTime;
   uli.HighPart = ft.dwHighDateTime;


### PR DESCRIPTION
Thanks @serge-nikulin for finding this alternative API! This seems to actually fix some timing issues we were facing.

This API doesn't exist on Windows prior windows 8 but given that we target and support only Windows 10 we can use it safely.

https://msdn.microsoft.com/en-us/library/windows/desktop/hh706895(v=vs.85).aspx

* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3638)](http://ci.ros2.org/job/ci_windows/3638/)
* Windows Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3642)](http://ci.ros2.org/job/ci_windows/3642/) (test failure unrelated)
* Windows Release [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3643)](http://ci.ros2.org/job/ci_windows/3643/)