### PR TITLE
Windows messages when atomic type is unsupported

### DIFF
--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -409,6 +409,4 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 // #define atomic_flag_test_and_set(object) \
 //   atomic_flag_test_and_set_explicit(object, memory_order_seq_cst)
 
-#undef _RCUTILS_PACKAGE_NAME
-
 #endif  // RCUTILS__STDATOMIC_HELPER__WIN32__STDATOMIC_H_

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -186,6 +186,10 @@ typedef _Atomic (ptrdiff_t) atomic_ptrdiff_t;
 typedef _Atomic (intmax_t) atomic_intmax_t;
 typedef _Atomic (uintmax_t) atomic_uintmax_t;
 
+#ifndef ROS_PACKAGE_NAME
+  #define ROS_PACKAGE_NAME "<Uknown Package>"
+#endif
+
 /*
  * 7.17.7 Operations on atomic types. (pruned modified for Windows' crappy C compiler)
  */

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -186,8 +186,10 @@ typedef _Atomic (ptrdiff_t) atomic_ptrdiff_t;
 typedef _Atomic (intmax_t) atomic_intmax_t;
 typedef _Atomic (uintmax_t) atomic_uintmax_t;
 
-#ifndef ROS_PACKAGE_NAME
-  #define ROS_PACKAGE_NAME "<Uknown Package>"
+#ifdef ROS_PACKAGE_NAME
+  #define RCUTILS_COPY_NAME ROS_PACKAGE_NAME
+#else
+  #define RCUTILS_COPY_NAME "<Uknown Package>"
 #endif
 
 /*
@@ -214,7 +216,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_compare_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
         exit(-1); \
         break; \
     } \
@@ -244,7 +246,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_exchange_strong"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_exchange_strong"); \
         exit(-1); \
         break; \
     } \
@@ -271,7 +273,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_add")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_add"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_add"); \
         exit(-1); \
         break; \
     } \
@@ -298,7 +300,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_and")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_and"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_and"); \
         exit(-1); \
         break; \
     } \
@@ -325,7 +327,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_or")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_or"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_or"); \
         exit(-1); \
         break; \
     } \
@@ -355,7 +357,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_xor")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_xor"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_xor"); \
         exit(-1); \
         break; \
     } \
@@ -382,7 +384,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_load")
         RCUTILS_LOG_ERROR_NAMED( \
-          ROS_PACKAGE_NAME, "Unsupported integer type in atomic_load"); \
+          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_load"); \
         exit(-1); \
         break; \
     } \
@@ -413,5 +415,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 //   atomic_flag_clear_explicit(object, memory_order_seq_cst)
 // #define atomic_flag_test_and_set(object) \
 //   atomic_flag_test_and_set_explicit(object, memory_order_seq_cst)
+
+#undef RCUTILS_COPY_NAME
 
 #endif  // RCUTILS__STDATOMIC_HELPER__WIN32__STDATOMIC_H_

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -189,7 +189,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #ifdef ROS_PACKAGE_NAME
   #define RCUTILS_COPY_NAME ROS_PACKAGE_NAME
 #else
-  #define RCUTILS_COPY_NAME "<Uknown Package>"
+  #define RCUTILS_COPY_NAME "<Unknown Package>"
 #endif
 
 /*

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -187,9 +187,9 @@ typedef _Atomic (intmax_t) atomic_intmax_t;
 typedef _Atomic (uintmax_t) atomic_uintmax_t;
 
 #ifdef ROS_PACKAGE_NAME
-  #define RCUTILS_COPY_NAME ROS_PACKAGE_NAME
+  #define _RCUTILS_PACKAGE_NAME ROS_PACKAGE_NAME
 #else
-  #define RCUTILS_COPY_NAME "<Unknown Package>"
+  #define _RCUTILS_PACKAGE_NAME "<Unknown Package>"
 #endif
 
 /*
@@ -216,7 +216,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_compare_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
         exit(-1); \
         break; \
     } \
@@ -246,7 +246,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_exchange_strong"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_exchange_strong"); \
         exit(-1); \
         break; \
     } \
@@ -273,7 +273,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_add")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_add"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_add"); \
         exit(-1); \
         break; \
     } \
@@ -300,7 +300,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_and")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_and"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_and"); \
         exit(-1); \
         break; \
     } \
@@ -327,7 +327,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_or")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_or"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_or"); \
         exit(-1); \
         break; \
     } \
@@ -357,7 +357,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_xor")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_fetch_xor"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_xor"); \
         exit(-1); \
         break; \
     } \
@@ -384,7 +384,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       default: \
         #pragma message("Unsupported integer type in atomic_fetch_load")
         RCUTILS_LOG_ERROR_NAMED( \
-          RCUTILS_COPY_NAME, "Unsupported integer type in atomic_load"); \
+          _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_load"); \
         exit(-1); \
         break; \
     } \
@@ -416,6 +416,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 // #define atomic_flag_test_and_set(object) \
 //   atomic_flag_test_and_set_explicit(object, memory_order_seq_cst)
 
-#undef RCUTILS_COPY_NAME
+#undef _RCUTILS_PACKAGE_NAME
 
 #endif  // RCUTILS__STDATOMIC_HELPER__WIN32__STDATOMIC_H_

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -214,7 +214,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedCompareExchange8((char *) object, desired, *expected); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_compare_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
         exit(-1); \
@@ -244,7 +243,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchange8((char *) object, desired); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_exchange_strong"); \
         exit(-1); \
@@ -271,7 +269,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchangeAdd8((char *) object, operand); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_fetch_add")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_add"); \
         exit(-1); \
@@ -298,7 +295,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedAnd8((char *) object, operand); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_fetch_and")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_and"); \
         exit(-1); \
@@ -325,7 +321,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedOr8((char *) object, operand); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_fetch_or")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_or"); \
         exit(-1); \
@@ -355,7 +350,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedXor8((char *) object, operand); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_fetch_xor")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_xor"); \
         exit(-1); \
@@ -382,7 +376,6 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchangeAdd8((char *) object, 0); \
         break; \
       default: \
-        #pragma message("Unsupported integer type in atomic_fetch_load")
         RCUTILS_LOG_ERROR_NAMED( \
           _RCUTILS_PACKAGE_NAME, "Unsupported integer type in atomic_load"); \
         exit(-1); \

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -212,6 +212,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedCompareExchange8((char *) object, desired, *expected); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_compare_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_compare_exchange_strong"); \
         exit(-1); \
@@ -241,6 +242,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchange8((char *) object, desired); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_exchange_strong")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_exchange_strong"); \
         exit(-1); \
@@ -267,6 +269,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchangeAdd8((char *) object, operand); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_fetch_add")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_add"); \
         exit(-1); \
@@ -293,6 +296,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedAnd8((char *) object, operand); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_fetch_and")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_and"); \
         exit(-1); \
@@ -319,6 +323,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedOr8((char *) object, operand); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_fetch_or")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_or"); \
         exit(-1); \
@@ -348,6 +353,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedXor8((char *) object, operand); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_fetch_xor")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_fetch_xor"); \
         exit(-1); \
@@ -374,6 +380,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchangeAdd8((char *) object, 0); \
         break; \
       default: \
+        #pragma message("Unsupported integer type in atomic_fetch_load")
         RCUTILS_LOG_ERROR_NAMED( \
           ROS_PACKAGE_NAME, "Unsupported integer type in atomic_load"); \
         exit(-1); \


### PR DESCRIPTION
This PR uses a default value if `ROS_PACKAGE_NAME` is not set, which appears to be the case for `rclpy`. ~~Also it adds a compile time message when an atomic type is not supported in addition to the existing runtime error.~~ (Edit, second part makes no sense. See comment below)


From https://ci.ros2.org/job/ci_windows/6471/consoleText

```
(ClCompile target) -> 
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(90): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(98): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(106): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(114): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(128): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(139): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(147): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(155): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(163): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
  C:\J\workspace\ci_windows\ws\install\include\rcutils/stdatomic_helper.h(171): error C2065: 'ROS_PACKAGE_NAME': undeclared identifier [C:\J\workspace\ci_windows\ws\build\rclpy\rclpy_signal_handler.vcxproj]
```