### PR TITLE
fix warning in release build due to assert

### DIFF
--- a/src/error_handling_helpers.h
+++ b/src/error_handling_helpers.h
@@ -110,6 +110,7 @@ __rcutils_convert_uint64_t_into_c_str(uint64_t number, char * buffer, size_t buf
 {
   assert(buffer != NULL);
   assert(buffer_size >= 21);
+  (void)buffer_size;  // prevent warning in release builds where there is no assert(...)
   size_t i = 0;
 
   // if number is 0, short circuit


### PR DESCRIPTION
This is needed to fix:

https://ci.ros2.org/view/nightly/job/nightly_linux_release/985/warnings23Result/package.-1451458490/

Fixes #123

Linux Release build CI:

- Before [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5461)](https://ci.ros2.org/job/ci_linux/5461/)
- After [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5460)](https://ci.ros2.org/job/ci_linux/5460/)