### PR TITLE
include format_string.h in error_handling.h

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -29,6 +29,7 @@ extern "C"
 #include <string.h>
 
 #include "rcutils/allocator.h"
+#include "rcutils/format_string.h"
 #include "rcutils/macros.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"


### PR DESCRIPTION
`RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING` uses `rcutils_format_string` but does not include `rcutils/format_string.h`. This PR adds the missing include.

CI `--end-with rcutils` because I doubt adding an include will break downstream tests.
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4072)](http://ci.ros2.org/job/ci_linux/4072/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1175)](http://ci.ros2.org/job/ci_linux-aarch64/1175/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3378)](http://ci.ros2.org/job/ci_osx/3378/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4143)](http://ci.ros2.org/job/ci_windows/4143/)
    * False positive CMake warning ros2/build_cop#79

