### PR TITLE
Split visibility macro project independent logic

### DIFF
--- a/include/rcutils/visibility_control.h
+++ b/include/rcutils/visibility_control.h
@@ -15,44 +15,18 @@
 #ifndef RCUTILS__VISIBILITY_CONTROL_H_
 #define RCUTILS__VISIBILITY_CONTROL_H_
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+#include "rcutils/visibility_control_macros.h"
 
-// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
-//     https://gcc.gnu.org/wiki/Visibility
-
-#if defined _WIN32 || defined __CYGWIN__
-  #ifdef __GNUC__
-    #define RCUTILS_EXPORT __attribute__ ((dllexport))
-    #define RCUTILS_IMPORT __attribute__ ((dllimport))
-  #else
-    #define RCUTILS_EXPORT __declspec(dllexport)
-    #define RCUTILS_IMPORT __declspec(dllimport)
-  #endif
-  #ifdef RCUTILS_BUILDING_DLL
-    #define RCUTILS_PUBLIC RCUTILS_EXPORT
-  #else
-    #define RCUTILS_PUBLIC RCUTILS_IMPORT
-  #endif
-  #define RCUTILS_PUBLIC_TYPE RCUTILS_PUBLIC
-  #define RCUTILS_LOCAL
+#ifdef RCUTILS_BUILDING_DLL
+# define RCUTILS_PUBLIC RCUTILS_EXPORT
 #else
-  #define RCUTILS_EXPORT __attribute__ ((visibility("default")))
-  #define RCUTILS_IMPORT
-  #if __GNUC__ >= 4
-    #define RCUTILS_PUBLIC __attribute__ ((visibility("default")))
-    #define RCUTILS_LOCAL  __attribute__ ((visibility("hidden")))
-  #else
-    #define RCUTILS_PUBLIC
-    #define RCUTILS_LOCAL
-  #endif
-  #define RCUTILS_PUBLIC_TYPE
-#endif
+# define RCUTILS_PUBLIC RCUTILS_IMPORT
+#endif  // !RCUTILS_BUILDING_DLL
 
-#ifdef __cplusplus
-}
-#endif
+#if defined(_MSC_VER) || defined(__CYGWIN__)
+# define RCUTILS_PUBLIC_TYPE RCUTILS_PUBLIC
+#else  // defined(_MSC_VER) || defined(__CYGWIN__)
+# define RCUTILS_PUBLIC_TYPE
+#endif  // !defined(_MSC_VER) && !defined(__CYGWIN__)
 
 #endif  // RCUTILS__VISIBILITY_CONTROL_H_

--- a/include/rcutils/visibility_control_macros.h
+++ b/include/rcutils/visibility_control_macros.h
@@ -1,0 +1,65 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__VISIBILITY_CONTROL_MACROS_H_
+#define RCUTILS__VISIBILITY_CONTROL_MACROS_H_
+
+// Defines macros to express whether a symbol is localed, imported, or exported
+//
+// Those macros are compatible with GCC, clang, and Microsoft Visual C++. They
+// can be used to enforce which symbols of a library are publicly accessible.
+//
+// RCUTILS_IMPORT, RCUTILS_EXPORT, and RCUTILS_LOCAL are respectively declaring
+// an imported, exported, or local symbol.
+// RCUTILS_LOCAL can be used directly. However, RCUTILS_IMPORT, and
+// RCUTILS_EXPORT may not be used directly. Every project need to provide
+// an additional header called `visibility_macros.h` containing:
+//
+// #ifdef <project>_BUILDING_DLL
+// # define <project>_PUBLIC RCUTILS_EXPORT
+// #else
+// # define <project>_PUBLIC RCUTILS_IMPORT
+// #endif // !<project>_BUILDING_DLL
+// #define <project>_LOCAL RCUTILS_LOCAL
+//
+// ...where "<project>" has been replaced by the project name, such as
+// "MY_PROJECT".
+// Your project CMakeLists.txt should also contain the following statement:
+//
+// target_compile_definitions(<your library> PRIVATE "<project>_BUILDING_DLL")
+//
+// A public (exported) class should then be tagged as <project>_PUBLIC, whereas
+// a non-public class should be tagged with <project>_LOCAL.
+//
+// See GCC documentation: https://gcc.gnu.org/wiki/Visibility
+
+#if defined(_MSC_VER) || defined(__CYGWIN__)
+// Use the Windows syntax when compiling with Microsoft Visual C++.
+//
+// GCC on Windows also support this syntax. When compiling with cygwin,
+// prefer using dllimport/dllexport are the semantic of those flags is closer
+// to msvc++ behavior. See GCC documentation:
+// https://gcc.gnu.org/onlinedocs/gcc/Microsoft-Windows-Function-Attributes.html
+# define RCUTILS_IMPORT __declspec(dllimport)
+# define RCUTILS_EXPORT __declspec(dllexport)
+# define RCUTILS_LOCAL
+#else  // defined(_MSC_VER) || defined(__CYGWIN__)
+// On Linux, use the GCC syntax. This syntax is understood by other compilers
+// such as clang, icpc, and xlc++.
+# define RCUTILS_IMPORT __attribute__ ((visibility("default")))
+# define RCUTILS_EXPORT __attribute__ ((visibility("default")))
+# define RCUTILS_LOCAL  __attribute__ ((visibility("hidden")))
+#endif  // !defined(_MSC_VER) && !defined(__CYGWIN__)
+
+#endif  // RCUTILS__VISIBILITY_CONTROL_MACROS_H_

--- a/include/rcutils/visibility_control_macros.h
+++ b/include/rcutils/visibility_control_macros.h
@@ -15,34 +15,34 @@
 #ifndef RCUTILS__VISIBILITY_CONTROL_MACROS_H_
 #define RCUTILS__VISIBILITY_CONTROL_MACROS_H_
 
-// Defines macros to express whether a symbol is localed, imported, or exported
-//
-// Those macros are compatible with GCC, clang, and Microsoft Visual C++. They
-// can be used to enforce which symbols of a library are publicly accessible.
-//
-// RCUTILS_IMPORT, RCUTILS_EXPORT, and RCUTILS_LOCAL are respectively declaring
-// an imported, exported, or local symbol.
-// RCUTILS_LOCAL can be used directly. However, RCUTILS_IMPORT, and
-// RCUTILS_EXPORT may not be used directly. Every project need to provide
-// an additional header called `visibility_macros.h` containing:
-//
-// #ifdef <project>_BUILDING_DLL
-// # define <project>_PUBLIC RCUTILS_EXPORT
-// #else
-// # define <project>_PUBLIC RCUTILS_IMPORT
-// #endif // !<project>_BUILDING_DLL
-// #define <project>_LOCAL RCUTILS_LOCAL
-//
-// ...where "<project>" has been replaced by the project name, such as
-// "MY_PROJECT".
-// Your project CMakeLists.txt should also contain the following statement:
-//
-// target_compile_definitions(<your library> PRIVATE "<project>_BUILDING_DLL")
-//
-// A public (exported) class should then be tagged as <project>_PUBLIC, whereas
-// a non-public class should be tagged with <project>_LOCAL.
-//
-// See GCC documentation: https://gcc.gnu.org/wiki/Visibility
+/// Defines macros to express whether a symbol is localed, imported, or exported
+///
+/// Those macros are compatible with GCC, clang, and Microsoft Visual C++. They
+/// can be used to enforce which symbols of a library are publicly accessible.
+///
+/// RCUTILS_IMPORT, RCUTILS_EXPORT, and RCUTILS_LOCAL are respectively declaring
+/// an imported, exported, or local symbol.
+/// RCUTILS_LOCAL can be used directly. However, RCUTILS_IMPORT, and
+/// RCUTILS_EXPORT may not be used directly. Every project need to provide
+/// an additional header called `visibility_macros.h` containing:
+///
+/// #ifdef <project>_BUILDING_DLL
+/// # define <project>_PUBLIC RCUTILS_EXPORT
+/// #else
+/// # define <project>_PUBLIC RCUTILS_IMPORT
+/// #endif // !<project>_BUILDING_DLL
+/// #define <project>_LOCAL RCUTILS_LOCAL
+///
+/// ...where "<project>" has been replaced by the project name, such as
+/// "MY_PROJECT".
+/// Your project CMakeLists.txt should also contain the following statement:
+///
+/// target_compile_definitions(<your library> PRIVATE "<project>_BUILDING_DLL")
+///
+/// A public (exported) class should then be tagged as <project>_PUBLIC, whereas
+/// a non-public class should be tagged with <project>_LOCAL.
+///
+/// See GCC documentation: https://gcc.gnu.org/wiki/Visibility
 
 #if defined(_MSC_VER) || defined(__CYGWIN__)
 // Use the Windows syntax when compiling with Microsoft Visual C++.


### PR DESCRIPTION
Until now, all ROS 2 packages had a long visibility_control.h header
which is a copy-and-paste of the rcutils one.

This commit reduces the size of visibility_control.h by moving out into
a new header called visibility_control_macros.h the macros re-usable by
other packages.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>