### PR TITLE
Compile flag fixes

### DIFF
--- a/src/cmdline_parser.c
+++ b/src/cmdline_parser.c
@@ -30,7 +30,7 @@ bool rcutils_cli_option_exist(char ** begin, char ** end, const char * option)
 char * rcutils_cli_get_option(char ** begin, char ** end, const char * option)
 {
   size_t idx = 0;
-  size_t end_idx = end - begin;
+  size_t end_idx = (size_t)(end - begin);
   for (; idx < end_idx; ++idx) {
     if (strncmp(begin[idx], option, strlen(option)) == 0) {
       break;

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -195,7 +195,7 @@ format_error_string(void)
   if (!__rcutils_error_is_set(__rcutils_error_state)) {
     return;
   }
-  size_t bytes_it_would_have_written = snprintf(
+  size_t bytes_it_would_have_written = (size_t)snprintf(
     NULL, 0,
     __error_format_string,
     __rcutils_error_state->message,

--- a/src/format_string.c
+++ b/src/format_string.c
@@ -45,7 +45,7 @@ rcutils_format_string_limit(
   va_list args2;
   va_copy(args2, args1);
   // first calculate the output string
-  size_t bytes_to_be_written = rcutils_vsnprintf(NULL, 0, format_string, args1);
+  size_t bytes_to_be_written = (size_t)rcutils_vsnprintf(NULL, 0, format_string, args1);
   va_end(args1);
   // allocate space for the return string
   if (bytes_to_be_written + 1 > limit) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -183,7 +183,7 @@ rcutils_logging_severity_level_from_string(
     return RCUTILS_RET_BAD_ALLOC;
   }
   for (int i = 0; severity_string_upper[i]; ++i) {
-    severity_string_upper[i] = toupper(severity_string_upper[i]);
+    severity_string_upper[i] = (char)toupper(severity_string_upper[i]);
   }
 
   // Determine the severity value matching the severity name.
@@ -514,7 +514,7 @@ void rcutils_logging_console_output_handler(
   }
   if ((size_t)written >= sizeof(static_message_buffer)) {
     // write was incomplete, allocate necessary memory dynamically
-    size_t message_buffer_size = written + 1;
+    size_t message_buffer_size = (size_t)written + 1U;
     void * dynamic_message_buffer = g_rcutils_logging_allocator.allocate(
       message_buffer_size, g_rcutils_logging_allocator.state);
     if (NULL == dynamic_message_buffer) {

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -90,11 +90,11 @@ rcutils_repl_str(
       }
     }
 
-    pos_cache[count-1] = pstr2 - str;
+    pos_cache[count-1] = (uintptr_t)(pstr2 - str);
     pstr = pstr2 + fromlen;
   }
 
-  orglen = pstr - str + strlen(pstr);
+  orglen = (size_t)(pstr - str) + strlen(pstr);
 
   /* Allocate memory for the post-replacement string. */
   if (count > 0) {

--- a/src/time.c
+++ b/src/time.c
@@ -63,7 +63,7 @@ rcutils_time_point_value_as_seconds_string(
   }
   // best to abs it to avoid issues with negative values in C89, see:
   //   https://stackoverflow.com/a/3604984/671658
-  uint64_t abs_time_point = llabs(*time_point);
+  uint64_t abs_time_point = (uint64_t)llabs(*time_point);
   // break into two parts to avoid floating point error
   uint64_t seconds = abs_time_point / (1000 * 1000 * 1000);
   uint64_t nanoseconds = abs_time_point % (1000 * 1000 * 1000);


### PR DESCRIPTION
## Description
- Courtesy of @serge-nikulin 
- This PR fixes warning generated when building with:

```
-Wall
-Wextra
-pedantic
-Wcast-align
-Wunused
-Wconversion
-Wsign-conversion
-Wdouble-promotion
-fvisibility=hidden
```

- Related to ros2/rclcpp#530 and ros2/rcl#276