### PR TITLE
Remove redundant stat() call.

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -90,10 +90,9 @@ bool
 rcutils_is_readable(const char * abs_path)
 {
   struct stat buf;
-  if (!rcutils_exists(abs_path)) {
+  if (stat(abs_path, &buf) < 0) {
     return false;
   }
-  stat(abs_path, &buf);
 #ifdef _WIN32
   if (!(buf.st_mode & _S_IREAD)) {
 #else
@@ -108,10 +107,9 @@ bool
 rcutils_is_writable(const char * abs_path)
 {
   struct stat buf;
-  if (!rcutils_exists(abs_path)) {
+  if (stat(abs_path, &buf) < 0) {
     return false;
   }
-  stat(abs_path, &buf);
 #ifdef _WIN32
   if (!(buf.st_mode & _S_IWRITE)) {
 #else
@@ -126,10 +124,9 @@ bool
 rcutils_is_readable_and_writable(const char * abs_path)
 {
   struct stat buf;
-  if (!rcutils_exists(abs_path)) {
+  if (stat(abs_path, &buf) < 0) {
     return false;
   }
-  stat(abs_path, &buf);
 #ifdef _WIN32
   // NOTE(marguedas) on windows all writable files are readable
   // hence the following check is equivalent to "& _S_IWRITE"


### PR DESCRIPTION
rcutils_exists() calls stat() then stat() is called again without checking its return value.

The unchecked return value was discovered via static analysis of rcutils.