### PR TITLE
Correct bug when reading RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -114,6 +114,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     } else {
       fprintf(stderr, "Error getting env. variable "
         "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s\n", ret_str);
+      ret = RCUTILS_RET_INVALID_ARGUMENT;
     }
 
     // Check the environment variable for colorized output

--- a/src/logging.c
+++ b/src/logging.c
@@ -82,24 +82,6 @@ enum rcutils_colorized_output g_colorized_output = RCUTILS_COLORIZED_OUTPUT_AUTO
 
 rcutils_ret_t rcutils_logging_initialize(void)
 {
-  const char * line_buffered;
-  const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
-
-  if (NULL == ret_str) {
-    if (strcmp(line_buffered, "1")) {
-      g_force_stdout_line_buffered = true;
-    } else {
-      if (!strcmp(line_buffered, "0")) {
-        fprintf(stderr,
-          "Warning: unexpected value [%s] specified for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED. "
-          "Default value 0 will be used. Valid values are 1 or 0.\n",
-          line_buffered);
-      }
-    }
-  } else {
-    fprintf(stderr, "Error getting env. variable "
-      "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s\n", ret_str);
-  }
   return rcutils_logging_initialize_with_allocator(rcutils_get_default_allocator());
 }
 
@@ -116,9 +98,27 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     g_rcutils_logging_output_handler = &rcutils_logging_console_output_handler;
     g_rcutils_logging_default_logger_level = RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL;
 
+    // Check the environment variable for line buffered output
+    const char * line_buffered;
+    const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
+
+    if (NULL == ret_str) {
+      if (!strcmp(line_buffered, "1")) {
+        g_force_stdout_line_buffered = true;
+      } else if (strcmp(line_buffered, "0")) {
+        fprintf(stderr,
+          "Warning: unexpected value [%s] specified for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED. "
+          "Default value 0 will be used. Valid values are 1 or 0.\n",
+          line_buffered);
+      }
+    } else {
+      fprintf(stderr, "Error getting env. variable "
+        "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s\n", ret_str);
+    }
+
     // Check the environment variable for colorized output
     const char * colorized_output;
-    const char * ret_str = rcutils_get_env("RCUTILS_COLORIZED_OUTPUT", &colorized_output);
+    ret_str = rcutils_get_env("RCUTILS_COLORIZED_OUTPUT", &colorized_output);
 
     if (NULL == ret_str) {
       if (!strcmp(colorized_output, "1")) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -105,7 +105,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     if (NULL == ret_str) {
       if (strcmp(line_buffered, "1") == 0) {
         g_force_stdout_line_buffered = true;
-      } else if (strcmp(line_buffered, "0") != 0) {
+      } else if (strcmp(line_buffered, "0") != 0 && strcmp(line_buffered, "") != 0) {
         fprintf(stderr,
           "Warning: unexpected value [%s] specified for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED. "
           "Default value 0 will be used. Valid values are 1 or 0.\n",

--- a/src/logging.c
+++ b/src/logging.c
@@ -103,9 +103,9 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
 
     if (NULL == ret_str) {
-      if (!strcmp(line_buffered, "1")) {
+      if (strcmp(line_buffered, "1") == 0) {
         g_force_stdout_line_buffered = true;
-      } else if (strcmp(line_buffered, "0")) {
+      } else if (strcmp(line_buffered, "0") != 0) {
         fprintf(stderr,
           "Warning: unexpected value [%s] specified for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED. "
           "Default value 0 will be used. Valid values are 1 or 0.\n",
@@ -121,11 +121,11 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     ret_str = rcutils_get_env("RCUTILS_COLORIZED_OUTPUT", &colorized_output);
 
     if (NULL == ret_str) {
-      if (!strcmp(colorized_output, "1")) {
+      if (strcmp(colorized_output, "1") == 0) {
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE;
-      } else if (!strcmp(colorized_output, "0")) {
+      } else if (strcmp(colorized_output, "0") == 0) {
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE;
-      } else if (strcmp(colorized_output, "")) {
+      } else if (strcmp(colorized_output, "") != 0) {
         fprintf(
           stderr,
           "Warning: unexpected value [%s] specified for RCUTILS_COLORIZED_OUTPUT. "

--- a/src/logging.c
+++ b/src/logging.c
@@ -133,7 +133,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
           " Valid values are 0 and 1.\n",
           colorized_output);
       }
-    } else if (NULL != ret_str) {
+    } else {
       RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
         "Failed to get if output is colorized from env. variable [%s]. Using DEFAULT.",
         ret_str);


### PR DESCRIPTION
I previously mentioned this in https://github.com/ros2/rcutils/pull/158#issuecomment-492367741.

Two changes:
- Logic for reading `RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED` was wrong. `g_force_stdout_line_buffered` was always silently set to 1, except when you did:
 `export RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=1`.
- Moved the code from `rcutils_logging_initialize` to `rcutils_logging_initialize_with_allocator`. I think we don't have any direct call to `rcutils_logging_initialize_with_allocator`, but it should be there.

