### PR TITLE
fix type of logging feature keys

### DIFF
--- a/rcutils/logging.py
+++ b/rcutils/logging.py
@@ -102,11 +102,11 @@ class Feature:
 
 feature_combinations = OrderedDict((
     ((), Feature()),
-    (('named'), Feature(
+    (('named', ), Feature(
         params=name_params,
         args=name_args,
         doc_lines=name_doc_lines)),
-    (('once'), Feature(
+    (('once', ), Feature(
         params=None,
         args=once_args,
         doc_lines=once_doc_lines)),
@@ -114,7 +114,7 @@ feature_combinations = OrderedDict((
         params=name_params,
         args={**once_args, **name_args},
         doc_lines=once_doc_lines + name_doc_lines)),
-    (('expression'), Feature(
+    (('expression', ), Feature(
         params=expression_params,
         args=expression_args,
         doc_lines=expression_doc_lines)),
@@ -122,7 +122,7 @@ feature_combinations = OrderedDict((
         params=OrderedDict((*expression_params.items(), *name_params.items())),
         args={**expression_args, **name_args},
         doc_lines=expression_doc_lines + name_doc_lines)),
-    (('function'), Feature(
+    (('function', ), Feature(
         params=function_params,
         args=function_args,
         doc_lines=function_doc_lines)),
@@ -130,7 +130,7 @@ feature_combinations = OrderedDict((
         params=OrderedDict((*function_params.items(), *name_params.items())),
         args={**function_args, **name_args},
         doc_lines=function_doc_lines + name_doc_lines)),
-    (('skip_first'), Feature(
+    (('skip_first', ), Feature(
         params=None,
         args=skipfirst_args,
         doc_lines=skipfirst_doc_lines)),
@@ -138,7 +138,7 @@ feature_combinations = OrderedDict((
         params=name_params,
         args={**skipfirst_args, **name_args},
         doc_lines=skipfirst_doc_lines + name_doc_lines)),
-    (('throttle'), Feature(
+    (('throttle', ), Feature(
         params=throttle_params,
         args=throttle_args,
         doc_lines=throttle_doc_lines)),


### PR DESCRIPTION
All keys are supposed to be tuples. For the cases with a missing trailing comma they are actually strings.

Luckily we don't have any feature names which are a substring of another feature string atm. Otherwise this would have failed when checking `'name' in key`.