### PR TITLE
Update the rcutils_find* APIs to return SIZE_MAX on invalid arguments.

### DIFF
--- a/include/rcutils/find.h
+++ b/include/rcutils/find.h
@@ -30,8 +30,7 @@ extern "C"
  * \param[in] str null terminated c string to search
  * \param[in] delimiter the character to search for
  * \returns the index of the first occurence of the delimiter if found, or
- * \returns `string_length` if the delimiter is not found, or
- * \returns `SIZE_MAX` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
  */
 RCUTILS_PUBLIC
 size_t
@@ -46,8 +45,7 @@ rcutils_find(const char * str, char delimiter);
  * \param[in] delimiter the character to search for
  * \param[in] string_length length of the string to search
  * \returns the index of the first occurence of the delimiter if found, or
- * \returns `string_length` if the delimiter is not found, or
- * \returns `SIZE_MAX` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
  */
 RCUTILS_PUBLIC
 size_t
@@ -60,8 +58,7 @@ rcutils_findn(const char * str, char delimiter, size_t string_length);
  * \param[in] str null terminated c string to search
  * \param[in] delimiter the character to search for
  * \returns the index of the last occurence of the delimiter if found, or
- * \returns `string_length` if the delimiter is not found, or
- * \returns `SIZE_MAX` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
  */
 RCUTILS_PUBLIC
 size_t
@@ -76,8 +73,7 @@ rcutils_find_last(const char * str, char delimiter);
  * \param[in] delimiter the character to search for
  * \param[in] string_length length of the string to search
  * \returns the index of the last occurence of the delimiter if found, or
- * \returns `string_length` if the delimiter is not found, or
- * \returns `SIZE_MAX` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
  */
 RCUTILS_PUBLIC
 size_t

--- a/include/rcutils/find.h
+++ b/include/rcutils/find.h
@@ -31,7 +31,7 @@ extern "C"
  * \param[in] delimiter the character to search for
  * \returns the index of the first occurence of the delimiter if found, or
  * \returns `string_length` if the delimiter is not found, or
- * \returns `0` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments
  */
 RCUTILS_PUBLIC
 size_t
@@ -47,7 +47,7 @@ rcutils_find(const char * str, char delimiter);
  * \param[in] string_length length of the string to search
  * \returns the index of the first occurence of the delimiter if found, or
  * \returns `string_length` if the delimiter is not found, or
- * \returns `0` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments
  */
 RCUTILS_PUBLIC
 size_t
@@ -61,7 +61,7 @@ rcutils_findn(const char * str, char delimiter, size_t string_length);
  * \param[in] delimiter the character to search for
  * \returns the index of the last occurence of the delimiter if found, or
  * \returns `string_length` if the delimiter is not found, or
- * \returns `0` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments
  */
 RCUTILS_PUBLIC
 size_t
@@ -77,7 +77,7 @@ rcutils_find_last(const char * str, char delimiter);
  * \param[in] string_length length of the string to search
  * \returns the index of the last occurence of the delimiter if found, or
  * \returns `string_length` if the delimiter is not found, or
- * \returns `0` for invalid arguments
+ * \returns `SIZE_MAX` for invalid arguments
  */
 RCUTILS_PUBLIC
 size_t

--- a/src/find.c
+++ b/src/find.c
@@ -17,6 +17,7 @@ extern "C"
 {
 #endif
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,7 +29,7 @@ size_t
 rcutils_find(const char * str, char delimiter)
 {
   if (!str || strlen(str) == 0) {
-    return 0;
+    return SIZE_MAX;
   }
   return rcutils_findn(str, delimiter, strlen(str));
 }
@@ -36,8 +37,8 @@ rcutils_find(const char * str, char delimiter)
 size_t
 rcutils_findn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str) {
-    return 0;
+  if (!str || strlen(str) == 0) {
+    return SIZE_MAX;
   }
 
   for (size_t i = 0; i < string_length; ++i) {
@@ -52,7 +53,7 @@ size_t
 rcutils_find_last(const char * str, char delimiter)
 {
   if (!str || strlen(str) == 0) {
-    return 0;
+    return SIZE_MAX;
   }
   return rcutils_find_lastn(str, delimiter, strlen(str));
 }
@@ -60,8 +61,8 @@ rcutils_find_last(const char * str, char delimiter)
 size_t
 rcutils_find_lastn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str) {
-    return 0;
+  if (!str || strlen(str) == 0) {
+    return SIZE_MAX;
   }
   size_t last_found = string_length;
   for (size_t i = 0; i < string_length; ++i) {

--- a/src/find.c
+++ b/src/find.c
@@ -37,7 +37,7 @@ rcutils_find(const char * str, char delimiter)
 size_t
 rcutils_findn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str || strlen(str) == 0) {
+  if (!str || string_length == 0) {
     return SIZE_MAX;
   }
 
@@ -61,7 +61,7 @@ rcutils_find_last(const char * str, char delimiter)
 size_t
 rcutils_find_lastn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str || strlen(str) == 0) {
+  if (!str || string_length == 0) {
     return SIZE_MAX;
   }
   size_t last_found = string_length;

--- a/src/find.c
+++ b/src/find.c
@@ -28,7 +28,7 @@ extern "C"
 size_t
 rcutils_find(const char * str, char delimiter)
 {
-  if (!str || strlen(str) == 0) {
+  if (!str || 0 == strlen(str)) {
     return SIZE_MAX;
   }
   return rcutils_findn(str, delimiter, strlen(str));
@@ -37,7 +37,7 @@ rcutils_find(const char * str, char delimiter)
 size_t
 rcutils_findn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str || string_length == 0) {
+  if (!str || 0 == string_length) {
     return SIZE_MAX;
   }
 
@@ -46,13 +46,13 @@ rcutils_findn(const char * str, char delimiter, size_t string_length)
       return i;
     }
   }
-  return string_length;
+  return SIZE_MAX;
 }
 
 size_t
 rcutils_find_last(const char * str, char delimiter)
 {
-  if (!str || strlen(str) == 0) {
+  if (!str || 0 == strlen(str)) {
     return SIZE_MAX;
   }
   return rcutils_find_lastn(str, delimiter, strlen(str));
@@ -61,11 +61,12 @@ rcutils_find_last(const char * str, char delimiter)
 size_t
 rcutils_find_lastn(const char * str, char delimiter, size_t string_length)
 {
-  if (!str || string_length == 0) {
+  if (!str || 0 == string_length) {
     return SIZE_MAX;
   }
-  size_t last_found = string_length;
-  for (size_t i = 0; i < string_length; ++i) {
+
+  size_t last_found = SIZE_MAX;
+  for (size_t i = 0; i < string_length; i++) {
     if (str[i] == delimiter) {
       last_found = i;
     }

--- a/src/find.c
+++ b/src/find.c
@@ -65,13 +65,12 @@ rcutils_find_lastn(const char * str, char delimiter, size_t string_length)
     return SIZE_MAX;
   }
 
-  size_t last_found = SIZE_MAX;
-  for (size_t i = 0; i < string_length; i++) {
+  for (size_t i = string_length - 1; i > 0; --i) {
     if (str[i] == delimiter) {
-      last_found = i;
+      return i;
     }
   }
-  return last_found;
+  return str[0] == delimiter ? 0 : SIZE_MAX;
 }
 
 #if __cplusplus

--- a/src/logging.c
+++ b/src/logging.c
@@ -17,6 +17,7 @@ extern "C"
 {
 #endif
 
+#include <stdint.h>
 #include <string.h>
 
 #include "rcutils/allocator.h"
@@ -240,7 +241,7 @@ int rcutils_logging_get_logger_effective_severity_threshold(const char * name)
     }
     // Determine the next ancestor's FQN by removing the child's name.
     size_t index_last_separator = rcutils_find_lastn(name, '.', substring_length);
-    if (index_last_separator == substring_length) {
+    if (SIZE_MAX == index_last_separator || index_last_separator == substring_length) {
       // There are no more separators in the substring.
       // The name we just checked was the last that we needed to, and it was unset.
       break;

--- a/src/logging.c
+++ b/src/logging.c
@@ -241,7 +241,7 @@ int rcutils_logging_get_logger_effective_severity_threshold(const char * name)
     }
     // Determine the next ancestor's FQN by removing the child's name.
     size_t index_last_separator = rcutils_find_lastn(name, '.', substring_length);
-    if (SIZE_MAX == index_last_separator || index_last_separator == substring_length) {
+    if (SIZE_MAX == index_last_separator) {
       // There are no more separators in the substring.
       // The name we just checked was the last that we needed to, and it was unset.
       break;

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -57,13 +57,13 @@ size_t test_find_lastn(const char * str, char delimiter, size_t str_len, size_t 
 
 TEST(test_find, find) {
   size_t ret0 = test_find("", '/', SIZE_MAX);
-  LOG((size_t)0, ret0);
+  LOG(SIZE_MAX, ret0);
 
   size_t ret00 = test_find(NULL, '/', SIZE_MAX);
-  LOG((size_t)0, ret00);
+  LOG(SIZE_MAX, ret00);
 
-  size_t ret1 = test_find("hello_world", '/', strlen("hello_world"));
-  LOG(strlen("hello_world"), ret1);
+  size_t ret1 = test_find("hello_world", '/', SIZE_MAX);
+  LOG(SIZE_MAX, ret1);
 
   size_t ret2 = test_find("hello/world", '/', 5);
   LOG((size_t)5, ret2);
@@ -83,13 +83,13 @@ TEST(test_find, find) {
 
 TEST(test_find, findn) {
   size_t ret0 = test_findn("", '/', 0, SIZE_MAX);
-  LOG((size_t)0, ret0);
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret1 = test_findn(NULL, '/', 10, SIZE_MAX);
-  LOG((size_t)0, ret1);
+  LOG((size_t)SIZE_MAX, ret1);
 
-  size_t ret2 = test_findn("hello_world", '/', strlen("hello_world"), strlen("hello_world"));
-  LOG(strlen("hello_world"), ret2);
+  size_t ret2 = test_findn("hello_world", '/', strlen("hello_world"), SIZE_MAX);
+  LOG(SIZE_MAX, ret2);
 
   size_t ret3 = test_findn("hello/world", '/', strlen("hello/world"), 5);
   LOG((size_t)5, ret3);
@@ -100,13 +100,13 @@ TEST(test_find, findn) {
 
 TEST(test_find, find_last) {
   size_t ret0 = test_find_last("", '/', SIZE_MAX);
-  LOG((size_t)0, ret0);
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret00 = test_find_last(NULL, '/', SIZE_MAX);
-  LOG((size_t)0, ret00);
+  LOG((size_t)SIZE_MAX, ret00);
 
-  size_t ret1 = test_find_last("hello_world", '/', strlen("hello_world"));
-  LOG(strlen("hello_world"), ret1);
+  size_t ret1 = test_find_last("hello_world", '/', SIZE_MAX);
+  LOG(SIZE_MAX, ret1);
 
   size_t ret2 = test_find_last("hello/world", '/', 5);
   LOG((size_t)5, ret2);
@@ -126,13 +126,13 @@ TEST(test_find, find_last) {
 
 TEST(test_find, find_lastn) {
   size_t ret0 = test_find_lastn("", '/', 0, SIZE_MAX);
-  LOG((size_t)0, ret0);
+  LOG(SIZE_MAX, ret0);
 
   size_t ret1 = test_find_lastn(NULL, '/', 10, SIZE_MAX);
-  LOG((size_t)0, ret1);
+  LOG(SIZE_MAX, ret1);
 
-  size_t ret2 = test_find_lastn("hello_world", '/', strlen("hello_world"), strlen("hello_world"));
-  LOG(strlen("hello_world"), ret2);
+  size_t ret2 = test_find_lastn("hello_world", '/', strlen("hello_world"), SIZE_MAX);
+  LOG(SIZE_MAX, ret2);
 
   size_t ret3 = test_find_lastn("hello/world", '/', strlen("hello/world"), 5);
   LOG((size_t)5, ret3);

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -57,13 +57,18 @@ size_t test_find_lastn(const char * str, char delimiter, size_t str_len, size_t 
 
 TEST(test_find, find) {
   size_t ret0 = test_find("", '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret0);
+  // We cast SIZE_MAX to a size_t here (and below) to shut up warnings on macOS.
+  // The problem on macOS is that size_t is a long unsigned int, while SIZE_MAX
+  // is an unsigned long long.  While the two are compatible on 64-bit, they are
+  // not considered the "same" by the compiler, and throw a warning.  Just cast
+  // SIZE_MAX to size_t to make the compiler happy.
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret00 = test_find(NULL, '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret00);
+  LOG((size_t)SIZE_MAX, ret00);
 
   size_t ret1 = test_find("hello_world", '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret1);
+  LOG((size_t)SIZE_MAX, ret1);
 
   size_t ret2 = test_find("hello/world", '/', 5);
   LOG((size_t)5, ret2);
@@ -83,13 +88,13 @@ TEST(test_find, find) {
 
 TEST(test_find, findn) {
   size_t ret0 = test_findn("", '/', 0, SIZE_MAX);
-  LOG(SIZE_MAX, ret0);
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret1 = test_findn(NULL, '/', 10, SIZE_MAX);
-  LOG(SIZE_MAX, ret1);
+  LOG((size_t)SIZE_MAX, ret1);
 
   size_t ret2 = test_findn("hello_world", '/', strlen("hello_world"), SIZE_MAX);
-  LOG(SIZE_MAX, ret2);
+  LOG((size_t)SIZE_MAX, ret2);
 
   size_t ret3 = test_findn("hello/world", '/', strlen("hello/world"), 5);
   LOG((size_t)5, ret3);
@@ -100,13 +105,13 @@ TEST(test_find, findn) {
 
 TEST(test_find, find_last) {
   size_t ret0 = test_find_last("", '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret0);
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret00 = test_find_last(NULL, '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret00);
+  LOG((size_t)SIZE_MAX, ret00);
 
   size_t ret1 = test_find_last("hello_world", '/', SIZE_MAX);
-  LOG(SIZE_MAX, ret1);
+  LOG((size_t)SIZE_MAX, ret1);
 
   size_t ret2 = test_find_last("hello/world", '/', 5);
   LOG((size_t)5, ret2);
@@ -126,13 +131,13 @@ TEST(test_find, find_last) {
 
 TEST(test_find, find_lastn) {
   size_t ret0 = test_find_lastn("", '/', 0, SIZE_MAX);
-  LOG(SIZE_MAX, ret0);
+  LOG((size_t)SIZE_MAX, ret0);
 
   size_t ret1 = test_find_lastn(NULL, '/', 10, SIZE_MAX);
-  LOG(SIZE_MAX, ret1);
+  LOG((size_t)SIZE_MAX, ret1);
 
   size_t ret2 = test_find_lastn("hello_world", '/', strlen("hello_world"), SIZE_MAX);
-  LOG(SIZE_MAX, ret2);
+  LOG((size_t)SIZE_MAX, ret2);
 
   size_t ret3 = test_find_lastn("hello/world", '/', strlen("hello/world"), 5);
   LOG((size_t)5, ret3);

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdint.h>
+
 #include "gtest/gtest.h"
 
 #include "rcutils/find.h"
@@ -54,10 +56,10 @@ size_t test_find_lastn(const char * str, char delimiter, size_t str_len, size_t 
 }
 
 TEST(test_find, find) {
-  size_t ret0 = test_find("", '/', 0);
+  size_t ret0 = test_find("", '/', SIZE_MAX);
   LOG((size_t)0, ret0);
 
-  size_t ret00 = test_find(NULL, '/', 0);
+  size_t ret00 = test_find(NULL, '/', SIZE_MAX);
   LOG((size_t)0, ret00);
 
   size_t ret1 = test_find("hello_world", '/', strlen("hello_world"));
@@ -80,10 +82,10 @@ TEST(test_find, find) {
 }
 
 TEST(test_find, findn) {
-  size_t ret0 = test_findn("", '/', 0, 0);
+  size_t ret0 = test_findn("", '/', 0, SIZE_MAX);
   LOG((size_t)0, ret0);
 
-  size_t ret1 = test_findn(NULL, '/', 10, 0);
+  size_t ret1 = test_findn(NULL, '/', 10, SIZE_MAX);
   LOG((size_t)0, ret1);
 
   size_t ret2 = test_findn("hello_world", '/', strlen("hello_world"), strlen("hello_world"));
@@ -97,10 +99,10 @@ TEST(test_find, findn) {
 }
 
 TEST(test_find, find_last) {
-  size_t ret0 = test_find_last("", '/', 0);
+  size_t ret0 = test_find_last("", '/', SIZE_MAX);
   LOG((size_t)0, ret0);
 
-  size_t ret00 = test_find_last(NULL, '/', 0);
+  size_t ret00 = test_find_last(NULL, '/', SIZE_MAX);
   LOG((size_t)0, ret00);
 
   size_t ret1 = test_find_last("hello_world", '/', strlen("hello_world"));
@@ -123,10 +125,10 @@ TEST(test_find, find_last) {
 }
 
 TEST(test_find, find_lastn) {
-  size_t ret0 = test_find_lastn("", '/', 0, 0);
+  size_t ret0 = test_find_lastn("", '/', 0, SIZE_MAX);
   LOG((size_t)0, ret0);
 
-  size_t ret1 = test_find_lastn(NULL, '/', 10, 0);
+  size_t ret1 = test_find_lastn(NULL, '/', 10, SIZE_MAX);
   LOG((size_t)0, ret1);
 
   size_t ret2 = test_find_lastn("hello_world", '/', strlen("hello_world"), strlen("hello_world"));

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -83,10 +83,10 @@ TEST(test_find, find) {
 
 TEST(test_find, findn) {
   size_t ret0 = test_findn("", '/', 0, SIZE_MAX);
-  LOG((size_t)SIZE_MAX, ret0);
+  LOG(SIZE_MAX, ret0);
 
   size_t ret1 = test_findn(NULL, '/', 10, SIZE_MAX);
-  LOG((size_t)SIZE_MAX, ret1);
+  LOG(SIZE_MAX, ret1);
 
   size_t ret2 = test_findn("hello_world", '/', strlen("hello_world"), SIZE_MAX);
   LOG(SIZE_MAX, ret2);
@@ -100,10 +100,10 @@ TEST(test_find, findn) {
 
 TEST(test_find, find_last) {
   size_t ret0 = test_find_last("", '/', SIZE_MAX);
-  LOG((size_t)SIZE_MAX, ret0);
+  LOG(SIZE_MAX, ret0);
 
   size_t ret00 = test_find_last(NULL, '/', SIZE_MAX);
-  LOG((size_t)SIZE_MAX, ret00);
+  LOG(SIZE_MAX, ret00);
 
   size_t ret1 = test_find_last("hello_world", '/', SIZE_MAX);
   LOG(SIZE_MAX, ret1);


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

fixes #58 

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3582)](http://ci.ros2.org/job/ci_linux/3582/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=778)](http://ci.ros2.org/job/ci_linux-aarch64/778/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2922)](http://ci.ros2.org/job/ci_osx/2922/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3675)](http://ci.ros2.org/job/ci_windows/3675/)