### PR TITLE
Replace ready_fn with ReadyToTest action

### DIFF
--- a/test/test_logging_long_messages.py
+++ b/test/test_logging_long_messages.py
@@ -17,13 +17,13 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     # Set the output format to a "verbose" format that is expected by the executable output
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = \
@@ -37,7 +37,7 @@ def generate_test_description(ready_fn):
     ))
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, {'process_name': process_name}
 

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -17,13 +17,13 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     processes_to_test = []
 
     launch_description = LaunchDescription()
@@ -71,7 +71,7 @@ def generate_test_description(ready_fn):
     processes_to_test.append(name)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
 
     return launch_description, {'processes_to_test': processes_to_test}


### PR DESCRIPTION
The ready_fn will be deprecated in the future in favor of the ReadyToTest() action in launch_testing. See ros2/launch#346 (comment) for background information

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>