### PR TITLE
Make LOG macro behave like genuine code

### DIFF
--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -24,7 +24,8 @@
 } while (0)
 #else
 #define LOG(X, arg) do { \
-    (void)arg; \
+    (void)(X); \
+    (void)(arg); \
 } while (0)
 #endif
 

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -21,7 +21,7 @@
 #if ENABLE_LOGGING
 #define LOG(expected, actual) do { \
     printf("Expected: %zu Actual: %zu\n", expected, actual); \
-  } while (0)
+} while (0)
 #else
 #define LOG(X, arg) {}
 #endif

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -19,8 +19,9 @@
 #define ENABLE_LOGGING 1
 
 #if ENABLE_LOGGING
-#define LOG(expected, actual) { \
-    printf("Expected: %zu Actual: %zu\n", expected, actual);}
+#define LOG(expected, actual) do { \
+    printf("Expected: %zu Actual: %zu\n", expected, actual); \
+  } while (0)
 #else
 #define LOG(X, arg) {}
 #endif

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -23,7 +23,9 @@
     printf("Expected: %zu Actual: %zu\n", expected, actual); \
 } while (0)
 #else
-#define LOG(X, arg) {}
+#define LOG(X, arg) do { \
+    (void)arg; \
+} while (0)
 #endif
 
 size_t test_find(const char * str, char delimiter, size_t expected_pos)


### PR DESCRIPTION
Macro is really a code replacement. In this implementation, you may worry about
some bugs
1.
```
        // Declaration
        int func(int, int)
        LOG(expected actural);
```
2.
```
        while (lst & lst = lst->next) // Miss ';'
        LOG(expected, actural)
```

After this change, you could make LOG macro act like a genuine code and only use
once.