### PR TITLE
changing default logging format to include timestamp

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -62,7 +62,8 @@ enum rcutils_colorized_output
 bool g_rcutils_logging_initialized = false;
 
 char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
-static const char * g_rcutils_logging_default_output_format = "[{severity}] [{name}]: {message}";
+static const char * g_rcutils_logging_default_output_format =
+  "[{time}]: [{severity}] [{name}]: {message}";
 
 static rcutils_allocator_t g_rcutils_logging_allocator;
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -63,7 +63,7 @@ bool g_rcutils_logging_initialized = false;
 
 char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
 static const char * g_rcutils_logging_default_output_format =
-  "[{time}]: [{severity}] [{name}]: {message}";
+  "[{severity}] [{time}] [{name}]: {message}";
 
 static rcutils_allocator_t g_rcutils_logging_allocator;
 


### PR DESCRIPTION
Covers https://github.com/ros2/rcutils/issues/189

Adds a timestamp to the default logging format. I think this is a reasonable default behavior.