### PR TITLE
Fix ASAN failure in test_string_map.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ if(BUILD_TESTING)
     test/test_string_map.cpp
   )
   if(TARGET test_string_map)
+    ament_target_dependencies(test_string_map "osrf_testing_tools_cpp")
     target_link_libraries(test_string_map ${PROJECT_NAME})
   endif()
 

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -130,54 +130,56 @@ TEST(test_string_map, lifecycle) {
   }
 }
 
-TEST_F(TestStringMap, getters) {
+TEST_F(TestStringMap, getters_capacity_null_list) {
   rcutils_ret_t ret;
+  size_t capacity;
+  ret = rcutils_string_map_get_capacity(NULL, &capacity);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+}
 
-  // null for string_map
-  {
-    size_t capacity, size;
-    ret = rcutils_string_map_get_capacity(NULL, &capacity);
-    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
-    rcutils_reset_error();
-    ret = rcutils_string_map_get_size(NULL, &size);
-    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
-    rcutils_reset_error();
-  }
+TEST_F(TestStringMap, getters_size_null_list) {
+  rcutils_ret_t ret;
+  size_t size;
+  ret = rcutils_string_map_get_size(NULL, &size);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+}
 
-  // null for capacity/size
-  {
-    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
-    ret = rcutils_string_map_init(&string_map, 0, allocator);
-    ASSERT_EQ(RCUTILS_RET_OK, ret);
+TEST_F(TestStringMap, getters_capacity_null_capacity) {
+  rcutils_ret_t ret;
+  ret = rcutils_string_map_init(&string_map, 0, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    ret = rcutils_string_map_get_capacity(&string_map, NULL);
-    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
-    rcutils_reset_error();
-    ret = rcutils_string_map_get_size(&string_map, NULL);
-    EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
-    rcutils_reset_error();
-  }
+  ret = rcutils_string_map_get_capacity(&string_map, NULL);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+}
 
-  // initialize to 0
-  {
-    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
-    ret = rcutils_string_map_init(&string_map, 0, allocator);
-    ASSERT_EQ(RCUTILS_RET_OK, ret);
+TEST_F(TestStringMap, getters_size_null_size) {
+  rcutils_ret_t ret;
+  ret = rcutils_string_map_init(&string_map, 0, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    size_t capacity = 42;
-    EXPECT_EQ(
-      RCUTILS_RET_OK,
-      rcutils_string_map_get_capacity(&string_map, &capacity));
-    EXPECT_EQ(0u, capacity);
+  ret = rcutils_string_map_get_size(&string_map, NULL);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+}
 
-    size_t size = 42;
-    ret = rcutils_string_map_get_size(&string_map, &size);
-    EXPECT_EQ(RCUTILS_RET_OK, ret);
-    EXPECT_EQ(0u, size);
+TEST_F(TestStringMap, getters_initialize_to_zero) {
+  rcutils_ret_t ret;
+  ret = rcutils_string_map_init(&string_map, 0, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    ret = rcutils_string_map_fini(&string_map);
-    ASSERT_EQ(RCUTILS_RET_OK, ret);
-  }
+  size_t capacity = 42;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_string_map_get_capacity(&string_map, &capacity));
+  EXPECT_EQ(0u, capacity);
+
+  size_t size = 42;
+  ret = rcutils_string_map_get_size(&string_map, &size);
+  EXPECT_EQ(RCUTILS_RET_OK, ret);
+  EXPECT_EQ(0u, size);
+
+  ret = rcutils_string_map_fini(&string_map);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST(test_string_map, reserve_and_clear) {

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -37,9 +37,15 @@ protected:
 
   void TearDown() final
   {
-    EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) <<
-      rcutils_get_error_string().str;
+    // Ensure the next call will be successful even if the test
+    // failed.
+    rcutils_reset_error();
+
+    // In some cases, the test may exit before the list has been initialized.
+    // This is OK to ignore.
+    const rcutils_ret_t ret = rcutils_string_map_fini(&string_map);
+    EXPECT_TRUE(ret == RCUTILS_RET_OK || ret == RCUTILS_RET_NOT_INITIALIZED);
+    rcutils_reset_error();
   }
 
   rcutils_allocator_t allocator;

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -17,6 +17,8 @@
 #include <string>
 
 #include "./allocator_testing_utils.h"
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/types/string_map.h"
@@ -137,32 +139,46 @@ TEST_F(TestStringMap, getters_capacity_null_capacity) {
   rcutils_ret_t ret;
   ret = rcutils_string_map_init(&string_map, 0, allocator);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
+  rcutils_reset_error();
+
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK,
+    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    rcutils_reset_error();
+  });
 
   ret = rcutils_string_map_get_capacity(&string_map, NULL);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
   rcutils_reset_error();
-
-  ret = rcutils_string_map_fini(&string_map);
-  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST_F(TestStringMap, getters_size_null_size) {
   rcutils_ret_t ret;
   ret = rcutils_string_map_init(&string_map, 0, allocator);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
+  rcutils_reset_error();
+
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK,
+    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    rcutils_reset_error();
+  });
 
   ret = rcutils_string_map_get_size(&string_map, NULL);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
   rcutils_reset_error();
-
-  ret = rcutils_string_map_fini(&string_map);
-  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST_F(TestStringMap, getters_initialize_to_zero) {
   rcutils_ret_t ret;
   ret = rcutils_string_map_init(&string_map, 0, allocator);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK,
+    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    rcutils_reset_error();
+  });
 
   size_t capacity = 42;
   EXPECT_EQ(
@@ -174,10 +190,6 @@ TEST_F(TestStringMap, getters_initialize_to_zero) {
   ret = rcutils_string_map_get_size(&string_map, &size);
   EXPECT_EQ(RCUTILS_RET_OK, ret);
   EXPECT_EQ(0u, size);
-
-  ret = rcutils_string_map_fini(&string_map);
-  ASSERT_EQ(RCUTILS_RET_OK, ret);
-  rcutils_reset_error();
 }
 
 TEST(test_string_map, reserve_and_clear) {

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -35,19 +35,6 @@ protected:
     string_map = rcutils_get_zero_initialized_string_map();
   }
 
-  void TearDown() final
-  {
-    // Ensure the next call will be successful even if the test
-    // failed.
-    rcutils_reset_error();
-
-    // In some cases, the test may exit before the list has been initialized.
-    // This is OK to ignore.
-    const rcutils_ret_t ret = rcutils_string_map_fini(&string_map);
-    EXPECT_TRUE(ret == RCUTILS_RET_OK || ret == RCUTILS_RET_NOT_INITIALIZED);
-    rcutils_reset_error();
-  }
-
   rcutils_allocator_t allocator;
   rcutils_allocator_t failing_allocator;
   rcutils_string_map_t string_map;
@@ -135,6 +122,7 @@ TEST_F(TestStringMap, getters_capacity_null_list) {
   size_t capacity;
   ret = rcutils_string_map_get_capacity(NULL, &capacity);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
 }
 
 TEST_F(TestStringMap, getters_size_null_list) {
@@ -142,6 +130,7 @@ TEST_F(TestStringMap, getters_size_null_list) {
   size_t size;
   ret = rcutils_string_map_get_size(NULL, &size);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
 }
 
 TEST_F(TestStringMap, getters_capacity_null_capacity) {
@@ -151,6 +140,10 @@ TEST_F(TestStringMap, getters_capacity_null_capacity) {
 
   ret = rcutils_string_map_get_capacity(&string_map, NULL);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
+
+  ret = rcutils_string_map_fini(&string_map);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST_F(TestStringMap, getters_size_null_size) {
@@ -160,6 +153,10 @@ TEST_F(TestStringMap, getters_size_null_size) {
 
   ret = rcutils_string_map_get_size(&string_map, NULL);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
+
+  ret = rcutils_string_map_fini(&string_map);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST_F(TestStringMap, getters_initialize_to_zero) {
@@ -180,6 +177,7 @@ TEST_F(TestStringMap, getters_initialize_to_zero) {
 
   ret = rcutils_string_map_fini(&string_map);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
+  rcutils_reset_error();
 }
 
 TEST(test_string_map, reserve_and_clear) {

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -146,6 +146,10 @@ TEST_F(TestStringMap, getters) {
 
   // null for capacity/size
   {
+    rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
+    ret = rcutils_string_map_init(&string_map, 0, allocator);
+    ASSERT_EQ(RCUTILS_RET_OK, ret);
+
     ret = rcutils_string_map_get_capacity(&string_map, NULL);
     EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
     rcutils_reset_error();


### PR DESCRIPTION
Partially addresses issue described in #146.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>