### PR TITLE
Parse log level from string

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -160,8 +160,9 @@ extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1]
 
 /// Get a severity value from its string representation (e.g. DEBUG).
 /**
- * String representation is capitalized, e.g. UNSET, DEBUG, INFO, WARN, ERROR,
- * FATAL.
+ * String representation must match one of the values in
+ * `g_rcutils_log_severity_names`, but is not case-sensitive.
+ * Examples: UNSET, DEBUG, INFO, WARN, Error, fatal.
  *
  * \param[in] severity_string String representation of the severity, must be a
  *   null terminated c string

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -175,6 +175,8 @@ extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1]
  *   string, or
  * \return `RCUTILS_RET_ERROR` if an unspecified error occured
  */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_logging_severity_level_from_string(
   const char * severity_string, rcutils_allocator_t allocator, int * severity);

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -165,6 +165,7 @@ extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1]
  *
  * \param[in] severity_string String representation of the severity, must be a
  *   null terminated c string
+ * \param[in] allocator rcutils_allocator_t to be used
  * \param[in,out] severity The severity level as a represented by the
  *   `RCUTILS_LOG_SEVERITY` enum
  * \return `RCUTILS_RET_OK` if successful, or
@@ -174,7 +175,8 @@ extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1]
  * \return `RCUTILS_RET_ERROR` if an unspecified error occured
  */
 rcutils_ret_t
-rcutils_logging_severity_level_from_string(const char * severity_string, int * severity);
+rcutils_logging_severity_level_from_string(
+  const char * severity_string, rcutils_allocator_t allocator, int * severity);
 
 /// The function signature to log messages.
 /**

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -158,6 +158,24 @@ enum RCUTILS_LOG_SEVERITY
 /// The names of severity levels.
 extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1];
 
+/// Get a severity value from its string representation (e.g. DEBUG).
+/**
+ * String representation is capitalized, e.g. UNSET, DEBUG, INFO, WARN, ERROR,
+ * FATAL.
+ *
+ * \param[in] severity_string String representation of the severity, must be a
+ *   null terminated c string
+ * \param[in,out] severity The severity level as a represented by the
+ *   `RCUTILS_LOG_SEVERITY` enum
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` on invalid arguments, or
+ * \return `RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID` if unable to match
+ *   string, or
+ * \return `RCUTILS_RET_ERROR` if an unspecified error occured
+ */
+rcutils_ret_t
+rcutils_logging_severity_level_from_string(const char * severity_string, int * severity);
+
 /// The function signature to log messages.
 /**
  * \param location The pointer to the location struct

--- a/include/rcutils/types/rcutils_ret.h
+++ b/include/rcutils/types/rcutils_ret.h
@@ -41,6 +41,8 @@ typedef int rcutils_ret_t;
 
 /// Internal severity map for logger thresholds is invalid.
 #define RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID 40
+/// String representation of a severity is invalid.
+#define RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID 41
 
 #ifdef __cplusplus
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -161,8 +161,14 @@ rcutils_ret_t rcutils_logging_shutdown(void)
 }
 
 rcutils_ret_t
-rcutils_logging_severity_level_from_string(const char * severity_string, int * severity)
+rcutils_logging_severity_level_from_string(
+  const char * severity_string, rcutils_allocator_t allocator, int * severity)
 {
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "invalid allocator", return RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(severity_string, RCUTILS_RET_INVALID_ARGUMENT, allocator);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(severity, RCUTILS_RET_INVALID_ARGUMENT, allocator);
+
   rcutils_ret_t ret = RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID;
   // Determine the severity value matching the severity name.
   for (size_t i = 0;
@@ -241,7 +247,9 @@ int rcutils_logging_get_logger_leveln(const char * name, size_t name_length)
   }
 
   int severity;
-  if (RCUTILS_RET_OK != rcutils_logging_severity_level_from_string(severity_string, &severity)) {
+  rcutils_ret_t ret = rcutils_logging_severity_level_from_string(
+    severity_string, g_rcutils_logging_allocator, &severity);
+  if (RCUTILS_RET_OK != ret) {
     fprintf(
       stderr,
       "Logger has an invalid severity level: %s\n", severity_string);

--- a/src/logging.c
+++ b/src/logging.c
@@ -160,6 +160,25 @@ rcutils_ret_t rcutils_logging_shutdown(void)
   return ret;
 }
 
+rcutils_ret_t
+rcutils_logging_severity_level_from_string(const char * severity_string, int * severity)
+{
+  rcutils_ret_t ret = RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID;
+  // Determine the severity value matching the severity name.
+  for (size_t i = 0;
+    i < sizeof(g_rcutils_log_severity_names) / sizeof(g_rcutils_log_severity_names[0]);
+    ++i)
+  {
+    const char * severity_string_i = g_rcutils_log_severity_names[i];
+    if (severity_string_i && strcmp(severity_string_i, severity_string) == 0) {
+      *severity = (enum RCUTILS_LOG_SEVERITY)i;
+      ret = RCUTILS_RET_OK;
+      break;
+    }
+  }
+  return ret;
+}
+
 rcutils_logging_output_handler_t rcutils_logging_get_output_handler(void)
 {
   RCUTILS_LOGGING_AUTOINIT
@@ -221,20 +240,8 @@ int rcutils_logging_get_logger_leveln(const char * name, size_t name_length)
     return RCUTILS_LOG_SEVERITY_UNSET;
   }
 
-  // Determine the severity value matching the severity name.
-  int severity = -1;
-  for (size_t i = 0;
-    i < sizeof(g_rcutils_log_severity_names) / sizeof(g_rcutils_log_severity_names[0]);
-    ++i)
-  {
-    const char * severity_string_i = g_rcutils_log_severity_names[i];
-    if (severity_string_i && strcmp(severity_string_i, severity_string) == 0) {
-      severity = (enum RCUTILS_LOG_SEVERITY)i;
-      break;
-    }
-  }
-
-  if (severity < 0) {
+  int severity;
+  if (RCUTILS_RET_OK != rcutils_logging_severity_level_from_string(severity_string, &severity)) {
     fprintf(
       stderr,
       "Logger has an invalid severity level: %s\n", severity_string);

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -121,22 +121,29 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
 }
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
   int severity;
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("UNSET", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("UNSET", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_UNSET, severity);
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("DEBUG", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("DEBUG", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, severity);
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("INFO", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("INFO", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_INFO, severity);
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("WARN", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("WARN", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_WARN, severity);
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("ERROR", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("ERROR", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_ERROR, severity);
-  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("FATAL", &severity));
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("FATAL", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_FATAL, severity);
   ASSERT_EQ(
     RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID,
-    rcutils_logging_severity_level_from_string("unknown", &severity));
+    rcutils_logging_severity_level_from_string("unknown", allocator, &severity));
 }
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -123,6 +123,7 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   int severity;
+  // check supported severities
   ASSERT_EQ(
     RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("UNSET", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_UNSET, severity);
@@ -141,6 +142,14 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
   ASSERT_EQ(
     RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("FATAL", allocator, &severity));
   ASSERT_EQ(RCUTILS_LOG_SEVERITY_FATAL, severity);
+  // check case-insensitive severities
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("info", allocator, &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_INFO, severity);
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("Info", allocator, &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_INFO, severity);
+  // check unknown severity
   ASSERT_EQ(
     RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID,
     rcutils_logging_severity_level_from_string("unknown", allocator, &severity));

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -120,6 +120,25 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
 }
 
+TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
+  int severity;
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("UNSET", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_UNSET, severity);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("DEBUG", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, severity);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("INFO", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_INFO, severity);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("WARN", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_WARN, severity);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("ERROR", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_ERROR, severity);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_severity_level_from_string("FATAL", &severity));
+  ASSERT_EQ(RCUTILS_LOG_SEVERITY_FATAL, severity);
+  ASSERT_EQ(
+    RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID,
+    rcutils_logging_severity_level_from_string("unknown", &severity));
+}
+
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);


### PR DESCRIPTION
connects to ros2/ros2#498

In addition to the enum of severity levels, [we have `g_rcutils_log_severity_names`](https://github.com/ros2/rcutils/compare/cli_logger_level?expand=1#diff-f909d0b1a298531f76132943dc55f86aR36), which includes the string representation of the enums. That is used for printing the severity of messages to the console (and internally for storing the logger levels in a string map instead of a string-to-int map).

This PR adds a function that lets callers use that array to convert a string severity to an int severity.

It's used in https://github.com/ros2/rcl/pull/256 and https://github.com/ros2/demos/pull/240