### PR TITLE
Fix race in rcutils launch_tests

### DIFF
--- a/test/test_logging_long_messages.py
+++ b/test/test_logging_long_messages.py
@@ -21,8 +21,10 @@ from launch.actions import ExecuteProcess
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
+import launch_testing.markers
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description():
     launch_description = LaunchDescription()
     # Set the output format to a "verbose" format that is expected by the executable output

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -21,8 +21,10 @@ from launch.actions import ExecuteProcess
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
+import launch_testing.markers
 
 
+@launch_testing.markers.keep_alive
 def generate_test_description():
     processes_to_test = []
 


### PR DESCRIPTION
  - The processes in these tests all self-terminate.  This causes a race with
    the active tests.  If the processes all terminate before the tests complete,
    launch_testing will treat it like an error.

  - You can repro this issue by putting the ReadyToTest action behind a TimerAction
    and delaying it a few seconds.

  - Fix is to explicitly decorate the launch description with the keep_alive marker

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>