### PR TITLE
make log location parameter const

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -167,7 +167,7 @@ extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1]
  * \param args The variable argument list
  */
 typedef void (* rcutils_logging_output_handler_t)(
-  rcutils_log_location_t *,  // location
+  const rcutils_log_location_t *,  // location
   int,  // severity
   const char *,  // name
   const char *,  // format
@@ -393,7 +393,7 @@ int rcutils_logging_get_logger_effective_level(const char * name);
  */
 RCUTILS_PUBLIC
 void rcutils_log(
-  rcutils_log_location_t * location,
+  const rcutils_log_location_t * location,
   int severity,
   const char * name,
   const char * format,
@@ -425,7 +425,7 @@ void rcutils_log(
  */
 RCUTILS_PUBLIC
 void rcutils_logging_console_output_handler(
-  rcutils_log_location_t * location,
+  const rcutils_log_location_t * location,
   int severity, const char * name, const char * format, va_list * args);
 
 // Provide the compiler with branch prediction information

--- a/src/logging.c
+++ b/src/logging.c
@@ -317,7 +317,7 @@ bool rcutils_logging_logger_is_enabled_for(const char * name, int severity)
 }
 
 void rcutils_log(
-  rcutils_log_location_t * location,
+  const rcutils_log_location_t * location,
   int severity, const char * name, const char * format, ...)
 {
   if (!rcutils_logging_logger_is_enabled_for(name, severity)) {
@@ -379,7 +379,7 @@ void rcutils_log(
   }
 
 void rcutils_logging_console_output_handler(
-  rcutils_log_location_t * location,
+  const rcutils_log_location_t * location,
   int severity, const char * name, const char * format, va_list * args)
 {
   if (!g_rcutils_logging_initialized) {

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -40,7 +40,7 @@ size_t g_log_calls = 0;
 
 struct LogEvent
 {
-  rcutils_log_location_t * location;
+  const rcutils_log_location_t * location;
   int level;
   std::string name;
   std::string message;
@@ -55,7 +55,7 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_rcutils_logging_default_logger_level);
 
   auto rcutils_logging_console_output_handler = [](
-    rcutils_log_location_t * location,
+    const rcutils_log_location_t * location,
     int level, const char * name, const char * format, va_list * args) -> void
     {
       g_log_calls += 1;

--- a/test/test_logging_macros.c
+++ b/test/test_logging_macros.c
@@ -21,7 +21,7 @@ size_t g_log_calls = 0;
 
 struct LogEvent
 {
-  rcutils_log_location_t * location;
+  const rcutils_log_location_t * location;
   int severity;
   const char * name;
   char * message;
@@ -29,7 +29,7 @@ struct LogEvent
 struct LogEvent g_last_log_event;
 
 void custom_handler(
-  rcutils_log_location_t * location,
+  const rcutils_log_location_t * location,
   int severity, const char * name, const char * format, va_list * args)
 {
   g_log_calls += 1;

--- a/test/test_logging_macros.cpp
+++ b/test/test_logging_macros.cpp
@@ -28,7 +28,7 @@ size_t g_log_calls = 0;
 
 struct LogEvent
 {
-  rcutils_log_location_t * location;
+  const rcutils_log_location_t * location;
   int level;
   std::string name;
   std::string message;
@@ -49,7 +49,7 @@ public:
     EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_rcutils_logging_default_logger_level);
 
     auto rcutils_logging_console_output_handler = [](
-      rcutils_log_location_t * location,
+      const rcutils_log_location_t * location,
       int level, const char * name, const char * format, va_list * args) -> void
       {
         g_log_calls += 1;


### PR DESCRIPTION
It doesn't appear to need to be mutable, and it can be copied by the output handler if needed.