### PR TITLE
Only evaluate logging 'function'/'expression' if severity is enabled

### DIFF
--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -61,11 +61,11 @@ extern "C"
   { \
     RCUTILS_LOGGING_AUTOINIT \
     static rcutils_log_location_t __rcutils_logging_location = {__func__, __FILE__, __LINE__}; \
-    condition_before \
     if (rcutils_logging_logger_is_enabled_for(name, severity)) { \
+      condition_before \
       rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
+      condition_after \
     } \
-    condition_after \
   }
 
 ///@@{

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -224,12 +224,15 @@ from rcutils.logging import severities
  * Log a message with severity @(severity)@
 @[ if feature_combinations[feature_combination].doc_lines]@
  with the following conditions:
+@[   for doc_line in feature_combinations[feature_combination].doc_lines]@
+ * - @(doc_line)
+@[   end for]@
+ *
+ * \note The conditions will only be evaluated if this logging statement is enabled.
+ *
 @[ else]@
 .
 @[ end if]@
-@[ for doc_line in feature_combinations[feature_combination].doc_lines]@
- * @(doc_line)
-@[ end for]@
 @[ for param_name, doc_line in feature_combinations[feature_combination].params.items()]@
  * \param @(param_name) @(doc_line)
 @[ end for]@

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -51,6 +51,9 @@ extern "C"
 /**
  * \def RCUTILS_LOG_COND_NAMED
  * The logging macro all other logging macros call directly or indirectly.
+ *
+ * \note The condition will only be evaluated if this logging statement is enabled.
+ *
  * \param severity The severity level
  * \param condition_before The condition macro(s) inserted before the log call
  * \param condition_after The condition macro(s) inserted after the log call

--- a/test/test_logging_macros.cpp
+++ b/test/test_logging_macros.cpp
@@ -108,18 +108,31 @@ TEST_F(TestLoggingMacros, test_logging_expression) {
 }
 
 int g_counter = 0;
+bool g_function_called = false;
 
 bool not_divisible_by_three()
 {
+  g_function_called = true;
   return (g_counter % 3) != 0;
 }
 
 TEST_F(TestLoggingMacros, test_logging_function) {
+  // check that evaluation of a specified function does not occur if the severity is not enabled
+  g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_INFO;
+  for (int i : {1, 2, 3, 4, 5, 6}) {
+    g_counter = i;
+    RCUTILS_LOG_DEBUG_FUNCTION(&not_divisible_by_three, "message %d", i);
+  }
+  EXPECT_EQ(0u, g_log_calls);
+  EXPECT_FALSE(g_function_called);
+  g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_DEBUG;
+
   for (int i : {1, 2, 3, 4, 5, 6}) {
     g_counter = i;
     RCUTILS_LOG_INFO_FUNCTION(&not_divisible_by_three, "message %d", i);
   }
   EXPECT_EQ(4u, g_log_calls);
+  EXPECT_TRUE(g_function_called);
   EXPECT_EQ("message 5", g_last_log_event.message);
 }
 

--- a/test/test_logging_macros.cpp
+++ b/test/test_logging_macros.cpp
@@ -119,7 +119,10 @@ bool not_divisible_by_three()
 TEST_F(TestLoggingMacros, test_logging_function) {
   // check that evaluation of a specified function does not occur if the severity is not enabled
   g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_INFO;
-  RCUTILS_LOG_DEBUG_FUNCTION(&not_divisible_by_three, "should not be logged");
+  for (int i : {0, 1}) {  // cover both true and false return values
+    g_counter = i;
+    RCUTILS_LOG_DEBUG_FUNCTION(&not_divisible_by_three, "message %d", i);
+  }
   EXPECT_EQ(0u, g_log_calls);
   EXPECT_FALSE(g_function_called);
   g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_DEBUG;

--- a/test/test_logging_macros.cpp
+++ b/test/test_logging_macros.cpp
@@ -109,7 +109,7 @@ TEST_F(TestLoggingMacros, test_logging_expression) {
 
 int g_counter = 0;
 
-bool mod3()
+bool not_divisible_by_three()
 {
   return (g_counter % 3) != 0;
 }
@@ -117,7 +117,7 @@ bool mod3()
 TEST_F(TestLoggingMacros, test_logging_function) {
   for (int i : {1, 2, 3, 4, 5, 6}) {
     g_counter = i;
-    RCUTILS_LOG_INFO_FUNCTION(&mod3, "message %d", i);
+    RCUTILS_LOG_INFO_FUNCTION(&not_divisible_by_three, "message %d", i);
   }
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ("message 5", g_last_log_event.message);

--- a/test/test_logging_macros.cpp
+++ b/test/test_logging_macros.cpp
@@ -119,10 +119,7 @@ bool not_divisible_by_three()
 TEST_F(TestLoggingMacros, test_logging_function) {
   // check that evaluation of a specified function does not occur if the severity is not enabled
   g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_INFO;
-  for (int i : {1, 2, 3, 4, 5, 6}) {
-    g_counter = i;
-    RCUTILS_LOG_DEBUG_FUNCTION(&not_divisible_by_three, "message %d", i);
-  }
+  RCUTILS_LOG_DEBUG_FUNCTION(&not_divisible_by_three, "should not be logged");
   EXPECT_EQ(0u, g_log_calls);
   EXPECT_FALSE(g_function_called);
   g_rcutils_logging_default_severity_threshold = RCUTILS_LOG_SEVERITY_DEBUG;


### PR DESCRIPTION
While working on https://github.com/ros2/demos/pull/194 I noticed that  `RCUTILS_LOG_DEBUG_FUNCTION` evaluates the function even when the debug severity is not enabled, which is inefficient. I looked for a specific reason it might have been done this way but couldn't find one (it's been like this since it was added). This behaviour is [not the case in ROS 1](https://github.com/ros/ros_comm/blob/4383f8fad9550836137077ed1a7120e5d3e745de/tools/rosconsole/include/ros/console.h#L366): the conditions are only evaluated if the severity is enabled.

An example of a side effect of this change is that the "hit" flag for the 'once' filter will only get evaluated after the severity is enabled now. I see this as an improvement because otherwise, without this PR,  `RCUTILS_LOG_DEBUG_ONCE` would never be printed if the first time it gets hit is when the severity threshold is INFO instead of DEBUG. Similar side effects apply for `SKIPFIRST`, `THROTTLE` but I don't consider any of them points for concern. The behaviour after this PR matches what I expect if/when we add a "notify logger levels changed" concept for resetting filter states whenever severity thresholds are changed.


* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3598)](http://ci.ros2.org/job/ci_linux/3598/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=789)](http://ci.ros2.org/job/ci_linux-aarch64/789/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2936)](http://ci.ros2.org/job/ci_osx/2936/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3688)](http://ci.ros2.org/job/ci_windows/3688/)