### PR TITLE
Add option to skip memory tool tests for address sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,15 +167,22 @@ if(BUILD_TESTING)
     COMMAND "$<TARGET_FILE:test_logging_macros_c>"
     GENERATE_RESULT_FOR_RETURN_CODE_ZERO)
 
-  set(SKIP_TEST_IF_WIN32_OR_AARCH64 "")
+  # Define option to skip tests which interfere with address sanitizer. This includes memory tool tests
+  # which override LD_PRELOAD variable.
+  option(SKIP_ASAN_INCOMPATIBLE_TESTS "Skip tests which are address sanitizer incompatible" OFF)
+
+  set(SKIP_MEMORY_TOOL_TESTS "")
   if(WIN32)
     # (memory tools doesn't do anything on Windows)
-    set(SKIP_TEST_IF_WIN32_OR_AARCH64 "SKIP_TEST")
+    set(SKIP_MEMORY_TOOL_TESTS "SKIP_TEST")
   endif()
   # TODO(wjwwood): reenable for ARM (aarch64) when fixed in osrf_testing_tools_cpp
   # see: https://github.com/osrf/osrf_testing_tools_cpp/issues/3
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    set(SKIP_TEST_IF_WIN32_OR_AARCH64 "SKIP_TEST")
+    set(SKIP_MEMORY_TOOL_TESTS "SKIP_TEST")
+  endif()
+  if(SKIP_ASAN_INCOMPATIBLE_TESTS)
+    set(SKIP_MEMORY_TOOL_TESTS "SKIP_TEST")
   endif()
 
   macro(rcutils_custom_add_gtest target)
@@ -189,7 +196,7 @@ if(BUILD_TESTING)
   # Gtests
   rcutils_custom_add_gtest(test_allocator test/test_allocator.cpp
     ENV ${memory_tools_test_env_vars}
-    ${SKIP_TEST_IF_WIN32_OR_AARCH64}
+    ${SKIP_MEMORY_TOOL_TESTS}
   )
   if(TARGET test_allocator)
     target_link_libraries(test_allocator ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)


### PR DESCRIPTION
Introduce a new cmake option -DSKIP_ASAN_INCOMPATIBLE_TESTS to turn off
memory tool tests. This is needed to prevent the override of LD_PRELOAD or library path
to interfere from the working of address sanitizer

Connects to ros2/ci#245