### PR TITLE
Make g_rcutils_log_severity_names public and immutable.

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -172,7 +172,8 @@ enum RCUTILS_LOG_SEVERITY
 };
 
 /// The names of severity levels.
-extern const char * g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1];
+RCUTILS_PUBLIC
+extern const char * const g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATAL + 1];
 
 /// Get a severity value from its string representation (e.g. DEBUG).
 /**

--- a/src/logging.c
+++ b/src/logging.c
@@ -43,7 +43,7 @@ extern "C"
 
 #define RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN (2048)
 
-const char * g_rcutils_log_severity_names[] = {
+const char * const g_rcutils_log_severity_names[] = {
   [RCUTILS_LOG_SEVERITY_UNSET] = "UNSET",
   [RCUTILS_LOG_SEVERITY_DEBUG] = "DEBUG",
   [RCUTILS_LOG_SEVERITY_INFO] = "INFO",


### PR DESCRIPTION
Precisely what the title says. Fully exposing it and making it immutable for downstream packages to use. Needed by https://github.com/ros2/rcl/pull/496.