### PR TITLE
Add definition of separator used for logger names

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -29,6 +29,9 @@ extern "C"
 {
 #endif
 
+#define RCUTILS_LOGGING_SEPARATOR_CHAR '.'
+#define RCUTILS_LOGGING_SEPARATOR_STRING "."
+
 /// The flag if the logging system has been initialized.
 RCUTILS_PUBLIC
 extern bool g_rcutils_logging_initialized;

--- a/src/logging.c
+++ b/src/logging.c
@@ -240,7 +240,8 @@ int rcutils_logging_get_logger_effective_level(const char * name)
       return severity;
     }
     // Determine the next ancestor's FQN by removing the child's name.
-    size_t index_last_separator = rcutils_find_lastn(name, '.', substring_length);
+    size_t index_last_separator = rcutils_find_lastn(
+      name, RCUTILS_LOGGING_SEPARATOR_CHAR, substring_length);
     if (SIZE_MAX == index_last_separator) {
       // There are no more separators in the substring.
       // The name we just checked was the last that we needed to, and it was unset.


### PR DESCRIPTION
rcutils logging has logger names as "a.b.c". this breaks out the dot separator so it doesn't have to be hard-coded here and elsewhere. For example, in rcl, we are [using the separator](https://github.com/ros2/rcl/pull/212/commits/05923fa15862fbc5f43de33505b89374725f6773#diff-b1ed1b132e1e72fee905fe7bc3b4c62bR87) when changing `/namespace/node` to logger name `namespace.node`.

Since some callers might want a char literal (e.g [here](https://github.com/ros2/rcutils/compare/master...node_logger_name#diff-f909d0b1a298531f76132943dc55f86aR244)) and some might want a string literal so it's null terminated (e.g. [here](https://github.com/ros2/rcl/pull/212/commits/4ff4d2119f2f830b4a0c31de7003cf4dcbc9930b#diff-b1ed1b132e1e72fee905fe7bc3b4c62bR87)), I've provided definitions for both. This seems like a bit of an unusual thing to do though, so I'm open to alternatives :smile: 