### PR TITLE
[174] Generate version.h file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,61 +91,70 @@ list(APPEND rcutils_sources
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
 ###############################################################################
-# Create version file in build/<package>/include/<package> folder which is already in the include list
-set(TMP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME})
-set(RCUTILS_VERSION_FILE_NAME ${TMP_INCLUDE_DIR}/version.h)
-set(NEED_TO_CREATE_VERSION_FILE false)
+# Create version file if needed
+function(ament_cmake_version)
+  include_directories(${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_version/include)
+  set(TMP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/ament_cmake_version/include/${PROJECT_NAME})
 
-# retrieve verson information from <package>.xml file
-# call ament_package_xml() if it has not been called before
-if(NOT _AMENT_PACKAGE_NAME)
-  ament_package_xml()
-endif()
-# parse version information from the version string
-string(REGEX REPLACE "([0-9]+\).([0-9]+)\.([0-9]+)" "" dummy ${rcutils_VERSION})
-set(RCUTILS_VERSION_MAJOR ${CMAKE_MATCH_1})
-set(RCUTILS_VERSION_MINOR ${CMAKE_MATCH_2})
-set(RCUTILS_VERSION_PATCH ${CMAKE_MATCH_3})
-string(TIMESTAMP RCUTILS_VERSION_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
+  set(${PROJECT_NAME}_VERSION_FILE_NAME ${TMP_INCLUDE_DIR}/version.h)
+  set(NEED_TO_CREATE_VERSION_FILE FALSE)
 
-# sanity checks
-if("${RCUTILS_VERSION_MAJOR}" STREQUAL "")
-  message(FATAL_ERROR "RCUTILS_VERSION_MAJOR is empty or non-numeric, check <package>.XML")
-endif()
-if("${RCUTILS_VERSION_MINOR}" STREQUAL "")
-  message(FATAL_ERROR "RCUTILS_VERSION_MINOR is empty or non-numeric, check <package>.XML")
-endif()
-if("${RCUTILS_VERSION_PATCH}" STREQUAL "")
-  message(FATAL_ERROR "RCUTILS_VERSION_PATCH is empty or non-numeric, check <package>.XML")
-endif()
-
-# Check if the version file exist
-if(EXISTS "${RCUTILS_VERSION_FILE_NAME}")
-  # The file exists
-  # Check if it contains the same version
-  file(STRINGS ${RCUTILS_VERSION_FILE_NAME} VERSION_FILE_STRINGS REGEX "#define RCUTILS_VERSION_STR")
-  if(VERSION_FILE_STRINGS STREQUAL "")
-    set(NEED_TO_CREATE_VERSION_FILE true)
-  else()
-    string(REGEX REPLACE "^#define[ \t]+RCUTILS_VERSION_STR[ \t]+\"([0-9]+\.[0-9]+\.[0-9]+)\"" "" dummy ${VERSION_FILE_STRINGS})
-    if(NOT (${CMAKE_MATCH_1} STREQUAL ${rcutils_VERSION}))
-      # Create new file if file version != rcutils_VERSION
-      set(NEED_TO_CREATE_VERSION_FILE true)
-    endif()
+  # retrieve verson information from <package>.xml file
+  # call ament_package_xml() if it has not been called before
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
   endif()
-else()
-  # if the version file does not exist, create it
-  set(NEED_TO_CREATE_VERSION_FILE true)
-endif()
+  # parse version information from the version string
+  string(REGEX MATCH "([0-9]+\).([0-9]+)\.([0-9]+)" "" dummy ${${PROJECT_NAME}_VERSION})
+  set(${PROJECT_NAME}_VERSION_MAJOR ${CMAKE_MATCH_1})
+  set(${PROJECT_NAME}_VERSION_MINOR ${CMAKE_MATCH_2})
+  set(${PROJECT_NAME}_VERSION_PATCH ${CMAKE_MATCH_3})
 
-if(${NEED_TO_CREATE_VERSION_FILE})
-  message(STATUS "Create new version file for version ${rcutils_VERSION}")
-  file(MAKE_DIRECTORY ${TMP_INCLUDE_DIR})
-  # create the version.h file
-  configure_file("resource/version.h.in" ${RCUTILS_VERSION_FILE_NAME} NEWLINE_STYLE UNIX)
-else()
-    message(STATUS "Skip version file creation")
-endif()
+  # sanity checks
+  if("${${PROJECT_NAME}_VERSION_MAJOR}" STREQUAL "")
+    message(FATAL_ERROR "${PROJECT_NAME}_VERSION_MAJOR is empty or non-numeric, check <package>.XML")
+  endif()
+  if("${${PROJECT_NAME}_VERSION_MINOR}" STREQUAL "")
+    message(FATAL_ERROR "${PROJECT_NAME}_VERSION_MINOR is empty or non-numeric, check <package>.XML")
+  endif()
+  if("${${PROJECT_NAME}_VERSION_PATCH}" STREQUAL "")
+    message(FATAL_ERROR "${PROJECT_NAME}_VERSION_PATCH is empty or non-numeric, check <package>.XML")
+  endif()
+
+  # Check if the version file exist
+  if(EXISTS "${${PROJECT_NAME}_VERSION_FILE_NAME}")
+    # The file exists
+    # Check if it contains the same version
+    file(STRINGS ${${PROJECT_NAME}_VERSION_FILE_NAME} VERSION_FILE_STRINGS REGEX "#define ${PROJECT_NAME}_VERSION_STR")
+    if(VERSION_FILE_STRINGS STREQUAL "")
+      set(NEED_TO_CREATE_VERSION_FILE TRUE)
+    else()
+      string(REGEX MATCH "^#define[ \t]+${PROJECT_NAME}_VERSION_STR[ \t]+\"([0-9]+\.[0-9]+\.[0-9]+)\"" "" dummy ${VERSION_FILE_STRINGS})
+      if(NOT (${CMAKE_MATCH_1} STREQUAL ${${PROJECT_NAME}_VERSION}))
+        # Create new file if file version != ${PROJECT_NAME}_VERSION
+        set(NEED_TO_CREATE_VERSION_FILE TRUE)
+      endif()
+    endif()
+  else()
+    # if the version file does not exist, create it
+    set(NEED_TO_CREATE_VERSION_FILE TRUE)
+  endif()
+
+  if(${NEED_TO_CREATE_VERSION_FILE})
+    message(STATUS "Create new version file for version ${${PROJECT_NAME}_VERSION}")
+    file(MAKE_DIRECTORY ${TMP_INCLUDE_DIR})
+    # create the version.h file
+    configure_file("resource/version.h.in" ${${PROJECT_NAME}_VERSION_FILE_NAME} NEWLINE_STYLE UNIX)
+  else()
+      message(STATUS "Skip version file creation")
+  endif()
+
+  install(
+    DIRECTORY ${TMP_INCLUDE_DIR}
+    DESTINATION include)
+endfunction()
+
+ament_cmake_version()
 
 add_library(
   ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,11 +124,11 @@ if(EXISTS "${RCUTILS_VERSION_FILE_NAME}")
   # The file exists
   # Check if it contains the same version
   file(STRINGS ${RCUTILS_VERSION_FILE_NAME} VERSION_FILE_STRINGS REGEX "#define RCUTILS_VERSION_STR")
-  if (VERSION_FILE_STRINGS STREQUAL "")
+  if(VERSION_FILE_STRINGS STREQUAL "")
     set(NEED_TO_CREATE_VERSION_FILE true)
   else()
     string(REGEX REPLACE "^#define[ \t]+RCUTILS_VERSION_STR[ \t]+\"([0-9]+\.[0-9]+\.[0-9]+)\"" "" dummy ${VERSION_FILE_STRINGS})
-    if (NOT (${CMAKE_MATCH_1} STREQUAL ${rcutils_VERSION}))
+    if(NOT (${CMAKE_MATCH_1} STREQUAL ${rcutils_VERSION}))
       # Create new file if file version != rcutils_VERSION
       set(NEED_TO_CREATE_VERSION_FILE true)
     endif()
@@ -138,7 +138,7 @@ else()
   set(NEED_TO_CREATE_VERSION_FILE true)
 endif()
 
-if (${NEED_TO_CREATE_VERSION_FILE})
+if(${NEED_TO_CREATE_VERSION_FILE})
   message(STATUS "Create new version file for version ${rcutils_VERSION}")
   file(MAKE_DIRECTORY ${TMP_INCLUDE_DIR})
   # create the version.h file

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,35 +94,57 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 # Create version file in build/<package>/include/<package> folder which is already in the include list
 set(TMP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME})
 set(RCUTILS_VERSION_FILE_NAME ${TMP_INCLUDE_DIR}/version.h)
-# if the version file does not exist, create its directory and the file itself
-if(NOT (EXISTS "${RCUTILS_VERSION_FILE_NAME}"))
+set(NEED_TO_CREATE_VERSION_FILE false)
+
+# retrieve verson information from <package>.xml file
+# call ament_package_xml() if it has not been called before
+if(NOT _AMENT_PACKAGE_NAME)
+  ament_package_xml()
+endif()
+# parse version information from the version string
+string(REGEX REPLACE "([0-9]+\).([0-9]+)\.([0-9]+)" "" dummy ${rcutils_VERSION})
+set(RCUTILS_VERSION_MAJOR ${CMAKE_MATCH_1})
+set(RCUTILS_VERSION_MINOR ${CMAKE_MATCH_2})
+set(RCUTILS_VERSION_PATCH ${CMAKE_MATCH_3})
+string(TIMESTAMP RCUTILS_VERSION_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
+
+# sanity checks
+if("${RCUTILS_VERSION_MAJOR}" STREQUAL "")
+  message(FATAL_ERROR "RCUTILS_VERSION_MAJOR is empty or non-numeric, check <package>.XML")
+endif()
+if("${RCUTILS_VERSION_MINOR}" STREQUAL "")
+  message(FATAL_ERROR "RCUTILS_VERSION_MINOR is empty or non-numeric, check <package>.XML")
+endif()
+if("${RCUTILS_VERSION_PATCH}" STREQUAL "")
+  message(FATAL_ERROR "RCUTILS_VERSION_PATCH is empty or non-numeric, check <package>.XML")
+endif()
+
+# Check if the version file exist
+if(EXISTS "${RCUTILS_VERSION_FILE_NAME}")
+  # The file exists
+  # Check if it contains the same version
+  file(STRINGS ${RCUTILS_VERSION_FILE_NAME} VERSION_FILE_STRINGS REGEX "#define RCUTILS_VERSION_STR")
+  if (VERSION_FILE_STRINGS STREQUAL "")
+    set(NEED_TO_CREATE_VERSION_FILE true)
+  else()
+    string(REGEX REPLACE "^#define[ \t]+RCUTILS_VERSION_STR[ \t]+\"([0-9]+\.[0-9]+\.[0-9]+)\"" "" dummy ${VERSION_FILE_STRINGS})
+    if (NOT (${CMAKE_MATCH_1} STREQUAL ${rcutils_VERSION}))
+      # Create new file if file version != rcutils_VERSION
+      set(NEED_TO_CREATE_VERSION_FILE true)
+    endif()
+  endif()
+else()
+  # if the version file does not exist, create it
+  set(NEED_TO_CREATE_VERSION_FILE true)
+endif()
+
+if (${NEED_TO_CREATE_VERSION_FILE})
+  message(STATUS "Create new version file for version ${rcutils_VERSION}")
   file(MAKE_DIRECTORY ${TMP_INCLUDE_DIR})
-
-  # retrieve verson information from <package>.xml file
-  # call ament_package_xml() if it has not been called before
-  if(NOT _AMENT_PACKAGE_NAME)
-    ament_package_xml()
-  endif()
-  # parse version information from the version string
-  string(REGEX REPLACE "([0-9]+\).([0-9]+)\.([0-9]+)" "" dummy ${rcutils_VERSION})
-  set(RCUTILS_VERSION_MAJOR ${CMAKE_MATCH_1})
-  set(RCUTILS_VERSION_MINOR ${CMAKE_MATCH_2})
-  set(RCUTILS_VERSION_PATCH ${CMAKE_MATCH_3})
-  string(TIMESTAMP RCUTILS_VERSION_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
-
-  # sanity checks
-  if("${RCUTILS_VERSION_MAJOR}" STREQUAL "")
-    message(FATAL_ERROR "RCUTILS_VERSION_MAJOR is empty or non-numeric, check <package>.XML")
-  endif()
-  if("${RCUTILS_VERSION_MINOR}" STREQUAL "")
-    message(FATAL_ERROR "RCUTILS_VERSION_MINOR is empty or non-numeric, check <package>.XML")
-  endif()
-  if("${RCUTILS_VERSION_PATCH}" STREQUAL "")
-    message(FATAL_ERROR "RCUTILS_VERSION_PATCH is empty or non-numeric, check <package>.XML")
-  endif()
-
   # create the version.h file
   configure_file("resource/version.h.in" ${RCUTILS_VERSION_FILE_NAME} NEWLINE_STYLE UNIX)
+else()
+    message(STATUS "Skip version file creation")
 endif()
 
 add_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,41 @@ list(APPEND rcutils_sources
   include/rcutils/logging_macros.h)
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
+###############################################################################
+# Create version file in build/<package>/include/<package> folder which is already in the include list
+set(TMP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_NAME})
+set(RCUTILS_VERSION_FILE_NAME ${TMP_INCLUDE_DIR}/version.h)
+# if the version file does not exist, create its directory and the file itself
+if(NOT (EXISTS "${RCUTILS_VERSION_FILE_NAME}"))
+  file(MAKE_DIRECTORY ${TMP_INCLUDE_DIR})
+
+  # retrieve verson information from <package>.xml file
+  # call ament_package_xml() if it has not been called before
+  if(NOT _AMENT_PACKAGE_NAME)
+    ament_package_xml()
+  endif()
+  # parse version information from the version string
+  string(REGEX REPLACE "([0-9]+\).([0-9]+)\.([0-9]+)" "" dummy ${rcutils_VERSION})
+  set(RCUTILS_VERSION_MAJOR ${CMAKE_MATCH_1})
+  set(RCUTILS_VERSION_MINOR ${CMAKE_MATCH_2})
+  set(RCUTILS_VERSION_PATCH ${CMAKE_MATCH_3})
+  string(TIMESTAMP RCUTILS_VERSION_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
+
+  # sanity checks
+  if("${RCUTILS_VERSION_MAJOR}" STREQUAL "")
+    message(FATAL_ERROR "RCUTILS_VERSION_MAJOR is empty or non-numeric, check <package>.XML")
+  endif()
+  if("${RCUTILS_VERSION_MINOR}" STREQUAL "")
+    message(FATAL_ERROR "RCUTILS_VERSION_MINOR is empty or non-numeric, check <package>.XML")
+  endif()
+  if("${RCUTILS_VERSION_PATCH}" STREQUAL "")
+    message(FATAL_ERROR "RCUTILS_VERSION_PATCH is empty or non-numeric, check <package>.XML")
+  endif()
+
+  # create the version.h file
+  configure_file("resource/version.h.in" ${RCUTILS_VERSION_FILE_NAME} NEWLINE_STYLE UNIX)
+endif()
+
 add_library(
   ${PROJECT_NAME}
   ${rcutils_sources})
@@ -342,6 +377,13 @@ if(BUILD_TESTING)
   )
   if(TARGET test_hash_map)
     target_link_libraries(test_hash_map ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_version_header
+    test/test_version_header.cpp
+  )
+  if(TARGET test_version_header)
+    target_link_libraries(test_version_header ${PROJECT_NAME})
   endif()
 endif()
 

--- a/resource/version.h.in
+++ b/resource/version.h.in
@@ -15,21 +15,17 @@
 #ifndef RCUTILS__VERSION_H_
 #define RCUTILS__VERSION_H_
 
-/// \def RCUTILS_VERSION_TIMESTAMP
-/// Defines version file generation time
-#define RCUTILS_VERSION_TIMESTAMP "@RCUTILS_VERSION_TIMESTAMP@"
-
 /// \def RCUTILS_VERSION_MAJOR
 /// Defines RCUTILS major version number
-#define RCUTILS_VERSION_MAJOR (@RCUTILS_VERSION_MAJOR@)
+#define RCUTILS_VERSION_MAJOR (@rcutils_VERSION_MAJOR@)
 
 /// \def RCUTILS_VERSION_MINOR
 /// Defines RCUTILS minor version number
-#define RCUTILS_VERSION_MINOR (@RCUTILS_VERSION_MINOR@)
+#define RCUTILS_VERSION_MINOR (@rcutils_VERSION_MINOR@)
 
 /// \def RCUTILS_VERSION_PATCH
 /// Defines RCUTILS version patch number
-#define RCUTILS_VERSION_PATCH (@RCUTILS_VERSION_PATCH@)
+#define RCUTILS_VERSION_PATCH (@rcutils_VERSION_PATCH@)
 
 /// \def RCUTILS_VERSION_STR
 /// Defines RCUTILS version string

--- a/resource/version.h.in
+++ b/resource/version.h.in
@@ -1,0 +1,38 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__VERSION_H_
+#define RCUTILS__VERSION_H_
+
+/// \def RCUTILS_VERSION_TIMESTAMP
+/// Defines version file generation time
+#define RCUTILS_VERSION_TIMESTAMP "@RCUTILS_VERSION_TIMESTAMP@"
+
+/// \def RCUTILS_VERSION_MAJOR
+/// Defines RCUTILS major version number
+#define RCUTILS_VERSION_MAJOR (@RCUTILS_VERSION_MAJOR@)
+
+/// \def RCUTILS_VERSION_MINOR
+/// Defines RCUTILS minor version number
+#define RCUTILS_VERSION_MINOR (@RCUTILS_VERSION_MINOR@)
+
+/// \def RCUTILS_VERSION_PATCH
+/// Defines RCUTILS version patch number
+#define RCUTILS_VERSION_PATCH (@RCUTILS_VERSION_PATCH@)
+
+/// \def RCUTILS_VERSION_STR
+/// Defines RCUTILS version string
+#define RCUTILS_VERSION_STR "@rcutils_VERSION@"
+
+#endif  // RCUTILS__VERSION_H_"

--- a/test/test_version_header.cpp
+++ b/test/test_version_header.cpp
@@ -17,12 +17,6 @@
 #include <string>
 
 TEST(test_version_header, test_version_macros) {
-#ifdef RCUTILS_VERSION_TIMESTAMP
-  EXPECT_NE(std::strlen(RCUTILS_VERSION_TIMESTAMP), 0);
-#else  // RCUTILS_VERSION_TIMESTAMP
-  EXPECT_TRUE(false);
-#endif  // RCUTILS_VERSION_TIMESTAMP
-
 #ifdef RCUTILS_VERSION_MAJOR
   EXPECT_GE(RCUTILS_VERSION_MAJOR, 0);
 #else  // RCUTILS_VERSION_MAJOR

--- a/test/test_version_header.cpp
+++ b/test/test_version_header.cpp
@@ -14,7 +14,7 @@
 
 #include <gtest/gtest.h>
 #include <rcutils/version.h>
-#include <cstring>
+#include <string>
 
 TEST(test_version_header, test_version_macros) {
 #ifdef RCUTILS_VERSION_TIMESTAMP

--- a/test/test_version_header.cpp
+++ b/test/test_version_header.cpp
@@ -1,0 +1,49 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <rcutils/version.h>
+#include <cstring>
+
+TEST(test_version_header, test_version_macros) {
+#ifdef RCUTILS_VERSION_TIMESTAMP
+  EXPECT_NE(std::strlen(RCUTILS_VERSION_TIMESTAMP), 0);
+#else  // RCUTILS_VERSION_TIMESTAMP
+  EXPECT_TRUE(false);
+#endif  // RCUTILS_VERSION_TIMESTAMP
+
+#ifdef RCUTILS_VERSION_MAJOR
+  EXPECT_GE(RCUTILS_VERSION_MAJOR, 0);
+#else  // RCUTILS_VERSION_MAJOR
+  EXPECT_TRUE(false);
+#endif  // RCUTILS_VERSION_MAJOR
+
+#ifdef RCUTILS_VERSION_MINOR
+  EXPECT_GE(RCUTILS_VERSION_MINOR, 0);
+#else  // RCUTILS_VERSION_MINOR
+  EXPECT_TRUE(false);
+#endif  // RCUTILS_VERSION_MINOR
+
+#ifdef RCUTILS_VERSION_PATCH
+  EXPECT_GE(RCUTILS_VERSION_PATCH, 0);
+#else  // RCUTILS_VERSION_PATCH
+  EXPECT_TRUE(false);
+#endif  // RCUTILS_VERSION_PATCH
+
+#ifdef RCUTILS_VERSION_STR
+  EXPECT_NE(std::strlen(RCUTILS_VERSION_STR), 0);
+#else  // RCUTILS_VERSION_STR
+  EXPECT_TRUE(false);
+#endif  // RCUTILS_VERSION_STR
+}

--- a/test/test_version_header.cpp
+++ b/test/test_version_header.cpp
@@ -42,7 +42,12 @@ TEST(test_version_header, test_version_macros) {
 #endif  // RCUTILS_VERSION_PATCH
 
 #ifdef RCUTILS_VERSION_STR
-  EXPECT_NE(std::strlen(RCUTILS_VERSION_STR), 0);
+  std::string version_str = std::to_string(RCUTILS_VERSION_MAJOR);
+  version_str += ".";
+  version_str += std::to_string(RCUTILS_VERSION_MINOR);
+  version_str += ".";
+  version_str += std::to_string(RCUTILS_VERSION_PATCH);
+  EXPECT_STREQ(version_str.c_str(), RCUTILS_VERSION_STR);
 #else  // RCUTILS_VERSION_STR
   EXPECT_TRUE(false);
 #endif  // RCUTILS_VERSION_STR


### PR DESCRIPTION
Fixes #174 

This pull request introduces `inluce/rcutils/version.h` file that contains version information.

To prevent full compilations during `rcutils` development, the file created only once and not being re-generated if already exists in the build folder.

Example of the generated version.h file:
```c
// Copyright 2015 Open Source Robotics Foundation, Inc.
//
// Licensed under the Apache License, Version 2.0 (the "License");
// you may not use this file except in compliance with the License.
// You may obtain a copy of the License at
//
//     http://www.apache.org/licenses/LICENSE-2.0
//
// Unless required by applicable law or agreed to in writing, software
// distributed under the License is distributed on an "AS IS" BASIS,
// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
// See the License for the specific language governing permissions and
// limitations under the License.

#ifndef RCUTILS__VERSION_H_
#define RCUTILS__VERSION_H_

/// \def RCUTILS_VERSION_TIMESTAMP
/// Defines version file generation time
#define RCUTILS_VERSION_TIMESTAMP "2019-08-12T20:41:01Z"

/// \def RCUTILS_VERSION_MAJOR
/// Defines RCUTILS major version number
#define RCUTILS_VERSION_MAJOR (0)

/// \def RCUTILS_VERSION_MINOR
/// Defines RCUTILS minor version number
#define RCUTILS_VERSION_MINOR (7)

/// \def RCUTILS_VERSION_PATCH
/// Defines RCUTILS version patch number
#define RCUTILS_VERSION_PATCH (3)

/// \def RCUTILS_VERSION_STR
/// Defines RCUTILS version string
#define RCUTILS_VERSION_STR "0.7.3"

#endif  // RCUTILS__VERSION_H_"
```