### PR TITLE
out-of-bounds read issue

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -274,7 +274,7 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level)
   // Convert the severity value into a string for storage.
   // TODO(dhood): replace string map with int map.
   if (level < 0 ||
-    level >
+    level >=
     (int)(sizeof(g_rcutils_log_severity_names) / sizeof(g_rcutils_log_severity_names[0])))
   {
     RCUTILS_SET_ERROR_MSG(

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -164,6 +164,9 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
     rcutils_logging_set_logger_level("rcutils_test_loggers", -1));
   ASSERT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
+    rcutils_logging_set_logger_level("rcutils_test_loggers", 51));
+  ASSERT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
     rcutils_logging_set_logger_level("rcutils_test_loggers", 1000));
 }
 


### PR DESCRIPTION
`g_rcutils_log_severity_names` of 51 8-byte elements at element index 51 (byte offset 408) is out of bound using index level (which evaluates to 51).
Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>