### PR TITLE
Use Win32 wrapper around 64 bit atomic operations

### DIFF
--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -208,7 +208,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedCompareExchange64((LONGLONG *) object, desired, *expected); \
+        out = InterlockedCompareExchange64((LONGLONG *) object, desired, *expected); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedCompareExchange((LONG *) object, desired, *expected); \
@@ -239,7 +239,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedExchange64((LONGLONG *) object, desired); \
+        out = InterlockedExchange64((LONGLONG *) object, desired); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedExchange((LONG *) object, desired); \
@@ -267,7 +267,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedExchangeAdd64((LONGLONG *) object, operand); \
+        out = InterlockedExchangeAdd64((LONGLONG *) object, operand); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedExchangeAdd((LONG *) object, operand); \
@@ -295,7 +295,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedAnd64((LONGLONG *) object, operand); \
+        out = InterlockedAnd64((LONGLONG *) object, operand); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedAnd((LONG *) object, operand); \
@@ -323,7 +323,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedOr64((LONGLONG *) object, operand); \
+        out = InterlockedOr64((LONGLONG *) object, operand); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedOr((LONG *) object, operand); \
@@ -354,7 +354,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedXor64((LONGLONG *) object, operand); \
+        out = InterlockedXor64((LONGLONG *) object, operand); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedXor((LONG *) object, operand); \
@@ -382,7 +382,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   do { \
     switch (sizeof(out)) { \
       case sizeof(uint64_t): \
-        out = _InterlockedExchangeAdd64((LONGLONG *) object, 0); \
+        out = InterlockedExchangeAdd64((LONGLONG *) object, 0); \
         break; \
       case sizeof(uint32_t): \
         out = _InterlockedExchangeAdd((LONG *) object, 0); \


### PR DESCRIPTION
64 bit comiler intrinsics are unavailable on x86 and ARM platforms in
MSVC. This change uses the Win32/UWP wrapping API for the 64 bit
atomics. Per documentation on MSDN, the functions will leverage compiler
intrinsics if available. All other intrinsics used in this file are available on x64, x86, and ARM versions of MSVC and pose no issue.

I've tested this fix against Dashing & Crystal as well -- please consider for patches.