### PR TITLE
Fix leak in test_logging.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(BUILD_TESTING)
     osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_IS_AVAILABLE)
 
   ament_add_gtest(test_logging test/test_logging.cpp)
-  target_link_libraries(test_logging ${PROJECT_NAME})
+  target_link_libraries(test_logging ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
 
   add_executable(test_logging_long_messages test/test_logging_long_messages.cpp)
   target_link_libraries(test_logging_long_messages ${PROJECT_NAME})

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging.h"
 
 #ifdef RMW_IMPLEMENTATION
@@ -29,11 +30,12 @@
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging_initialization) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
   EXPECT_TRUE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   EXPECT_TRUE(g_rcutils_logging_initialized);
-  g_rcutils_logging_initialized = false;
-  EXPECT_FALSE(g_rcutils_logging_initialized);
 }
 
 size_t g_log_calls = 0;
@@ -51,6 +53,9 @@ LogEvent g_last_log_event;
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
   EXPECT_TRUE(g_rcutils_logging_initialized);
   g_rcutils_logging_default_logger_level = RCUTILS_LOG_SEVERITY_DEBUG;
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_DEBUG, g_rcutils_logging_default_logger_level);
@@ -123,8 +128,6 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   // restore original state
   rcutils_logging_set_default_logger_level(original_level);
   rcutils_logging_set_output_handler(original_function);
-  g_rcutils_logging_initialized = false;
-  EXPECT_FALSE(g_rcutils_logging_initialized);
 }
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
@@ -164,6 +167,9 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);
 
   // check setting of acceptable severities
@@ -219,6 +225,9 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severity_hierarchy) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
 
   // check resolving of effective thresholds in hierarchy of loggers
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);


### PR DESCRIPTION
Add rcutils_logging_shutdown() every time needed
in test_logging.cpp. Remove spurious `g_rcutils_logging_initialized = false;`
preventing rcutils_logging_shutdown() from freeing memory.

Before:
```
  $ ./test_logging
  Running main() from ../../../install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
  [==========] Running 5 tests from 1 test case.
  [----------] Global test environment set-up.
  [----------] 5 tests from TestLogging
  [ RUN      ] TestLogging.test_logging_initialization
  [       OK ] TestLogging.test_logging_initialization (0 ms)
  [ RUN      ] TestLogging.test_logging
  [       OK ] TestLogging.test_logging (0 ms)
  [ RUN      ] TestLogging.test_log_severity
  [       OK ] TestLogging.test_log_severity (0 ms)
  [ RUN      ] TestLogging.test_logger_severities
  [       OK ] TestLogging.test_logger_severities (0 ms)
  [ RUN      ] TestLogging.test_logger_severity_hierarchy
  [       OK ] TestLogging.test_logger_severity_hierarchy (0 ms)
  [----------] 5 tests from TestLogging (0 ms total)

  [----------] Global test environment tear-down
  [==========] 5 tests from 1 test case ran. (0 ms total)
  [  PASSED  ] 5 tests.

  =================================================================
  ==1676==ERROR: LeakSanitizer: detected memory leaks

  Direct leak of 72 byte(s) in 1 object(s) allocated from:
      #0 0x7f7a7229db50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
      #1 0x7f7a71f9abb5 in __default_allocate (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x8bb5)
      #2 0x7f7a71fad1b0 in rcutils_string_map_init (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x1b1b0)
      #3 0x7f7a71fa4641 in rcutils_logging_initialize_with_allocator (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x12641)
      #4 0x7f7a71fa41ab in rcutils_logging_initialize (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x121ab)
      #5 0x561e9d22c972 in TestLogging_test_logging_Test::TestBody() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x1a972)
      #6 0x561e9d2b545d in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0xa345d)
      #7 0x561e9d2a71c7 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x951c7)
      #8 0x561e9d2534c9 in testing::Test::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x414c9)
      #9 0x561e9d2548f4 in testing::TestInfo::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x428f4)
      #10 0x561e9d255498 in testing::TestCase::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x43498)
      #11 0x561e9d2705a9 in testing::internal::UnitTestImpl::RunAllTests() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x5e5a9)
      #12 0x561e9d2b7f10 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0xa5f10)
      #13 0x561e9d2a9490 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x97490)
      #14 0x561e9d26d33d in testing::UnitTest::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x5b33d)
      #15 0x561e9d24088c in RUN_ALL_TESTS() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x2e88c)
      #16 0x561e9d2407d2 in main (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x2e7d2)
      #17 0x7f7a71402b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

  Direct leak of 72 byte(s) in 1 object(s) allocated from:
      #0 0x7f7a7229db50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
      #1 0x7f7a71f9abb5 in __default_allocate (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x8bb5)
      #2 0x7f7a71fad1b0 in rcutils_string_map_init (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x1b1b0)
      #3 0x7f7a71fa4641 in rcutils_logging_initialize_with_allocator (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x12641)
      #4 0x7f7a71fa41ab in rcutils_logging_initialize (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/install-asan/rcutils/lib/librcutils.so+0x121ab)
      #5 0x561e9d22a9b6 in TestLogging_test_logging_initialization_Test::TestBody() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x189b6)
      #6 0x561e9d2b545d in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0xa345d)
      #7 0x561e9d2a71c7 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x951c7)
      #8 0x561e9d2534c9 in testing::Test::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x414c9)
      #9 0x561e9d2548f4 in testing::TestInfo::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x428f4)
      #10 0x561e9d255498 in testing::TestCase::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x43498)
      #11 0x561e9d2705a9 in testing::internal::UnitTestImpl::RunAllTests() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x5e5a9)
      #12 0x561e9d2b7f10 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0xa5f10)
      #13 0x561e9d2a9490 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x97490)
      #14 0x561e9d26d33d in testing::UnitTest::Run() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x5b33d)
      #15 0x561e9d24088c in RUN_ALL_TESTS() (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x2e88c)
      #16 0x561e9d2407d2 in main (/home/ANT.AMAZON.COM/tmoulard/ros2_ws/build-asan/rcutils/test_logging+0x2e7d2)
      #17 0x7f7a71402b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

  SUMMARY: AddressSanitizer: 144 byte(s) leaked in 2 allocation(s).
```

After:
```
  $ ./test_logging
  Running main() from ../../../install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
  [==========] Running 5 tests from 1 test case.
  [----------] Global test environment set-up.
  [----------] 5 tests from TestLogging
  [ RUN      ] TestLogging.test_logging_initialization
  [       OK ] TestLogging.test_logging_initialization (0 ms)
  [ RUN      ] TestLogging.test_logging
  [       OK ] TestLogging.test_logging (0 ms)
  [ RUN      ] TestLogging.test_log_severity
  [       OK ] TestLogging.test_log_severity (0 ms)
  [ RUN      ] TestLogging.test_logger_severities
  [       OK ] TestLogging.test_logger_severities (0 ms)
  [ RUN      ] TestLogging.test_logger_severity_hierarchy
  [       OK ] TestLogging.test_logger_severity_hierarchy (0 ms)
  [----------] 5 tests from TestLogging (1 ms total)

  [----------] Global test environment tear-down
  [==========] 5 tests from 1 test case ran. (1 ms total)
  [  PASSED  ] 5 tests.
```

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>