### PR TITLE
All logging to the same stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(rcutils_sources
   src/snprintf.c
   src/split.c
   src/strdup.c
+  src/strerror.c
   src/string_array.c
   src/string_map.c
   src/time.c

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -37,7 +37,7 @@ extern "C"
  */
 RCUTILS_PUBLIC
 void
-rcutils_safe_strerror(char * buffer, size_t buffer_length);
+rcutils_strerror(char * buffer, size_t buffer_length);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -1,0 +1,33 @@
+// Copyright 2017 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__STRERROR_H_
+#define RCUTILS__STRERROR_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/visibility_control.h"
+
+RCUTILS_PUBLIC
+void
+rcutils_safe_strerror(char * buffer, size_t buffer_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__STRERROR_H_

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -23,7 +23,8 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// Retrieve the string corresponding to the last system error.
-/** This function retrieves the value of errno, and calls the system-specific
+/**
+ * This function retrieves the value of errno, and calls the system-specific
  * equivalent of `strerror` on it, storing the output in the provided buffer.
  * If the error message is longer than the buffer, it will be truncated.
  * The memory for the c-string buffer that is passed in must be managed by the

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Open Source Robotics Foundation, Inc.
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,18 @@ extern "C"
 
 #include "rcutils/visibility_control.h"
 
+/// Retrieve the string corresponding to the last system error.
+/* This function retrieves the value of errno, and calls the system-specific
+ * equivalent of `strerror` on it, storing the output in the provided buffer.
+ * If the error message is longer than the buffer, it will be truncated.
+ * The memory for the c-string buffer that is passed in must be managed by the
+ * caller.
+ *
+ * This function is thread-safe.
+ *
+ * \param[in/out] buffer the buffer in which to store the data
+ * \param[in] buffer_length the maximum length of the buffer
+ */
 RCUTILS_PUBLIC
 void
 rcutils_safe_strerror(char * buffer, size_t buffer_length);

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -23,7 +23,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// Retrieve the string corresponding to the last system error.
-/* This function retrieves the value of errno, and calls the system-specific
+/** This function retrieves the value of errno, and calls the system-specific
  * equivalent of `strerror` on it, storing the output in the provided buffer.
  * If the error message is longer than the buffer, it will be truncated.
  * The memory for the c-string buffer that is passed in must be managed by the

--- a/src/logging.c
+++ b/src/logging.c
@@ -92,14 +92,15 @@ enum rcutils_get_env_retval
   RCUTILS_GET_ENV_ERROR = -1,
   RCUTILS_GET_ENV_ZERO = 0,
   RCUTILS_GET_ENV_ONE = 1,
-  RCUTILS_GET_ENV_DEFAULT = 2,
+  RCUTILS_GET_ENV_EMPTY = 2,
 };
 
-// A utility function to get zero or one from an environment variable.  Returns
-// RCUTILS_GET_ENV_ERROR if we failed to get the environment variable or if it was
-// something we don't understand.  Return RCUTILS_GET_ENV_ZERO if the value in the
-// environment variable is "0", RCUTILS_GET_ENV_ONE if the value in the environment
-// variable is "1", or RCUTILS_GET_ENV_DEFAULT if the environment variables is empty.
+// A utility function to get zero or one from an environment variable.
+// Returns RCUTILS_GET_ENV_ERROR if we failed to get the environment variable
+// or if it was something we don't understand.
+// Return RCUTILS_GET_ENV_ZERO if the value in the environment variable is "0",
+// RCUTILS_GET_ENV_ONE if the value in the environment variable is "1", or
+// RCUTILS_GET_ENV_EMPTY if the environment variables is empty.
 static enum rcutils_get_env_retval rcutils_get_env_var_zero_or_one(
   const char * name, const char * zero_semantic,
   const char * one_semantic)
@@ -117,7 +118,7 @@ static enum rcutils_get_env_retval rcutils_get_env_var_zero_or_one(
   }
 
   if (strcmp(env_var_value, "") == 0) {
-    return RCUTILS_GET_ENV_DEFAULT;
+    return RCUTILS_GET_ENV_EMPTY;
   }
   if (strcmp(env_var_value, "0") == 0) {
     return RCUTILS_GET_ENV_ZERO;
@@ -155,7 +156,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
         fprintf(
           stderr,
           "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored.  "
-          "Please set RCUTILS_CONSOLE_USE_STDOUT and RCUTILS_CONSOLE_BUFFERED_STREAM "
+          "Please set RCUTILS_LOGGING_USE_STDOUT and RCUTILS_LOGGING_BUFFERED_STREAM "
           "to control the stream and the buffering of log messages.\n");
       }
     } else {
@@ -168,16 +169,16 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     }
 
     // Set the default output stream for all severities to stderr so that errors
-    // are propagated immediately.  The user can choose to set the output stream
-    // to stdout by setting the RCUTILS_CONSOLE_USE_STDOUT environment
-    // variable to 1.
+    // are propagated immediately.
+    // The user can choose to set the output stream to stdout by setting the
+    // RCUTILS_LOGGING_USE_STDOUT environment variable to 1.
     enum rcutils_get_env_retval retval = rcutils_get_env_var_zero_or_one(
-      "RCUTILS_CONSOLE_USE_STDOUT", "use stderr",
+      "RCUTILS_LOGGING_USE_STDOUT", "use stderr",
       "use stdout");
     switch (retval) {
       case RCUTILS_GET_ENV_ERROR:
         return RCUTILS_RET_INVALID_ARGUMENT;
-      case RCUTILS_GET_ENV_DEFAULT:
+      case RCUTILS_GET_ENV_EMPTY:
       case RCUTILS_GET_ENV_ZERO:
         g_output_stream = stderr;
         break;
@@ -187,17 +188,18 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     }
 
     // Allow the user to choose how buffering on the stream works by setting
-    // RCUTILS_CONSOLE_BUFFERED_STREAM.  With an empty environment variable, use the
-    // default of the stream.  With a value of 0, force the stream to be unbuffered.
-    // With a value of 1, force the stream to be buffered.
+    // RCUTILS_LOGGING_BUFFERED_STREAM.
+    // With an empty environment variable, use the default of the stream.
+    // With a value of 0, force the stream to be unbuffered.
+    // With a value of 1, force the stream to be line buffered.
     retval =
       rcutils_get_env_var_zero_or_one(
-      "RCUTILS_CONSOLE_BUFFERED_STREAM", "not buffered",
+      "RCUTILS_LOGGING_BUFFERED_STREAM", "not buffered",
       "buffered");
     switch (retval) {
       case RCUTILS_GET_ENV_ERROR:
         return RCUTILS_RET_INVALID_ARGUMENT;
-      case RCUTILS_GET_ENV_DEFAULT:
+      case RCUTILS_GET_ENV_EMPTY:
         break;
       case RCUTILS_GET_ENV_ZERO:
         if (setvbuf(g_output_stream, NULL, _IONBF, 0) != 0) {
@@ -229,7 +231,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     switch (retval) {
       case RCUTILS_GET_ENV_ERROR:
         return RCUTILS_RET_INVALID_ARGUMENT;
-      case RCUTILS_GET_ENV_DEFAULT:
+      case RCUTILS_GET_ENV_EMPTY:
         g_colorized_output = RCUTILS_COLORIZED_OUTPUT_AUTO;
         break;
       case RCUTILS_GET_ENV_ZERO:

--- a/src/logging.c
+++ b/src/logging.c
@@ -206,7 +206,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
       int mode = retval == RCUTILS_GET_ENV_ZERO ? _IONBF : _IOLBF;
       if (setvbuf(g_output_stream, NULL, mode, 0) != 0) {
         char error_string[1024];
-        rcutils_safe_strerror(error_string, sizeof(error_string));
+        rcutils_strerror(error_string, sizeof(error_string));
         fprintf(
           stderr, "Error setting stream buffering mode: %s\n", error_string);
         RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(

--- a/src/logging.c
+++ b/src/logging.c
@@ -39,6 +39,7 @@ extern "C"
 #include "rcutils/logging.h"
 #include "rcutils/snprintf.h"
 #include "rcutils/strdup.h"
+#include "rcutils/strerror.h"
 #include "rcutils/time.h"
 #include "rcutils/types/string_map.h"
 
@@ -200,21 +201,23 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
         break;
       case RCUTILS_GET_ENV_ZERO:
         if (setvbuf(g_output_stream, NULL, _IONBF, 0) != 0) {
+          char error_string[1024];
+          rcutils_safe_strerror(error_string, sizeof(error_string));
           fprintf(
-            stderr, "Error setting stream buffering mode: %s\n", strerror(errno));
+            stderr, "Error setting stream buffering mode: %s\n", error_string);
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Error setting stream buffering mode: %s", strerror(
-              errno));
+            "Error setting stream buffering mode: %s", error_string);
           return RCUTILS_RET_ERROR;
         }
         break;
       case RCUTILS_GET_ENV_ONE:
         if (setvbuf(g_output_stream, NULL, _IOLBF, 0) != 0) {
+          char error_string[1024];
+          rcutils_safe_strerror(error_string, sizeof(error_string));
           fprintf(
-            stderr, "Error setting stream buffering mode: %s\n", strerror(errno));
+            stderr, "Error setting stream buffering mode: %s\n", error_string);
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Error setting stream buffering mode: %s", strerror(
-              errno));
+            "Error setting stream buffering mode: %s", error_string);
           return RCUTILS_RET_ERROR;
         }
         break;

--- a/src/logging.c
+++ b/src/logging.c
@@ -109,7 +109,9 @@ static enum rcutils_get_env_retval rcutils_get_env_var_zero_or_one(
     fprintf(
       stderr, "Error getting environment variable "
       "%s: %s\n", name, ret_str);
-    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Error getting environment variable: %s", ret_str);
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Error getting environment variable %s: %s", name,
+      ret_str);
     return RCUTILS_GET_ENV_ERROR;
   }
 
@@ -144,6 +146,25 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
 
     g_rcutils_logging_output_handler = &rcutils_logging_console_output_handler;
     g_rcutils_logging_default_logger_level = RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL;
+
+    const char * line_buffered = NULL;
+    const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
+    if (NULL == ret_str) {
+      if (strcmp(line_buffered, "") != 0) {
+        fprintf(
+          stderr,
+          "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored.  "
+          "Please set RCUTILS_CONSOLE_USE_STDOUT and RCUTILS_CONSOLE_BUFFERED_STREAM "
+          "to control the stream and the buffering of log messages.\n");
+      }
+    } else {
+      fprintf(
+        stderr, "Error getting environment variable "
+        "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s\n", ret_str);
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Error getting environment variable RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s", ret_str);
+      return RCUTILS_RET_ERROR;
+    }
 
     // Set the default output stream for all severities to stderr so that errors
     // are propagated immediately.  The user can choose to set the output stream
@@ -205,7 +226,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
 
     // Check for the environment variable for custom output formatting
     const char * output_format;
-    const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_OUTPUT_FORMAT", &output_format);
+    ret_str = rcutils_get_env("RCUTILS_CONSOLE_OUTPUT_FORMAT", &output_format);
     if (NULL == ret_str && strcmp(output_format, "") != 0) {
       size_t chars_to_copy = strlen(output_format);
       if (chars_to_copy > RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN - 1) {

--- a/src/strerror.c
+++ b/src/strerror.c
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
-#include <string.h>
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+#include <errno.h>
+#include <string.h>
+
+#include "rcutils/strerror.h"
 
 void
 rcutils_safe_strerror(char * buffer, size_t buffer_length)

--- a/src/strerror.c
+++ b/src/strerror.c
@@ -1,0 +1,47 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void
+rcutils_safe_strerror(char * buffer, size_t buffer_length)
+{
+#if defined(_WIN32)
+  strerror_s(buffer, buffer_length, errno);
+#elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)
+  /* GNU-specific */
+  char * msg = strerror_r(errno, buffer, buffer_length);
+  if (msg != buffer) {
+    strncpy(buffer, msg, buffer_length);
+    buffer[buffer_length - 1] = '\0';
+  }
+#else
+  /* XSI-compliant */
+  int error_status = strerror_r(errno, buffer, buffer_length);
+  if (error_status != 0) {
+    strncpy(buffer, "Failed to get error", buffer_length);
+    buffer[buffer_length - 1] = '\0';
+  }
+#endif
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/strerror.c
+++ b/src/strerror.c
@@ -23,7 +23,7 @@ extern "C"
 #include "rcutils/strerror.h"
 
 void
-rcutils_safe_strerror(char * buffer, size_t buffer_length)
+rcutils_strerror(char * buffer, size_t buffer_length)
 {
 #if defined(_WIN32)
   strerror_s(buffer, buffer_length, errno);

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -92,7 +92,7 @@ class TestLoggingOutputFormatAfterShutdown(unittest.TestCase):
     def test_logging_output(self, proc_output, processes_to_test):
         """Test all executables output against expectations."""
         for process_name in processes_to_test:
-            launch_testing.asserts.assertInStdout(
+            launch_testing.asserts.assertInStderr(
                 proc_output,
                 expected_output=launch_testing.tools.expected_output_from_file(
                     path=os.path.join(os.path.dirname(__file__), process_name)


### PR DESCRIPTION
This PR is a rehash of the now-closed #181.  In particular, this PR proposes to make it so that all output from all logging levels go to the same stream.  This replicates the behavior of basically all other logging systems; see https://github.com/ros2/rcutils/pull/181#issuecomment-546553594 for details.

Compared to #181, this PR is now rebased on master, and has made it so that the stream that all output goes to is configurable.  The default is stderr/unbuffered (so that error messages go out right away), but if users want a very minor performance improvement, they can switch it to stdout/buffered by setting `RCUTILS_CONSOLE_LINE_BUFFERED=1`.

Unfortunately, the change to stderr by default means that a lot of tests in the ROS 2 core (and probably beyond) are going to start failing.  That's because those tests are typically trying to capture stdout output, and there is no longer any output there.  Solutions I can think of:

1.  Make the default stream stdout (failing tests isn't a great reason to do this, in my opinion).
1.  Change all of the failing tests to set `RCUTILS_CONSOLE_LINE_BUFFERED=1` (this will fix it in the core, but still leave downstream consumers with failing tests).
1.  Change launch_testing to capture stderr along with stdout.
1.  ???

@ros2/team Opinions on how to proceed with fixing tests appreciated.

@rotu FYI

Fixes #168