### PR TITLE
remove macros from source file

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -28,8 +28,6 @@ extern "C"
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
 
-RCUTILS_PUBLIC
-RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_time_point_value_as_nanoseconds_string(
   const rcutils_time_point_value_t * time_point,


### PR DESCRIPTION
These macros should only be specified in the header file: https://github.com/ros2/rcutils/blob/e52f2cfc1aac935bb0e6c35a7f3ad332a56d6d71/include/rcutils/time.h#L134-L135