### PR TITLE
Add colorized output

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -70,9 +70,10 @@ extern bool g_rcutils_logging_initialized;
  *
  * The `RCUTILS_COLORIZED_OUTPUT` environment variable allows configuring if colours
  * are used or not. Available values are:
- *  - `FORCE_ENABLE`: Use colours.
- *  - `FORCE_DISABLE`: Don't use colours.
- *  - `DEFAULT`: Is colours if the target stream is a terminal.
+ *  - `1`: Force using colours.
+ *  - `0`: Don't use colours.
+ * If it is unset, colours are used depending if the target stream is a terminal or not.
+ * See `isatty` documentation.
  *
  * The format string can use these tokens by referencing them in curly brackets,
  * e.g. `"[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"`.

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -68,6 +68,12 @@ extern bool g_rcutils_logging_initialized;
  *   - `time`, the timestamp of log message in floating point seconds
  *   - `time_as_nanoseconds`, the timestamp of log message in integer nanoseconds
  *
+ * The `RCUTILS_COLORIZED_OUTPUT` environment variable allows configuring if colours
+ * are used or not. Available values are:
+ *  - `FORCE_ENABLE`: Use colours.
+ *  - `FORCE_DISABLE`: Don't use colours.
+ *  - `DEFAULT`: Is colours if the target stream is a terminal.
+ *
  * The format string can use these tokens by referencing them in curly brackets,
  * e.g. `"[{severity}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"`.
  * Any number of tokens can be used.
@@ -477,6 +483,8 @@ RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5);
  * The console output format of the logged message can be configured through
  * the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable: see
  * rcutils_logging_initialize_with_allocator() for details.
+ * For configuring if using colours or not, `RCUTILS_COLORIZED_OUTPUT` can be used:
+ * see rcutils_logging_initialize_with_allocator() for details.
  *
  * <hr>
  * Attribute          | Adherence

--- a/src/logging.c
+++ b/src/logging.c
@@ -22,10 +22,12 @@ extern "C"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
 
 #ifdef WIN32
+# include <io.h>
 # include <windows.h>
+#else
+# include <unistd.h>
 #endif
 
 #include "rcutils/allocator.h"
@@ -734,6 +736,7 @@ rcutils_ret_t rcutils_logging_format_message(
       } \
     } \
   }
+# define EXPAND(x) x
 # define APPLY(macro, ...) EXPAND(macro(__VA_ARGS__))
 # define SET_OUTPUT_COLOR_WITH_SEVERITY(status, severity, stream, output_array) \
   { \

--- a/src/logging.c
+++ b/src/logging.c
@@ -48,9 +48,9 @@ const char * g_rcutils_log_severity_names[] = {
 
 enum rcutils_colorized_output
 {
-  RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE,
-  RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE,
-  RCUTILS_COLORIZED_OUTPUT_DEFAULT,
+  RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE = 0,
+  RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE = 1,
+  RCUTILS_COLORIZED_OUTPUT_AUTO = 2,
 };
 
 bool g_rcutils_logging_initialized = false;
@@ -72,7 +72,7 @@ int g_rcutils_logging_default_logger_level = 0;
 bool g_force_stdout_line_buffered = false;
 bool g_stdout_flush_failure_reported = false;
 
-enum rcutils_colorized_output g_colorized_output = RCUTILS_COLORIZED_OUTPUT_DEFAULT;
+enum rcutils_colorized_output g_colorized_output = RCUTILS_COLORIZED_OUTPUT_AUTO;
 
 rcutils_ret_t rcutils_logging_initialize(void)
 {

--- a/src/logging.c
+++ b/src/logging.c
@@ -672,13 +672,25 @@ rcutils_ret_t rcutils_logging_format_message(
 # define COLOR_RED 4
 # define COLOR_GREEN 2
 # define COLOR_YELLOW 6
+# define IS_STREAM_A_TTY(stream) (_isatty(_fileno(stream)) != 0)
 #else
 # define COLOR_NORMAL "\033[0m"
 # define COLOR_RED "\033[31m"
 # define COLOR_GREEN "\033[32m"
 # define COLOR_YELLOW "\033[33m"
+# define IS_STREAM_A_TTY(stream) (isatty(fileno(stream)) != 0)
 #endif
 
+#define IS_OUTPUT_COLORIZED(is_colorized, stream) \
+  { \
+    if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE) { \
+      is_colorized = true; \
+    } else if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE) { \
+      is_colorized = false; \
+    } else { \
+      is_colorized = IS_STREAM_A_TTY(stream); \
+    } \
+  }
 #define SET_COLOR_WITH_SEVERITY(status, severity, color) \
   { \
     switch (severity) { \
@@ -701,16 +713,6 @@ rcutils_ret_t rcutils_logging_format_message(
     } \
   }
 #ifdef WIN32
-# define IS_OUTPUT_COLORIZED(is_colorized, stream) \
-  { \
-    if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE) { \
-      is_colorized = true; \
-    } else if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE) { \
-      is_colorized = false; \
-    } else { \
-      is_colorized = _isatty(_fileno(stream)) != 0; \
-    } \
-  }
 # define SET_OUTPUT_COLOR_WITH_COLOR(status, color, handle) \
   { \
     if (RCUTILS_RET_OK == status) { \
@@ -753,16 +755,6 @@ rcutils_ret_t rcutils_logging_format_message(
     APPLY(SET_OUTPUT_COLOR_WITH_COLOR, status, COLOR_NORMAL, handle) \
   }
 #else
-# define IS_OUTPUT_COLORIZED(is_colorized, stream) \
-  { \
-    if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE) { \
-      is_colorized = true; \
-    } else if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE) { \
-      is_colorized = false; \
-    } else { \
-      is_colorized = isatty(fileno(stream)) != 0; \
-    } \
-  }
 # define SET_OUTPUT_COLOR_WITH_COLOR(status, color, output_array) \
   { \
     if (RCUTILS_RET_OK == status) { \

--- a/src/logging.c
+++ b/src/logging.c
@@ -126,17 +126,18 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
       } else if (!strcmp(colorized_output, "0")) {
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE;
       } else if (strcmp(colorized_output, "")) {
-          fprintf(stderr,
-            "Warning: unexpected value [%s] specified for RCUTILS_COLORIZED_OUTPUT. "
-            "Output will be colorized if target stream is a terminal."
-            " Valid values are 0 and 1.\n",
-            colorized_output);
+        fprintf(
+          stderr,
+          "Warning: unexpected value [%s] specified for RCUTILS_COLORIZED_OUTPUT. "
+          "Output will be colorized if target stream is a terminal."
+          " Valid values are 0 and 1.\n",
+          colorized_output);
       }
     } else if (NULL != ret_str) {
-        RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Failed to get if output is colorized from env. variable [%s]. Using DEFAULT.",
-            ret_str);
-          ret = RCUTILS_RET_INVALID_ARGUMENT;
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Failed to get if output is colorized from env. variable [%s]. Using DEFAULT.",
+        ret_str);
+      ret = RCUTILS_RET_INVALID_ARGUMENT;
     }
 
     // Check for the environment variable for custom output formatting
@@ -768,7 +769,7 @@ rcutils_ret_t rcutils_logging_format_message(
   }
 # define SET_OUTPUT_COLOR_WITH_SEVERITY(status, severity, stream, output_array) \
   { \
-    const char* color = NULL; \
+    const char * color = NULL; \
     SET_COLOR_WITH_SEVERITY(status, severity, color) \
     SET_OUTPUT_COLOR_WITH_COLOR(status, color, output_array) \
   }
@@ -873,6 +874,7 @@ void rcutils_logging_console_output_handler(
   }
 
   // Only does something in windows
+  // cppcheck-suppress uninitvar  // suppress cppcheck false positive
   SET_STANDARD_COLOR_IN_STREAM(is_colorized, status, stream)
 
   status = rcutils_char_array_fini(&msg_array);

--- a/src/logging.c
+++ b/src/logging.c
@@ -738,21 +738,19 @@ rcutils_ret_t rcutils_logging_format_message(
       } \
     } \
   }
-# define EXPAND(x) x
-# define APPLY(macro, ...) EXPAND(macro(__VA_ARGS__))
 # define SET_OUTPUT_COLOR_WITH_SEVERITY(status, severity, stream, output_array) \
   { \
     WORD color; \
     HANDLE handle; \
-    APPLY(SET_COLOR_WITH_SEVERITY, status, severity, color) \
-    APPLY(GET_HANDLE_FROM_STREAM, status, handle, stream) \
-    APPLY(SET_OUTPUT_COLOR_WITH_COLOR, status, color, handle) \
+    SET_COLOR_WITH_SEVERITY(status, severity, color) \
+    GET_HANDLE_FROM_STREAM(status, handle, stream) \
+    SET_OUTPUT_COLOR_WITH_COLOR(status, color, handle) \
   }
 # define SET_STANDARD_COLOR(status, stream, output_array) \
   { \
     HANDLE handle; \
-    APPLY(GET_HANDLE_FROM_STREAM, status, handle, stream) \
-    APPLY(SET_OUTPUT_COLOR_WITH_COLOR, status, COLOR_NORMAL, handle) \
+    GET_HANDLE_FROM_STREAM(status, handle, stream) \
+    SET_OUTPUT_COLOR_WITH_COLOR(status, COLOR_NORMAL, handle) \
   }
 #else
 # define SET_OUTPUT_COLOR_WITH_COLOR(status, color, output_array) \

--- a/src/logging.c
+++ b/src/logging.c
@@ -114,19 +114,17 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     const char * colorized_output;
     const char * ret_str = rcutils_get_env("RCUTILS_COLORIZED_OUTPUT", &colorized_output);
 
-    if (NULL == ret_str && strcmp(colorized_output, "") != 0) {
-      if (!strcmp(colorized_output, "FORCE_ENABLE")) {
+    if (NULL == ret_str) {
+      if (!strcmp(colorized_output, "1")) {
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE;
-      } else if (!strcmp(colorized_output, "FORCE_DISABLE")) {
+      } else if (!strcmp(colorized_output, "0")) {
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE;
-      } else {
-        if (strcmp(colorized_output, "DEFAULT")) {
+      } else if (strcmp(colorized_output, "")) {
           fprintf(stderr,
             "Warning: unexpected value [%s] specified for RCUTILS_COLORIZED_OUTPUT. "
-            "Default value DEFAULT will be used. Valid values are FORCE_ENABLE, FORCE_DISABLE"
-            " and DEFAULT.\n",
+            "Output will be colorized if target stream is a terminal."
+            " Valid values are 0 and 1.\n",
             colorized_output);
-        }
       }
     } else if (NULL != ret_str) {
         RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(


### PR DESCRIPTION
It is just what the title says.

Working well in Linux. Colors were taken from ROS1:
https://github.com/ros/rosconsole/blob/ba4e1ae06b5bce3039ac5d20853248b51198e431/src/rosconsole/rosconsole.cpp#L75-L85
https://github.com/ros/rosconsole/blob/ba4e1ae06b5bce3039ac5d20853248b51198e431/src/rosconsole/rosconsole.cpp#L341-L363

I haven't tried it on MAC, but as far as I understand it should work as-is.

I could do something like this in windows if it is desired:
https://stackoverflow.com/questions/8765938/colorful-text-using-printf-in-c