### PR TITLE
extra byte for files on Windows

### DIFF
--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -285,7 +285,13 @@ TEST_F(TestFilesystemFixture, calculate_directory_size) {
   char * path =
     rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
   size_t size = rcutils_calculate_directory_size(path, g_allocator);
+#ifdef WIN32
+  // Due to different line breaks on windows, we have one more byte in the file.
+  // See https://github.com/ros2/rcutils/issues/198
+  ASSERT_EQ(6u, size);
+#else
   ASSERT_EQ(5u, size);
+#endif
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
     g_allocator.deallocate(path, g_allocator.state);
   });
@@ -305,7 +311,13 @@ TEST_F(TestFilesystemFixture, calculate_file_size) {
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
     g_allocator.deallocate(path, g_allocator.state);
   });
+#ifdef WIN32
+  // Due to different line breaks on windows, we have one more byte in the file.
+  // See https://github.com/ros2/rcutils/issues/198
+  ASSERT_EQ(6u, size);
+#else
   ASSERT_EQ(5u, size);
+#endif
 
   char * non_existing_path =
     rcutils_join_path(this->test_path, "non_existing_file.txt", g_allocator);


### PR DESCRIPTION
fixes https://github.com/ros2/rcutils/issues/198

note: I opted for a simple `#ifdef WIN32` solution as it really just depends on how we checkout the file with git - whether LF get converted into CRLF. The actual functionality of the implementation seems to be sound.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9028)](http://ci.ros2.org/job/ci_linux/9028/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4787)](http://ci.ros2.org/job/ci_linux-aarch64/4787/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7388)](http://ci.ros2.org/job/ci_osx/7388/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8962)](http://ci.ros2.org/job/ci_windows/8962/)

Signed-off-by: Karsten Knese <karsten@openrobotics.org>