### PR TITLE
Logging autoinit fixup; add RCUTILS_WARN_UNUSED to logging functions

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -403,9 +403,8 @@ void rcutils_log(
  * The messages with a severity `WARN`, `ERROR`, and `FATAL` are written to
  * `stderr`.
  * The console output format of the logged message can be configured through
- * the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable.
- * By default, the severity and name is prepended and the location
- * information is appended.
+ * the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable: see
+ * rcutils_logging_initialize_with_allocator() for details.
  *
  * <hr>
  * Attribute          | Adherence

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -20,6 +20,7 @@
 #include <stdio.h>
 
 #include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 
@@ -80,6 +81,7 @@ extern bool g_rcutils_logging_initialized;
  *   thresholds will not be configurable.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allocator);
 
 /// Initialize the logging system.
@@ -104,6 +106,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
  *   thresholds will not be configurable.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t rcutils_logging_initialize();
 
 /// Shutdown the logging system.
@@ -124,6 +127,7 @@ rcutils_ret_t rcutils_logging_initialize();
  *   severity map cannot be finalized.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t rcutils_logging_shutdown();
 
 /// The structure identifying the caller location in the source code.
@@ -184,6 +188,7 @@ extern rcutils_logging_output_handler_t g_rcutils_logging_output_handler;
  * \return The function pointer of the current output handler.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_logging_output_handler_t rcutils_logging_get_output_handler();
 
 /// Set the current output handler.
@@ -224,6 +229,7 @@ extern int g_rcutils_logging_default_severity_threshold;
  * \return The severity threshold.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 int rcutils_logging_get_default_severity_threshold();
 
 /// Set the default severity threshold for loggers.
@@ -264,6 +270,7 @@ void rcutils_logging_set_default_severity_threshold(int severity);
  * \return -1 if an error occurred
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 int rcutils_logging_get_logger_severity_threshold(const char * name);
 
 /// Get the severity threshold for a logger and its name length.
@@ -288,6 +295,7 @@ int rcutils_logging_get_logger_severity_threshold(const char * name);
  * \return -1 if an error occurred
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 int rcutils_logging_get_logger_severity_thresholdn(const char * name, size_t name_length);
 
 /// Set the severity threshold for a logger.
@@ -311,6 +319,7 @@ int rcutils_logging_get_logger_severity_thresholdn(const char * name, size_t nam
  * \return `RCUTILS_RET_ERROR` if an unspecified error occured
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t rcutils_logging_set_logger_severity_threshold(const char * name, int severity);
 
 /// Determine if a logger is enabled for a severity.
@@ -329,6 +338,7 @@ rcutils_ret_t rcutils_logging_set_logger_severity_threshold(const char * name, i
  * \return true if the logger is enabled for the severity; false otherwise.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 bool rcutils_logging_logger_is_enabled_for(const char * name, int severity);
 
 /// Determine the effective severity threshold for a logger.
@@ -357,6 +367,7 @@ bool rcutils_logging_logger_is_enabled_for(const char * name, int severity);
  * \return -1 if an error occurred.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 int rcutils_logging_get_logger_effective_severity_threshold(const char * name);
 
 /// Log a message.
@@ -449,7 +460,15 @@ void rcutils_logging_console_output_handler(
  */
 #define RCUTILS_LOGGING_AUTOINIT \
   if (RCUTILS_UNLIKELY(!g_rcutils_logging_initialized)) { \
-    rcutils_logging_initialize(); \
+    rcutils_ret_t ret = rcutils_logging_initialize(); \
+    if (ret != RCUTILS_RET_OK) { \
+      RCUTILS_SAFE_FWRITE_TO_STDERR( \
+        "[rcutils|" __FILE__ ":" RCUTILS_STRINGIFY(__LINE__) \
+        "] error initializing logging: "); \
+      RCUTILS_SAFE_FWRITE_TO_STDERR(rcutils_get_error_string_safe()); \
+      RCUTILS_SAFE_FWRITE_TO_STDERR("\n"); \
+      rcutils_reset_error(); \
+    } \
   }
 
 #if __cplusplus

--- a/src/logging.c
+++ b/src/logging.c
@@ -174,10 +174,10 @@ int rcutils_logging_get_logger_severity_threshold(const char * name)
 
 int rcutils_logging_get_logger_severity_thresholdn(const char * name, size_t name_length)
 {
+  RCUTILS_LOGGING_AUTOINIT
   if (!name) {
     return -1;
   }
-  RCUTILS_LOGGING_AUTOINIT
 
   // Skip the map lookup if the default was requested,
   // as it can still be used even if the severity map is invalid.
@@ -223,10 +223,10 @@ int rcutils_logging_get_logger_severity_thresholdn(const char * name, size_t nam
 
 int rcutils_logging_get_logger_effective_severity_threshold(const char * name)
 {
+  RCUTILS_LOGGING_AUTOINIT
   if (!name) {
     return -1;
   }
-  RCUTILS_LOGGING_AUTOINIT
   size_t substring_length = strlen(name);
   while (true) {
     int severity = rcutils_logging_get_logger_severity_thresholdn(name, substring_length);
@@ -255,12 +255,12 @@ int rcutils_logging_get_logger_effective_severity_threshold(const char * name)
 
 rcutils_ret_t rcutils_logging_set_logger_severity_threshold(const char * name, int severity)
 {
+  RCUTILS_LOGGING_AUTOINIT
   if (!name) {
     RCUTILS_SET_ERROR_MSG(
       "Invalid logger name", g_rcutils_logging_allocator);
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
-  RCUTILS_LOGGING_AUTOINIT
   if (strlen(name) == 0) {
     g_rcutils_logging_default_severity_threshold = severity;
     return RCUTILS_RET_OK;

--- a/test/test_logging_long_messages.cpp
+++ b/test/test_logging_long_messages.cpp
@@ -14,11 +14,17 @@
 
 #include <iostream>
 
+#include "rcutils/error_handling.h"
 #include "rcutils/logging.h"
+#include "rcutils/types/rcutils_ret.h"
 
 int main(int, char **)
 {
-  rcutils_logging_initialize();
+  rcutils_ret_t ret = rcutils_logging_initialize();
+  if (ret != RCUTILS_RET_OK) {
+    fprintf(stderr, "error initializing logging: %s\n", rcutils_get_error_string_safe());
+    return -1;
+  }
 
   // check all attributes for a debug log message
   rcutils_log_location_t location = {"func", "file", 42u};

--- a/test/test_logging_macros.c
+++ b/test/test_logging_macros.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "rcutils/logging_macros.h"
+#include "rcutils/types/rcutils_ret.h"
 
 size_t g_log_calls = 0;
 
@@ -52,8 +53,8 @@ int main(int argc, char ** argv)
   if (g_rcutils_logging_initialized) {
     return 1;
   }
-  rcutils_logging_initialize();
-  if (!g_rcutils_logging_initialized) {
+  rcutils_ret_t ret = rcutils_logging_initialize();
+  if (ret != RCUTILS_RET_OK || !g_rcutils_logging_initialized) {
     return 2;
   }
 
@@ -71,7 +72,7 @@ int main(int argc, char ** argv)
   if (strcmp(g_last_log_event.location->function_name, "main")) {
     return 5;
   }
-  if (g_last_log_event.location->line_number != 64u) {
+  if (g_last_log_event.location->line_number != 65u) {
     return 6;
   }
   if (g_last_log_event.severity != RCUTILS_LOG_SEVERITY_INFO) {
@@ -94,7 +95,7 @@ int main(int argc, char ** argv)
   if (strcmp(g_last_log_event.location->function_name, "main")) {
     return 12;
   }
-  if (g_last_log_event.location->line_number != 87u) {
+  if (g_last_log_event.location->line_number != 88u) {
     return 13;
   }
   if (g_last_log_event.severity != RCUTILS_LOG_SEVERITY_INFO) {
@@ -112,8 +113,8 @@ int main(int argc, char ** argv)
     free(g_last_log_event.message);
   }
 
-  rcutils_logging_shutdown();
-  if (g_rcutils_logging_initialized) {
+  ret = rcutils_logging_shutdown();
+  if (ret != RCUTILS_RET_OK || g_rcutils_logging_initialized) {
     return 17;
   }
 }


### PR DESCRIPTION
Three independent commits here, please see the individual messages.

The buildfarm is a bit congested at the moment so these CI jobs are from yesterday that included changes from this PR and an additional commit that I have since spun off into a separate PR (https://github.com/ros2/rcutils/pull/80). That additional commit was unrelated to these changes so I'm confident that even without it CI would have come back green for just this PR.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3671)](http://ci.ros2.org/job/ci_linux/3671/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=844)](http://ci.ros2.org/job/ci_linux-aarch64/844/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3005)](http://ci.ros2.org/job/ci_osx/3005/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3768)](http://ci.ros2.org/job/ci_windows/3768/)