### PR TITLE
increase max length of env var value on Windows to 32767

### DIFF
--- a/src/get_env.c
+++ b/src/get_env.c
@@ -24,7 +24,9 @@ extern "C"
 
 #ifdef _WIN32
 # include <errno.h>
-# define WINDOWS_ENV_BUFFER_SIZE 2048
+// all environment variables live together in a single memory block
+// which has a limit of 32767 characters
+# define WINDOWS_ENV_BUFFER_SIZE 32767
 static char __env_buffer[WINDOWS_ENV_BUFFER_SIZE];
 #endif  // _WIN32
 


### PR DESCRIPTION
Trying to use `rcutils_get_env()` in ros2/rmw_implementation#57 fails since that package e.g. tries to get the environment variable `PATH` which exceeds the current limit of 2048 characters on the Jenkins CI nodes.

Therefore this PR raises the limit to the maximum size of the sum of all environment variables (see https://devblogs.microsoft.com/oldnewthing/20100203-00/?p=15083).

* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8999)](http://ci.ros2.org/job/ci_windows/8999/)