### PR TITLE
add tests for stdatomic_helper.h and fix bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,17 @@ if(BUILD_TESTING)
     target_link_libraries(test_char_array ${PROJECT_NAME})
   endif()
 
+  # Can't use C++ with stdatomic_helper.h
+  add_executable(test_atomics_executable
+    test/test_atomics.c
+  )
+  set_target_properties(test_atomics_executable
+    PROPERTIES
+      LANGUAGE C
+  )
+  target_link_libraries(test_atomics_executable ${PROJECT_NAME})
+  add_test(NAME test_atomics COMMAND test_atomics_executable)
+
   rcutils_custom_add_gmock(test_error_handling test/test_error_handling.cpp
     # Append the directory of librcutils so it is found at test time.
     APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"

--- a/include/rcutils/stdatomic_helper.h
+++ b/include/rcutils/stdatomic_helper.h
@@ -16,6 +16,7 @@
 #define RCUTILS__STDATOMIC_HELPER_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // disable unused function warnings within this file, due to inline in a header

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -199,6 +199,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_compare_exchange_strong(object, out, expected, desired) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -228,6 +230,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_exchange(object, out, desired) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -254,6 +258,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_fetch_add(object, out, operand) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -280,6 +286,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_fetch_and(object, out, operand) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -306,6 +314,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_fetch_or(object, out, operand) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -335,6 +345,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_fetch_xor(object, out, operand) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
@@ -361,6 +373,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 #define rcutils_win32_atomic_load(object, out) \
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
+  __pragma(warning(disable: 4047)) \
+  __pragma(warning(disable: 4024)) \
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \

--- a/test/test_atomics.c
+++ b/test/test_atomics.c
@@ -18,14 +18,12 @@
 // Cannot use gtest or C++ because stdatomic_helper.h forces a compiler error if C++ is used
 
 #define TEST_ATOMIC_TYPE(BASE_TYPE, ATOMIC_TYPE) \
-  do \
-  { \
+  do { \
     ATOMIC_TYPE uut; \
     atomic_init(&uut, (BASE_TYPE)0); \
     BASE_TYPE loaded_value; \
     rcutils_atomic_load(&uut, loaded_value); \
-    if ((BASE_TYPE)0 != loaded_value) \
-    { \
+    if ((BASE_TYPE)0 != loaded_value) { \
       fprintf(stderr, "load test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
       return 1; \
     } \
@@ -33,13 +31,11 @@
     rcutils_atomic_store(&uut, (BASE_TYPE)28); \
     rcutils_atomic_exchange(&uut, exchanged_value, (BASE_TYPE)42); \
     rcutils_atomic_load(&uut, loaded_value); \
-    if ((BASE_TYPE)28 != exchanged_value) \
-    { \
+    if ((BASE_TYPE)28 != exchanged_value) { \
       fprintf(stderr, "exchange test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
       return 1; \
     } \
-    if ((BASE_TYPE)42 != loaded_value) \
-    { \
+    if ((BASE_TYPE)42 != loaded_value) { \
       fprintf(stderr, "exchange test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
       return 1; \
     } \
@@ -52,14 +48,14 @@ main()
   TEST_ATOMIC_TYPE(char, atomic_char);
   TEST_ATOMIC_TYPE(signed char, atomic_schar);
   TEST_ATOMIC_TYPE(unsigned char, atomic_uchar);
-  TEST_ATOMIC_TYPE(short, atomic_short);
-  TEST_ATOMIC_TYPE(unsigned short, atomic_ushort);
+  TEST_ATOMIC_TYPE(short, atomic_short);  // NOLINT(runtime/int)
+  TEST_ATOMIC_TYPE(unsigned short, atomic_ushort);  // NOLINT(runtime/int)
   TEST_ATOMIC_TYPE(int, atomic_int);
   TEST_ATOMIC_TYPE(unsigned int, atomic_uint);
-  TEST_ATOMIC_TYPE(long, atomic_long);
-  TEST_ATOMIC_TYPE(unsigned long, atomic_ulong);
-  TEST_ATOMIC_TYPE(long long, atomic_llong);
-  TEST_ATOMIC_TYPE(unsigned long long, atomic_ullong);
+  TEST_ATOMIC_TYPE(long, atomic_long);  // NOLINT(runtime/int)
+  TEST_ATOMIC_TYPE(unsigned long, atomic_ulong);  // NOLINT(runtime/int)
+  TEST_ATOMIC_TYPE(long long, atomic_llong);  // NOLINT(runtime/int)
+  TEST_ATOMIC_TYPE(unsigned long long, atomic_ullong);  // NOLINT(runtime/int)
   TEST_ATOMIC_TYPE(int_least16_t, atomic_int_least16_t);
   TEST_ATOMIC_TYPE(uint_least16_t, atomic_uint_least16_t);
   TEST_ATOMIC_TYPE(int_least32_t, atomic_int_least32_t);

--- a/test/test_atomics.c
+++ b/test/test_atomics.c
@@ -1,0 +1,85 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include "rcutils/stdatomic_helper.h"
+
+// Cannot use gtest or C++ because stdatomic_helper.h forces a compiler error if C++ is used
+
+#define TEST_ATOMIC_TYPE(BASE_TYPE, ATOMIC_TYPE) \
+  do \
+  { \
+    ATOMIC_TYPE uut; \
+    atomic_init(&uut, (BASE_TYPE)0); \
+    BASE_TYPE loaded_value; \
+    rcutils_atomic_load(&uut, loaded_value); \
+    if ((BASE_TYPE)0 != loaded_value) \
+    { \
+      fprintf(stderr, "load test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
+      return 1; \
+    } \
+    BASE_TYPE exchanged_value; \
+    rcutils_atomic_store(&uut, (BASE_TYPE)28); \
+    rcutils_atomic_exchange(&uut, exchanged_value, (BASE_TYPE)42); \
+    rcutils_atomic_load(&uut, loaded_value); \
+    if ((BASE_TYPE)28 != exchanged_value) \
+    { \
+      fprintf(stderr, "exchange test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
+      return 1; \
+    } \
+    if ((BASE_TYPE)42 != loaded_value) \
+    { \
+      fprintf(stderr, "exchange test failed " #ATOMIC_TYPE " base " #BASE_TYPE "\n"); \
+      return 1; \
+    } \
+  } while (0)
+
+int
+main()
+{
+  TEST_ATOMIC_TYPE(_Bool, atomic_bool);
+  TEST_ATOMIC_TYPE(char, atomic_char);
+  TEST_ATOMIC_TYPE(signed char, atomic_schar);
+  TEST_ATOMIC_TYPE(unsigned char, atomic_uchar);
+  TEST_ATOMIC_TYPE(short, atomic_short);
+  TEST_ATOMIC_TYPE(unsigned short, atomic_ushort);
+  TEST_ATOMIC_TYPE(int, atomic_int);
+  TEST_ATOMIC_TYPE(unsigned int, atomic_uint);
+  TEST_ATOMIC_TYPE(long, atomic_long);
+  TEST_ATOMIC_TYPE(unsigned long, atomic_ulong);
+  TEST_ATOMIC_TYPE(long long, atomic_llong);
+  TEST_ATOMIC_TYPE(unsigned long long, atomic_ullong);
+  TEST_ATOMIC_TYPE(int_least16_t, atomic_int_least16_t);
+  TEST_ATOMIC_TYPE(uint_least16_t, atomic_uint_least16_t);
+  TEST_ATOMIC_TYPE(int_least32_t, atomic_int_least32_t);
+  TEST_ATOMIC_TYPE(uint_least32_t, atomic_uint_least32_t);
+  TEST_ATOMIC_TYPE(int_least64_t, atomic_int_least64_t);
+  TEST_ATOMIC_TYPE(uint_least64_t, atomic_uint_least64_t);
+  TEST_ATOMIC_TYPE(int_fast16_t, atomic_int_fast16_t);
+  TEST_ATOMIC_TYPE(uint_fast16_t, atomic_uint_fast16_t);
+  TEST_ATOMIC_TYPE(int_fast32_t, atomic_int_fast32_t);
+  TEST_ATOMIC_TYPE(uint_fast32_t, atomic_uint_fast32_t);
+  TEST_ATOMIC_TYPE(int_fast64_t, atomic_int_fast64_t);
+  TEST_ATOMIC_TYPE(uint_fast64_t, atomic_uint_fast64_t);
+  TEST_ATOMIC_TYPE(intptr_t, atomic_intptr_t);
+  TEST_ATOMIC_TYPE(uintptr_t, atomic_uintptr_t);
+  TEST_ATOMIC_TYPE(size_t, atomic_size_t);
+  TEST_ATOMIC_TYPE(ptrdiff_t, atomic_ptrdiff_t);
+  TEST_ATOMIC_TYPE(intmax_t, atomic_intmax_t);
+  TEST_ATOMIC_TYPE(uintmax_t, atomic_uintmax_t);
+
+  TEST_ATOMIC_TYPE(int *, _Atomic(int *));
+  TEST_ATOMIC_TYPE(int **, _Atomic(int **));
+  return 0;
+}


### PR DESCRIPTION
This adds a test for stdatomic_helper.h and fixes a couple bugs:

* Adds `<stddef.h>` for the `ptrdiff_t` type
* Ignores `C4047` and `C4024` which occur when creating atomic pointers on windows
  * [C4024](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4024?view=vs-2019)
    * When using `int *` the compiler complains that the value to exchange passed to `InterlockedExchange...()` functions has a different type than the function expects. This doesn't matter because all we care about is the size.
  * [C4047](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4047?view=vs-2019)
     * When using `int *` the compiler complains that `int *` has more levels of indirection than the expected type of the parameter of all the `InterlockedExchange...()` functions. This also doesn't matter because all we care about is the size.

<details><summary>Warnings without ignoring C4047 and C4024</summary>

```
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'LONG64' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'LONG' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'short' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'char' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: 'function': 'LONG64' differs in levels of indirection from 'int *' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4024: '_InterlockedExchange64': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: 'function': 'LONG' differs in levels of indirection from 'int *' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4024: '_InterlockedExchange': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: 'function': 'SHORT' differs in levels of indirection from 'int *' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4024: '_InterlockedExchange16': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'SHORT' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: 'function': 'CHAR' differs in levels of indirection from 'int *' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4024: '_InterlockedExchange8': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(82): warning C4047: '=': 'int *' differs in levels of indirection from 'CHAR' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'LONG64' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'LONG' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'short' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'char' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: 'function': 'LONG64' differs in levels of indirection from 'int **' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4024: '_InterlockedExchange64': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: 'function': 'LONG' differs in levels of indirection from 'int **' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4024: '_InterlockedExchange': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: 'function': 'SHORT' differs in levels of indirection from 'int **' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4024: '_InterlockedExchange16': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'SHORT' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: 'function': 'CHAR' differs in levels of indirection from 'int **' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4024: '_InterlockedExchange8': different types for formal and actual parameter 2 [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
C:\Users\osrf\Desktop\sloretz_ws\ws\src\ros2\rcutils\test\test_atomics.c(83): warning C4047: '=': 'int **' differs in levels of indirection from 'CHAR' [C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\test_atomics_executable.vcxproj]
  test_atomics_executable.vcxproj -> C:\Users\osrf\Desktop\sloretz_ws\ws\build\rcutils\Release\test_atomics_executable.exe
```
</details>