### PR TITLE
Use strlen / strnlen_s in RCUTILS_SAFE_FWRITE_TO_STDERR

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -22,6 +22,8 @@ extern "C"
 {
 #endif
 
+#define __STDC_WANT_LIB_EXT1__ 1  // needed for `strnlen_s`
+#include <string.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -41,7 +43,13 @@ typedef struct rcutils_error_state_t
   rcutils_allocator_t allocator;
 } rcutils_error_state_t;
 
-#define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
+#ifdef __STDC_LIB_EXT1__ || WIN32
+// Limit the buffer size in the `fwrite` call to give an upper bound to buffer overrun in the case
+// of non-null terminated `msg`.
+#define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), strnlen_s(msg, 4096), stderr)
+#else
+#define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), strlen(msg), stderr)
+#endif
 
 /// Copy an error state into a destination error state.
 /**

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -22,12 +22,14 @@ extern "C"
 {
 #endif
 
-#define __STDC_WANT_LIB_EXT1__ 1  // needed for `strnlen_s`
-#include <string.h>
+// Needed for `strnlen_s` from `<string.h>` for implementations that define `__STDC_LIB_EXT1__`
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "rcutils/allocator.h"
 #include "rcutils/macros.h"
@@ -43,7 +45,7 @@ typedef struct rcutils_error_state_t
   rcutils_allocator_t allocator;
 } rcutils_error_state_t;
 
-#ifdef __STDC_LIB_EXT1__ || WIN32
+#if defined(__STDC_LIB_EXT1__) || defined(_WIN32)
 // Limit the buffer size in the `fwrite` call to give an upper bound to buffer overrun in the case
 // of non-null terminated `msg`.
 #define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), strnlen_s(msg, 4096), stderr)

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -22,9 +22,6 @@ extern "C"
 {
 #endif
 
-// Needed for `strnlen_s` from `<string.h>` for implementations that define `__STDC_LIB_EXT1__`
-#define __STDC_WANT_LIB_EXT1__ 1
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -45,7 +42,8 @@ typedef struct rcutils_error_state_t
   rcutils_allocator_t allocator;
 } rcutils_error_state_t;
 
-#if defined(__STDC_LIB_EXT1__) || defined(_WIN32)
+// TODO(dhood): use __STDC_LIB_EXT1__ if/when supported in other implementations.
+#if defined(_WIN32)
 // Limit the buffer size in the `fwrite` call to give an upper bound to buffer overrun in the case
 // of non-null terminated `msg`.
 #define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), strnlen_s(msg, 4096), stderr)


### PR DESCRIPTION
fixes #78 
Otherwise it does not work correctly for dynamic buffers

CI forthcoming, at which point I'll put this into review once I'm sure it works cross-platform