### PR TITLE
Modify rcutils_getenv to be thread safe

### DIFF
--- a/include/rcutils/get_env.h
+++ b/include/rcutils/get_env.h
@@ -49,8 +49,6 @@ extern "C"
  *
  * Environment variables will be truncated at 2048 characters on Windows.
  *
- * This function is not thread-safe.
- *
  * \param[in] env_name the name of the environment variable
  * \param[out] env_value pointer to the value cstring, or "" if unset
  * \return NULL on success (success can be returning an empty string)

--- a/include/rcutils/thread.h
+++ b/include/rcutils/thread.h
@@ -1,0 +1,33 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__THREAD_H_
+#define RCUTILS__THREAD_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef _WIN32
+# define THREAD_LOCAL_STORAGE __thread
+#else
+# define THREAD_LOCAL_STORAGE __declspec(thread)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__THREAD_H_

--- a/src/get_env.c
+++ b/src/get_env.c
@@ -21,10 +21,11 @@ extern "C"
 #include <stdlib.h>
 
 #include "rcutils/get_env.h"
+#include "rcutils/thread.h"
 
 #ifdef _WIN32
 # define WINDOWS_ENV_BUFFER_SIZE 2048
-static char __env_buffer[WINDOWS_ENV_BUFFER_SIZE];
+THREAD_LOCAL_STORAGE static char __env_buffer[WINDOWS_ENV_BUFFER_SIZE];
 #endif  // _WIN32
 
 


### PR DESCRIPTION
Complements https://github.com/ros2/rcl/pull/502

Documentation about thread local storage:
- https://gcc.gnu.org/onlinedocs/gcc-3.3/gcc/Thread-Local.html
- https://docs.microsoft.com/en-us/cpp/cpp/thread?view=vs-2019
- https://clang.llvm.org/docs/AttributeReference.html#id289