### PR TITLE
reiterate over char array

### DIFF
--- a/include/rcutils/types/char_array.h
+++ b/include/rcutils/types/char_array.h
@@ -52,6 +52,8 @@ rcutils_get_zero_initialized_char_array(void);
  * \param buffer_capacity the size of the memory to allocate for the byte stream
  * \param allocator the allocator to use for the memory allocation
  * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENTS` if any arguments are invalid, or
+ * \return 'RCUTILS_RET_BAD_ALLOC` if no memory could be allocated correctly
  * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
  */
 RCUTILS_PUBLIC
@@ -65,13 +67,14 @@ rcutils_char_array_init(
 /// Finalize a char array struct.
 /**
  * Cleans up and deallocates any resources used in a rcutils_char_array_t.
- * Passing a rcutils_char_array_t which has not been zero initialized using
- * rcutils_get_zero_initialized_char_array() to this function is undefined
+ * The array passed to this function needs to have been initialized by
+ * rcutils_char_array_init().
+ * Passing an uninitialized instance to this function leads to undefined
  * behavior.
  *
  * \param char_array pointer to the rcutils_char_array_t to be cleaned up
  * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENTS` if the char_array argument is invalid
  * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
  */
 RCUTILS_PUBLIC
@@ -86,12 +89,11 @@ rcutils_char_array_fini(rcutils_char_array_t * char_array);
  * truncated.
  * Be aware, that this will deallocate the memory and therefore invalidates any
  * pointers to this storage.
- * If the new size is larger, new memory is getting allocated and the existing
- * content is copied over.
  *
  * \param char_array pointer to the instance of rcutils_char_array_t which is being resized
  * \param new_size the new size of the internal buffer
  * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` if new_size is set to zero
  * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
  * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
  */

--- a/src/char_array.c
+++ b/src/char_array.c
@@ -75,7 +75,7 @@ rcutils_char_array_resize(rcutils_char_array_t * char_array, size_t new_size)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(char_array, RCUTILS_RET_INVALID_ARGUMENT);
 
-  if (new_size == 0lu) {
+  if (0lu == new_size) {
     RCUTILS_SET_ERROR_MSG("new size of char_array has to be greater than zero");
     return RCUTILS_RET_INVALID_ARGUMENT;
   }

--- a/src/char_array.c
+++ b/src/char_array.c
@@ -33,26 +33,21 @@ rcutils_char_array_init(
   size_t buffer_capacity,
   const rcutils_allocator_t * allocator)
 {
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    char_array,
-    "char array pointer is null",
-    return RCUTILS_RET_ERROR);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(char_array, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR(allocator, return RCUTILS_RET_INVALID_ARGUMENT);
 
-  if (!rcutils_allocator_is_valid(allocator)) {
-    RCUTILS_SET_ERROR_MSG("char array has no valid allocator");
-    return RCUTILS_RET_ERROR;
-  }
-
-  char_array->buffer_length = 0;
+  char_array->buffer_length = 0lu;
   char_array->buffer_capacity = buffer_capacity;
   char_array->allocator = *allocator;
 
-  if (buffer_capacity > 0u) {
+  if (buffer_capacity > 0lu) {
     char_array->buffer =
       (char *)allocator->allocate(buffer_capacity * sizeof(char), allocator->state);
     RCUTILS_CHECK_FOR_NULL_WITH_MSG(
       char_array->buffer,
       "failed to allocate memory for char array",
+      char_array->buffer_capacity = 0lu;
+      char_array->buffer_length = 0lu;
       return RCUTILS_RET_BAD_ALLOC);
   }
 
@@ -62,21 +57,15 @@ rcutils_char_array_init(
 rcutils_ret_t
 rcutils_char_array_fini(rcutils_char_array_t * char_array)
 {
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    char_array,
-    "char array pointer is null",
-    return RCUTILS_RET_ERROR);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(char_array, RCUTILS_RET_INVALID_ARGUMENT);
 
   rcutils_allocator_t * allocator = &char_array->allocator;
-  if (!rcutils_allocator_is_valid(allocator)) {
-    RCUTILS_SET_ERROR_MSG("char array has no valid allocator");
-    return RCUTILS_RET_ERROR;
-  }
+  RCUTILS_CHECK_ALLOCATOR(allocator, return RCUTILS_RET_INVALID_ARGUMENT);
 
   allocator->deallocate(char_array->buffer, allocator->state);
   char_array->buffer = NULL;
-  char_array->buffer_length = 0u;
-  char_array->buffer_capacity = 0u;
+  char_array->buffer_length = 0lu;
+  char_array->buffer_capacity = 0lu;
 
   return RCUTILS_RET_OK;
 }
@@ -84,16 +73,15 @@ rcutils_char_array_fini(rcutils_char_array_t * char_array)
 rcutils_ret_t
 rcutils_char_array_resize(rcutils_char_array_t * char_array, size_t new_size)
 {
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    char_array,
-    "char array pointer is null",
-    return RCUTILS_RET_ERROR);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(char_array, RCUTILS_RET_INVALID_ARGUMENT);
+
+  if (new_size == 0lu) {
+    RCUTILS_SET_ERROR_MSG("new size of char_array has to be greater than zero");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
 
   rcutils_allocator_t * allocator = &char_array->allocator;
-  if (!rcutils_allocator_is_valid(allocator)) {
-    RCUTILS_SET_ERROR_MSG("char array has no valid allocator");
-    return RCUTILS_RET_ERROR;
-  }
+  RCUTILS_CHECK_ALLOCATOR(allocator, return RCUTILS_RET_INVALID_ARGUMENT);
 
   if (new_size == char_array->buffer_capacity) {
     // nothing to do here
@@ -104,6 +92,8 @@ rcutils_char_array_resize(rcutils_char_array_t * char_array, size_t new_size)
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     char_array->buffer,
     "failed to reallocate memory for char array",
+    char_array->buffer_capacity = 0lu;
+    char_array->buffer_length = 0lu;
     return RCUTILS_RET_BAD_ALLOC);
 
   char_array->buffer_capacity = new_size;

--- a/src/uint8_array.c
+++ b/src/uint8_array.c
@@ -75,7 +75,7 @@ rcutils_uint8_array_resize(rcutils_uint8_array_t * uint8_array, size_t new_size)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(uint8_array, RCUTILS_RET_INVALID_ARGUMENT);
 
-  if (new_size == 0lu) {
+  if (0lu == new_size) {
     RCUTILS_SET_ERROR_MSG("new size of uint8_array has to be greater than zero");
     return RCUTILS_RET_INVALID_ARGUMENT;
   }

--- a/test/test_char_array.cpp
+++ b/test/test_char_array.cpp
@@ -23,9 +23,9 @@ TEST(test_char_array, default_initialization) {
 
   auto allocator = rcutils_get_default_allocator();
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_init(&char_array, 0, &allocator));
-  EXPECT_EQ(0u, char_array.buffer_capacity);
+  EXPECT_EQ(0lu, char_array.buffer_capacity);
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_fini(&char_array));
-  EXPECT_EQ(0u, char_array.buffer_capacity);
+  EXPECT_EQ(0lu, char_array.buffer_capacity);
   EXPECT_FALSE(char_array.buffer);
 }
 
@@ -39,10 +39,15 @@ TEST(test_char_array, resize) {
   char_array.buffer_length = 5;
   EXPECT_STREQ("1234\0", char_array.buffer);
 
+  ret = rcutils_char_array_resize(&char_array, 0);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+  EXPECT_EQ(5lu, char_array.buffer_capacity);
+  EXPECT_EQ(5lu, char_array.buffer_length);
+
   ret = rcutils_char_array_resize(&char_array, 11);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
-  EXPECT_EQ(11u, char_array.buffer_capacity);
-  EXPECT_EQ(5u, char_array.buffer_length);
+  EXPECT_EQ(11lu, char_array.buffer_capacity);
+  EXPECT_EQ(5lu, char_array.buffer_length);
 
   memcpy(char_array.buffer, "0987654321\0", 11);
   char_array.buffer_length = 11;
@@ -50,8 +55,8 @@ TEST(test_char_array, resize) {
 
   ret = rcutils_char_array_resize(&char_array, 3);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
-  EXPECT_EQ(3u, char_array.buffer_capacity);
-  EXPECT_EQ(3u, char_array.buffer_length);
+  EXPECT_EQ(3lu, char_array.buffer_capacity);
+  EXPECT_EQ(3lu, char_array.buffer_length);
   EXPECT_EQ('0', char_array.buffer[0]);
   EXPECT_EQ('9', char_array.buffer[1]);
   EXPECT_EQ('8', char_array.buffer[2]);


### PR DESCRIPTION
This is a follow up PR to incorporate feedback in ros2/rcutils#125 for the `uint8_array` as the same remarks apply.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5641)](http://ci.ros2.org/job/ci_linux/5641/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2259)](http://ci.ros2.org/job/ci_linux-aarch64/2259/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4664)](http://ci.ros2.org/job/ci_osx/4664/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5531)](http://ci.ros2.org/job/ci_windows/5531/)