### PR TITLE
Use GCC extension for printf-like functions

### DIFF
--- a/include/rcutils/format_string.h
+++ b/include/rcutils/format_string.h
@@ -69,7 +69,8 @@ rcutils_format_string_limit(
   rcutils_allocator_t allocator,
   size_t limit,
   const char * format_string,
-  ...);
+  ...)
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -466,7 +466,8 @@ void rcutils_log(
   int severity,
   const char * name,
   const char * format,
-  ...);
+  ...)
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5);
 
 /// The default output handler outputs log messages to the standard streams.
 /**

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -64,6 +64,32 @@ extern "C"
 #define RCUTILS_STRINGIFY(x) RCUTILS_STRINGIFY_IMPL(x)
 #define RCUTILS_UNUSED(x) (void)(x)
 
+#if defined _WIN32 || defined __CYGWIN__
+#define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index)
+#else
+// This macro can be used to annotate printf-like functions which are relying
+// on a format string and a variable number of arguments.
+//
+// This enables GCC to emit warnings if dangerous patterns are detected.
+// See GCC documentation for details:
+// https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+//
+// format_string_index is the index of the format string passed to the function
+// first_to_check_index is the index of the first "optional argument".
+//
+// For the following function:
+// int snprintf(char *str, size_t size, const char *format, ...);
+//              ^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^
+//              ARG 1      ARG 2        ARG 3               ARG 4
+//                                      format string       first optional argument
+//
+// format_string_index value would be 3, first_to_check_index value would be 4.
+//
+// IMPORTANT: the first argument has an index of ONE (not zero!).
+#define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index) \
+  __attribute__ ((format (printf, format_string_index, first_to_check_index)))
+#endif // !defined _WIN32 || defined __CYGWIN__
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -89,8 +89,8 @@ extern "C"
  * \param first_to_check_index index of the first "optional argument"
  */
 #define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index) \
-  __attribute__ ((format (printf, format_string_index, first_to_check_index)))
-#endif // !defined _WIN32 || defined __CYGWIN__
+  __attribute__ ((format(printf, format_string_index, first_to_check_index)))
+#endif  // !defined _WIN32 || defined __CYGWIN__
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -65,27 +65,29 @@ extern "C"
 #define RCUTILS_UNUSED(x) (void)(x)
 
 #if defined _WIN32 || defined __CYGWIN__
+/// Macro to annotate printf-like functions on Linux. Disabled on Windows.
 #define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index)
 #else
-// This macro can be used to annotate printf-like functions which are relying
-// on a format string and a variable number of arguments.
-//
-// This enables GCC to emit warnings if dangerous patterns are detected.
-// See GCC documentation for details:
-// https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
-//
-// format_string_index is the index of the format string passed to the function
-// first_to_check_index is the index of the first "optional argument".
-//
-// For the following function:
-// int snprintf(char *str, size_t size, const char *format, ...);
-//              ^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^
-//              ARG 1      ARG 2        ARG 3               ARG 4
-//                                      format string       first optional argument
-//
-// format_string_index value would be 3, first_to_check_index value would be 4.
-//
-// IMPORTANT: the first argument has an index of ONE (not zero!).
+/// Macro to annotate printf-like functions which are relying on a format string and a variable
+/// number of arguments.
+/**
+ * This enables GCC to emit warnings if dangerous patterns are detected.
+ * See GCC documentation for details:
+ * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+ *
+ * For the following function:
+ * int snprintf(char *str, size_t size, const char *format, ...);
+ *              ^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^
+ *              ARG 1      ARG 2        ARG 3               ARG 4
+ *                                      format string       first optional argument
+ *
+ * format_string_index value would be 3, first_to_check_index value would be 4.
+ *
+ * IMPORTANT: the first argument has an index of ONE (not zero!).
+ *
+ * \param format_string_index index of the format string passed to the function
+ * \param first_to_check_index index of the first "optional argument"
+ */
 #define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index) \
   __attribute__ ((format (printf, format_string_index, first_to_check_index)))
 #endif // !defined _WIN32 || defined __CYGWIN__

--- a/include/rcutils/snprintf.h
+++ b/include/rcutils/snprintf.h
@@ -54,7 +54,8 @@ extern "C"
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 int
-rcutils_snprintf(char * buffer, size_t buffer_size, const char * format, ...);
+rcutils_snprintf(char * buffer, size_t buffer_size, const char * format, ...)
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4);
 
 /// Format a string with va_list for arguments, see rcutils_snprintf().
 RCUTILS_PUBLIC

--- a/test/test_format_string.cpp
+++ b/test/test_format_string.cpp
@@ -44,7 +44,7 @@ TEST(test_format_string_limit, invalid_arguments) {
   auto allocator = rcutils_get_default_allocator();
   auto failing_allocator = get_failing_allocator();
 
-  char * formatted = rcutils_format_string_limit(allocator, 10, NULL, "test");
+  char * formatted = rcutils_format_string_limit(allocator, 10, NULL);
   EXPECT_STREQ(NULL, formatted);
 
   formatted = rcutils_format_string_limit(failing_allocator, 10, "%s", "test");

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -113,15 +113,15 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_EQ("name3", g_last_log_event.name);
   EXPECT_EQ("message 33", g_last_log_event.message);
 
-  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_WARN, "", "");
+  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_WARN, "", "%s", "");
   EXPECT_EQ(3u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_WARN, g_last_log_event.level);
 
-  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_ERROR, "", "");
+  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_ERROR, "", "%s", "");
   EXPECT_EQ(4u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_ERROR, g_last_log_event.level);
 
-  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_FATAL, NULL, "");
+  rcutils_log(NULL, RCUTILS_LOG_SEVERITY_FATAL, NULL, "%s", "");
   EXPECT_EQ(5u, g_log_calls);
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_FATAL, g_last_log_event.level);
 

--- a/test/test_logging_long_messages.cpp
+++ b/test/test_logging_long_messages.cpp
@@ -35,7 +35,7 @@ int main(int, char **)
   }
   message[sizeof(message) - 2] = 'X';
   message[sizeof(message) - 1] = '\0';
-  rcutils_log(&location, RCUTILS_LOG_SEVERITY_INFO, "name1", message);
+  rcutils_log(&location, RCUTILS_LOG_SEVERITY_INFO, "name1", "%s", message);
 
   message[1] = '%';
   message[2] = 'd';


### PR DESCRIPTION
This commit annotates rcutils_format_string_limit, rcutils_log
and rcutils_snprintf with the GCC extension for printf-like
statements.

Annotating this function allows GCC to emit warnings when dangerous
patterns are used through the whole codebase.

As those functions are wrappers around different flavors of printf,
surfacing those warnings prevents dangerous printf statements.

For instance:

```
const char* message = // some dynamically evaluated logging message
printf(message);
```

...is unsafe. Instead, we should be using:

```
printf("%s", message);
```

...to avoid crashes if the variable "message" contains a sequence
of characters printf may recognize (like "%d").

printf-related warnings are enabled by '-Wformat*' flags ('-Wformat',
'-Wformat-security', etc.).

The complete list of flags and detected patterns is available in
the GCC documentation:

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

Note: clang does also support this attribute but not MSVC. On
Windows, no additional safety is provided by this commit.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>