### PR TITLE
Add LL suffix to avoid c4307

### DIFF
--- a/include/rcutils/time.h
+++ b/include/rcutils/time.h
@@ -27,18 +27,18 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// Convenience macro to convert seconds to nanoseconds.
-#define RCUTILS_S_TO_NS(seconds) (seconds * (1000 * 1000 * 1000))
+#define RCUTILS_S_TO_NS(seconds) (seconds * (1000LL * 1000LL * 1000LL))
 /// Convenience macro to convert milliseconds to nanoseconds.
-#define RCUTILS_MS_TO_NS(milliseconds) (milliseconds * (1000 * 1000))
+#define RCUTILS_MS_TO_NS(milliseconds) (milliseconds * (1000LL * 1000LL))
 /// Convenience macro to convert microseconds to nanoseconds.
-#define RCUTILS_US_TO_NS(microseconds) (microseconds * 1000)
+#define RCUTILS_US_TO_NS(microseconds) (microseconds * 1000LL)
 
 /// Convenience macro to convert nanoseconds to seconds.
-#define RCUTILS_NS_TO_S(nanoseconds) (nanoseconds / (1000 * 1000 * 1000))
+#define RCUTILS_NS_TO_S(nanoseconds) (nanoseconds / (1000LL * 1000LL * 1000LL))
 /// Convenience macro to convert nanoseconds to milliseconds.
-#define RCUTILS_NS_TO_MS(nanoseconds) (nanoseconds / (1000 * 1000))
+#define RCUTILS_NS_TO_MS(nanoseconds) (nanoseconds / (1000LL * 1000LL))
 /// Convenience macro to convert nanoseconds to microseconds.
-#define RCUTILS_NS_TO_US(nanoseconds) (nanoseconds / 1000)
+#define RCUTILS_NS_TO_US(nanoseconds) (nanoseconds / 1000LL)
 
 /// A single point in time, measured in nanoseconds since the Unix epoch.
 typedef int64_t rcutils_time_point_value_t;


### PR DESCRIPTION
MSVC will warn with code C4307 and calculate an unintended value if the result of `RCUTILS_S_TO_NS` is greater than 32bits. As far as I can tell this is because `1000` is small enough to fit in an `int` so that becomes its type according to https://en.cppreference.com/w/cpp/language/integer_literal . MSVC says the size of `int` is 4 bytes even on 64bit platforms https://msdn.microsoft.com/en-us/library/s3f49ktz.aspx. In the `RCUTILS_S_TO_NS` case this means that `seconds * 1000 * 1000 * 1000` is done using 32bit math and will overflow when seconds is greater than 2.