### PR TITLE
Change functions to accept const ptrs to allocators

### DIFF
--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -39,6 +39,8 @@ extern "C"
  * until all uses of the allocator have been made.
  * Particular care should be taken when giving an allocator to functions like
  * rcutils_*_init() where it is stored within another object and used later.
+ * Developers should note that, while the fields of a const-qualified allocator
+ * struct cannot be modified, the state of the allocator can be modified.
  */
 typedef struct rcutils_allocator_t
 {
@@ -64,7 +66,11 @@ typedef struct rcutils_allocator_t
   /** An error should be indicated by returning `NULL`. */
   void * (*zero_allocate)(size_t number_of_elements, size_t size_of_element, void * state);
   /// Implementation defined state storage.
-  /** This is passed as the final parameter to other allocator functions. */
+  /**
+   * This is passed as the final parameter to other allocator functions.
+   * Note that the contents of the state can be modified even in const-qualified
+   * allocator objects.
+   */
   void * state;
 } rcutils_allocator_t;
 

--- a/include/rcutils/repl_str.h
+++ b/include/rcutils/repl_str.h
@@ -129,7 +129,7 @@ rcutils_repl_str(
   const char * str,
   const char * from,
   const char * to,
-  rcutils_allocator_t * allocator);
+  const rcutils_allocator_t * allocator);
 
 // Implementation copied from above mentioned source continues in repl_str.c.
 

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -90,7 +90,7 @@ rcutils_ret_t
 rcutils_string_array_init(
   rcutils_string_array_t * string_array,
   size_t size,
-  rcutils_allocator_t * allocator);
+  const rcutils_allocator_t * allocator);
 
 /// Finalize a string array, reclaiming all resources.
 /**

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -47,7 +47,7 @@ rcutils_repl_str(
   const char * str,
   const char * from,
   const char * to,
-  rcutils_allocator_t * allocator)
+  const rcutils_allocator_t * allocator)
 {
   /* Adjust each of the below values to suit your needs. */
 

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -39,7 +39,7 @@ rcutils_ret_t
 rcutils_string_array_init(
   rcutils_string_array_t * string_array,
   size_t size,
-  rcutils_allocator_t * allocator)
+  const rcutils_allocator_t * allocator)
 {
   if (!allocator) {
     RCUTILS_SET_ERROR_MSG("allocator is null", rcutils_get_default_allocator())


### PR DESCRIPTION
In https://github.com/ros2/rcl/pull/212, I wanted to pass a `const rcl_allocator_t *` to `repl_str`, but got warnings that the parameter wasn't const.

@dirk-thomas and I spoke about that and were concerned that the functions that currently take const ptrs actually should not, because the state of the allocator can change when the allocator's used. We theorised that a warning about modifying a const variable (when `allocate` is called in a function that takes `const rcutils_allocator_t *`) wasn't being generated because of the [type erasure in the signature](https://github.com/ros2/rcutils/blob/00e2b9db9f4b71374f1388570be2de3edabd2e37/include/rcutils/allocator.h#L47).

@wjwwood pointed out that the state is actually stored as a pointer, so it's fair to use const since these functions never reassign the pointer. That's also why it's fair to pass an allocator by value in other places: it will still impact the state of the original allocator (another thing @dirk-thomas and I were concerned about).

Therefore this PR just changes the remaining functions to take a `const rcutils_allocator_t *` since they don't modify the struct, so that it can be called from places like `rcl_node_init` which is [using a const pointer](https://github.com/ros2/rcl/blob/34a4a728ab861ab25f58550fe4c7d79d95b76021/rcl/src/rcl/node.c#L106).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3941)](http://ci.ros2.org/job/ci_linux/3941/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1059)](http://ci.ros2.org/job/ci_linux-aarch64/1059/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3271)](http://ci.ros2.org/job/ci_osx/3271/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4040)](http://ci.ros2.org/job/ci_windows/4040/)