### PR TITLE
Disable uncrustify indentation check for macros that use windows  `__pragma`

### DIFF
--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -195,7 +195,10 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 /*
  * 7.17.7 Operations on atomic types. (pruned modified for Windows' crappy C compiler)
  */
-// *INDENT-OFF*  // uncrustify doesn't like the extra indentations in macros
+
+// TODO(emersonknapp) Regression in uncrustify breaks formatting for macros with __pragma
+// remove indent-off when we have fix for https://github.com/uncrustify/uncrustify/issues/2314
+// *INDENT-OFF*
 
 #define rcutils_win32_atomic_compare_exchange_strong(object, out, expected, desired) \
   __pragma(warning(push)) \

--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -195,6 +195,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
 /*
  * 7.17.7 Operations on atomic types. (pruned modified for Windows' crappy C compiler)
  */
+// *INDENT-OFF*  // uncrustify doesn't like the extra indentations in macros
 
 #define rcutils_win32_atomic_compare_exchange_strong(object, out, expected, desired) \
   __pragma(warning(push)) \
@@ -397,6 +398,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
     } \
   } while (0); \
   __pragma(warning(pop))
+
+// *INDENT-ON*
 
 #define rcutils_win32_atomic_store(object, desired) \
   do { \


### PR DESCRIPTION
Connects to https://github.com/ament/uncrustify_vendor/pull/5