### PR TITLE
Fix armhf warning

### DIFF
--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -22,6 +22,7 @@ extern "C"
 #include <rcutils/error_handling.h>
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -33,6 +33,10 @@ extern "C"
 // RCUTILS_REPORT_ERROR_HANDLING_ERRORS and RCUTILS_WARN_ON_TRUNCATION are set in the header below
 #include "./error_handling_helpers.h"
 
+#ifndef SIZE_MAX
+#define SIZE_MAX (size_t)-1
+#endif
+
 // g_ is to global variable, as gtls_ is to global thread-local storage variable
 RCUTILS_THREAD_LOCAL bool gtls_rcutils_thread_local_initialized = false;
 RCUTILS_THREAD_LOCAL rcutils_error_state_t gtls_rcutils_error_state;
@@ -92,7 +96,7 @@ __format_overwriting_error_state_message(
 {
   assert(NULL != buffer);
   assert(0 != buffer_size);
-  assert(INT64_MAX > buffer_size);
+  assert(SIZE_MAX > buffer_size);
   assert(NULL != new_error_state);
 
   int64_t bytes_left = buffer_size;

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -21,8 +21,8 @@ extern "C"
 
 #include <rcutils/error_handling.h>
 
+#include <limits.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,10 +33,6 @@ extern "C"
 
 // RCUTILS_REPORT_ERROR_HANDLING_ERRORS and RCUTILS_WARN_ON_TRUNCATION are set in the header below
 #include "./error_handling_helpers.h"
-
-#ifndef SIZE_MAX
-#define SIZE_MAX (size_t)-1
-#endif
 
 // g_ is to global variable, as gtls_ is to global thread-local storage variable
 RCUTILS_THREAD_LOCAL bool gtls_rcutils_thread_local_initialized = false;


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/721

Fixes these warnings https://ci.ros2.org/view/All/job/test_ci_linux-armhf/8/warnings23Result/package.-1643903456/

On armhf, size_t is 32 bits, so gcc raises warning for this line "comparison is always true due to limited range of data type"

Signed-off-by: Emerson Knapp <eknapp@amazon.com>