### PR TITLE
Prevent default logger's level from being unset

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -32,6 +32,12 @@ extern "C"
 #define RCUTILS_LOGGING_SEPARATOR_CHAR '.'
 #define RCUTILS_LOGGING_SEPARATOR_STRING "."
 
+/**
+ * \def RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL
+ * \brief The default severity level of the default logger.
+ */
+#define RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL RCUTILS_LOG_SEVERITY_INFO
+
 /// The flag if the logging system has been initialized.
 RCUTILS_PUBLIC
 extern bool g_rcutils_logging_initialized;
@@ -237,6 +243,10 @@ int rcutils_logging_get_default_logger_level();
 
 /// Set the default severity level for loggers.
 /**
+ * If the severity level requested is `RCUTILS_LOG_SEVERITY_UNSET`, the default
+ * value for the default logger (`RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL`)
+ * will be restored instead.
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/src/logging.c
+++ b/src/logging.c
@@ -95,7 +95,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     g_rcutils_logging_allocator = allocator;
 
     g_rcutils_logging_output_handler = &rcutils_logging_console_output_handler;
-    g_rcutils_logging_default_logger_level = RCUTILS_LOG_SEVERITY_INFO;
+    g_rcutils_logging_default_logger_level = RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL;
 
     // Check for the environment variable for custom output formatting
     const char * output_format;
@@ -184,6 +184,10 @@ void rcutils_logging_set_default_logger_level(int level)
 {
   // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   RCUTILS_LOGGING_AUTOINIT
+  if (RCUTILS_LOG_SEVERITY_UNSET == level) {
+    // Restore the default
+    level = RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL;
+  }
   g_rcutils_logging_default_logger_level = level;
   // *INDENT-ON*
 }

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -89,10 +89,14 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
 
   // check default level
   int original_level = rcutils_logging_get_default_logger_level();
-  rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);
-  EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, rcutils_logging_get_default_logger_level());
-  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_DEBUG, "name2", "message %d", 22);
+  rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_ERROR);
+  EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, rcutils_logging_get_default_logger_level());
+  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_INFO, "name2", "message %d", 22);
   EXPECT_EQ(1u, g_log_calls);
+  // It shouldn't be possible to set the default logger's level to UNSET.
+  // Setting unset to the default logger should result in the default being restored.
+  rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_UNSET);
+  EXPECT_EQ(RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL, rcutils_logging_get_default_logger_level());
 
   // check other severity levels
   rcutils_log(NULL, RCUTILS_LOG_SEVERITY_INFO, "name3", "message %d", 33);


### PR DESCRIPTION
Otherwise getting the _effective_ level of a logger can return unset, where it should always return one of info, warn, etc (falling back to the default if a logger's level hasn't been explicitly set).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4564)](http://ci.ros2.org/job/ci_linux/4564/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1474)](http://ci.ros2.org/job/ci_linux-aarch64/1474/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3751)](http://ci.ros2.org/job/ci_osx/3751/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4649)](http://ci.ros2.org/job/ci_windows/4649/)