### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -167,7 +167,8 @@ rcutils_set_error_state(const char * error_string, const char * file, size_t lin
  * \param[in] error_return_type The type to return if the argument is `NULL`.
  */
 #define RCUTILS_CHECK_ARGUMENT_FOR_NULL(argument, error_return_type) \
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(argument, #argument " argument is null", \
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG( \
+    argument, #argument " argument is null", \
     return error_return_type)
 
 /// Check a value for null, with an error message and error statement.

--- a/src/char_array.c
+++ b/src/char_array.c
@@ -38,7 +38,8 @@ rcutils_char_array_init(
   const rcutils_allocator_t * allocator)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(char_array, RCUTILS_RET_ERROR);
-  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, "char array has no valid allocator",
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "char array has no valid allocator",
     return RCUTILS_RET_ERROR);
 
   char_array->owns_buffer = true;
@@ -67,7 +68,8 @@ rcutils_char_array_fini(rcutils_char_array_t * char_array)
 
   if (char_array->owns_buffer) {
     rcutils_allocator_t * allocator = &char_array->allocator;
-    RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, "char array has no valid allocator",
+    RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+      allocator, "char array has no valid allocator",
       return RCUTILS_RET_ERROR);
 
     allocator->deallocate(char_array->buffer, allocator->state);
@@ -91,7 +93,8 @@ rcutils_char_array_resize(rcutils_char_array_t * char_array, size_t new_size)
   }
 
   rcutils_allocator_t * allocator = &char_array->allocator;
-  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, "char array has no valid allocator",
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "char array has no valid allocator",
     return RCUTILS_RET_ERROR);
 
   if (new_size == char_array->buffer_capacity) {

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -102,12 +102,13 @@ __format_overwriting_error_state_message(
     size_t written = 0;
 
     // write the first static part of the error message
-    written = __rcutils_copy_string(offset, bytes_left,
-        "\n"
-        ">>> [rcutils|error_handling.c:" RCUTILS_STRINGIFY(__LINE__) "] rcutils_set_error_state()\n"
-        "This error state is being overwritten:\n"
-        "\n"
-        "  '");
+    written = __rcutils_copy_string(
+      offset, bytes_left,
+      "\n"
+      ">>> [rcutils|error_handling.c:" RCUTILS_STRINGIFY(__LINE__) "] rcutils_set_error_state()\n"
+      "This error state is being overwritten:\n"
+      "\n"
+      "  '");
     offset += written;
     bytes_left -= written;
     if (0 >= bytes_left) {break;}
@@ -120,12 +121,13 @@ __format_overwriting_error_state_message(
     if (0 >= bytes_left) {break;}
 
     // write the middle part of the state error message
-    written = __rcutils_copy_string(offset, bytes_left,
-        "'\n"
-        "\n"
-        "with this new error message:\n"
-        "\n"
-        "  '");
+    written = __rcutils_copy_string(
+      offset, bytes_left,
+      "'\n"
+      "\n"
+      "with this new error message:\n"
+      "\n"
+      "  '");
     offset += written;
     bytes_left -= written;
     if (0 >= bytes_left) {break;}
@@ -141,11 +143,12 @@ __format_overwriting_error_state_message(
     if (0 >= bytes_left) {break;}
 
     // write the last part of the state error message
-    written = __rcutils_copy_string(offset, bytes_left,
-        "'\n"
-        "\n"
-        "rcutils_reset_error() should be called after error handling to avoid this.\n"
-        "<<<\n");
+    written = __rcutils_copy_string(
+      offset, bytes_left,
+      "'\n"
+      "\n"
+      "rcutils_reset_error() should be called after error handling to avoid this.\n"
+      "<<<\n");
     bytes_left -= written;
   } while (0);
 

--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -162,8 +162,8 @@ static rcutils_ret_t hash_map_insert_entry(
 
   // If we have initialized this bucket yet then do so
   if (NULL == bucket->impl) {
-    ret = rcutils_array_list_init(bucket, BUCKET_INITIAL_CAP, sizeof(rcutils_hash_map_entry_t *),
-        allocator);
+    ret = rcutils_array_list_init(
+      bucket, BUCKET_INITIAL_CAP, sizeof(rcutils_hash_map_entry_t *), allocator);
   }
 
   if (RCUTILS_RET_OK == ret) {
@@ -220,8 +220,8 @@ static rcutils_ret_t hash_map_check_and_grow_map(rcutils_hash_map_t * hash_map)
     }
 
     // Cleanup the old map and swap in the new one
-    ret = hash_map_deallocate_map(hash_map->impl->map, hash_map->impl->capacity,
-        &hash_map->impl->allocator, false);
+    ret = hash_map_deallocate_map(
+      hash_map->impl->map, hash_map->impl->capacity, &hash_map->impl->allocator, false);
     // everything worked up to this point, so if we fail to dealloc the old map still set the new
     hash_map->impl->map = new_map;
     hash_map->impl->capacity = new_capacity;
@@ -286,8 +286,8 @@ rcutils_ret_t
 rcutils_hash_map_fini(rcutils_hash_map_t * hash_map)
 {
   HASH_MAP_VALIDATE_HASH_MAP(hash_map);
-  rcutils_ret_t ret = hash_map_deallocate_map(hash_map->impl->map, hash_map->impl->capacity,
-      &hash_map->impl->allocator, true);
+  rcutils_ret_t ret = hash_map_deallocate_map(
+    hash_map->impl->map, hash_map->impl->capacity, &hash_map->impl->allocator, true);
 
   if (RCUTILS_RET_OK == ret) {
     hash_map->impl->allocator.deallocate(hash_map->impl, hash_map->impl->allocator.state);

--- a/src/logging.c
+++ b/src/logging.c
@@ -107,13 +107,15 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
       if (strcmp(line_buffered, "1") == 0) {
         g_force_stdout_line_buffered = true;
       } else if (strcmp(line_buffered, "0") != 0 && strcmp(line_buffered, "") != 0) {
-        fprintf(stderr,
+        fprintf(
+          stderr,
           "Warning: unexpected value [%s] specified for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED. "
           "Default value 0 will be used. Valid values are 1 or 0.\n",
           line_buffered);
       }
     } else {
-      fprintf(stderr, "Error getting env. variable "
+      fprintf(
+        stderr, "Error getting env. variable "
         "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s\n", ret_str);
       ret = RCUTILS_RET_INVALID_ARGUMENT;
     }
@@ -159,7 +161,8 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
           ret_str);
         ret = RCUTILS_RET_INVALID_ARGUMENT;
       }
-      memcpy(g_rcutils_logging_output_format_string, g_rcutils_logging_default_output_format,
+      memcpy(
+        g_rcutils_logging_output_format_string, g_rcutils_logging_default_output_format,
         strlen(g_rcutils_logging_default_output_format) + 1);
     }
 
@@ -513,8 +516,8 @@ const char * expand_line_number(
   }
 
   // Even in the case of truncation the result will still be null-terminated.
-  int written = rcutils_snprintf(line_number_expansion, sizeof(line_number_expansion), "%zu",
-      location->line_number);
+  int written = rcutils_snprintf(
+    line_number_expansion, sizeof(line_number_expansion), "%zu", location->line_number);
   if (written < 0) {
     fprintf(stderr, "failed to format line number: '%zu'\n", location->line_number);
     return NULL;
@@ -764,7 +767,8 @@ rcutils_ret_t rcutils_logging_format_message(
     if (RCUTILS_RET_OK == status) { \
       status = rcutils_char_array_strncat(&output_array, color, strlen(color)); \
       if (RCUTILS_RET_OK != status) { \
-        fprintf(stderr, "Error: rcutils_char_array_strncat failed with: %d\n", \
+        fprintf( \
+          stderr, "Error: rcutils_char_array_strncat failed with: %d\n", \
           status); \
       } \
     } \
@@ -844,7 +848,8 @@ void rcutils_logging_console_output_handler(
     va_copy(args_clone, *args);
     status = rcutils_char_array_vsprintf(&msg_array, format, args_clone);
     if (RCUTILS_RET_OK != status) {
-      fprintf(stderr, "Error: rcutils_char_array_vsprintf failed with: %d\n",
+      fprintf(
+        stderr, "Error: rcutils_char_array_vsprintf failed with: %d\n",
         status);
     }
     va_end(args_clone);
@@ -854,7 +859,8 @@ void rcutils_logging_console_output_handler(
     status = rcutils_logging_format_message(
       location, severity, name, timestamp, msg_array.buffer, &output_array);
     if (RCUTILS_RET_OK != status) {
-      fprintf(stderr, "Error: rcutils_logging_format_message failed with: %d\n",
+      fprintf(
+        stderr, "Error: rcutils_logging_format_message failed with: %d\n",
         status);
     }
   }
@@ -869,7 +875,8 @@ void rcutils_logging_console_output_handler(
       int flush_result = fflush(stream);
       if (flush_result != 0 && !g_stdout_flush_failure_reported) {
         g_stdout_flush_failure_reported = true;
-        fprintf(stderr, "Error: failed to perform fflush on stdout, fflush return code is: %d\n",
+        fprintf(
+          stderr, "Error: failed to perform fflush on stdout, fflush return code is: %d\n",
           flush_result);
       }
     }

--- a/src/split.c
+++ b/src/split.c
@@ -189,7 +189,8 @@ rcutils_split_last(
       result_error = RCUTILS_RET_BAD_ALLOC;
       goto fail;
     }
-    snprintf(string_array->data[0], found_last + 1 - lhs_offset - inner_rhs_offset,
+    snprintf(
+      string_array->data[0], found_last + 1 - lhs_offset - inner_rhs_offset,
       "%s", str + lhs_offset);
 
     string_array->data[1] = allocator.allocate(
@@ -199,7 +200,8 @@ rcutils_split_last(
       result_error = RCUTILS_RET_BAD_ALLOC;
       goto fail;
     }
-    snprintf(string_array->data[1], string_size - found_last - rhs_offset, "%s",
+    snprintf(
+      string_array->data[1], string_size - found_last - rhs_offset, "%s",
       str + found_last + 1);
   }
 

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -63,7 +63,8 @@ TEST_F(CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION), test_default_allocat
   on_unexpected_free([&frees]() {frees++;});
 
   rcutils_allocator_t allocator;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     allocator = rcutils_get_default_allocator();
   });
   EXPECT_EQ(0u, mallocs);
@@ -72,23 +73,27 @@ TEST_F(CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION), test_default_allocat
   EXPECT_EQ(0u, frees);
 
   void * allocated_memory = nullptr;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     allocated_memory = allocator.allocate(1024, allocator.state);
   });
   EXPECT_EQ(1u, mallocs);
   EXPECT_NE(nullptr, allocated_memory);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     allocated_memory = allocator.reallocate(allocated_memory, 2048, allocator.state);
   });
   EXPECT_EQ(1u, reallocs);
   EXPECT_NE(nullptr, allocated_memory);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     allocator.deallocate(allocated_memory, allocator.state);
     allocated_memory = allocator.zero_allocate(1024, sizeof(void *), allocator.state);
   });
   EXPECT_EQ(1u, callocs);
   EXPECT_NE(nullptr, allocated_memory);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     allocator.deallocate(allocated_memory, allocator.state);
   });
   EXPECT_EQ(1u, mallocs);

--- a/test/test_error_handling.cpp
+++ b/test/test_error_handling.cpp
@@ -82,11 +82,13 @@ Stack trace (most recent call last):
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   const char * test_message = "test message";
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(test_message);
   });
   using ::testing::StartsWith;
@@ -94,7 +96,8 @@ Stack trace (most recent call last):
   rcutils_error_string_t error_string = rcutils_get_error_string();
   EXPECT_NO_MEMORY_OPERATIONS_END();
   ASSERT_THAT(error_string.str, StartsWith(test_message));
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }
@@ -104,12 +107,14 @@ TEST(test_error_handling, reset) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   {
     const char * test_message = "test message";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       RCUTILS_SET_ERROR_MSG(test_message);
     });
     using ::testing::StartsWith;
@@ -121,7 +126,8 @@ TEST(test_error_handling, reset) {
   rcutils_reset_error();
   {
     const char * test_message = "different message";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       RCUTILS_SET_ERROR_MSG(test_message);
     });
     using ::testing::StartsWith;
@@ -130,7 +136,8 @@ TEST(test_error_handling, reset) {
     EXPECT_NO_MEMORY_OPERATIONS_END();
     ASSERT_THAT(error_string.str, StartsWith(test_message));
   }
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   {
@@ -145,7 +152,8 @@ TEST(test_error_handling, reset) {
     EXPECT_NO_MEMORY_OPERATIONS_END();
     ASSERT_STREQ("error not set", error_string.str);
   }
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }
@@ -155,11 +163,13 @@ TEST(test_error_handling, invalid_arguments) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   printf("The following error from within error_handling.c is expected.\n");
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(NULL);
   });
   EXPECT_FALSE(rcutils_error_is_set());
@@ -171,7 +181,8 @@ TEST(test_error_handling, invalid_arguments) {
   }
 
   printf("The following error from within error_handling.c is expected.\n");
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_set_error_state("valid error message", NULL, 42);
   });
   EXPECT_FALSE(rcutils_error_is_set());
@@ -182,7 +193,8 @@ TEST(test_error_handling, invalid_arguments) {
     ASSERT_STREQ("error not set", error_string.str);
   }
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }
@@ -192,7 +204,8 @@ TEST(test_error_handling, empty) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   {
@@ -207,7 +220,8 @@ TEST(test_error_handling, empty) {
     EXPECT_NO_MEMORY_OPERATIONS_END();
     ASSERT_STREQ("error not set", error_string.str);
   }
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }
@@ -217,11 +231,13 @@ TEST(test_error_handling, recursive) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   const char * test_message = "test message";
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(test_message);
   });
   using ::testing::HasSubstr;
@@ -231,7 +247,8 @@ TEST(test_error_handling, recursive) {
     EXPECT_NO_MEMORY_OPERATIONS_END();
     ASSERT_THAT(error_string.str, HasSubstr(", at"));
   }
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(rcutils_get_error_string().str);
   });
   std::string err_msg;
@@ -252,11 +269,13 @@ TEST(test_error_handling, copy) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   const char * test_message = "test message";
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(test_message);
   });
   using ::testing::HasSubstr;
@@ -276,7 +295,8 @@ TEST(test_error_handling, copy) {
   EXPECT_NO_MEMORY_OPERATIONS_END();
   ASSERT_NE(nullptr, error_state);
   ASSERT_STREQ(test_message, error_state->message);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }
@@ -286,11 +306,13 @@ TEST(test_error_handling, overwrite) {
   rcutils_ret_t ret =
     rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
   ASSERT_EQ(ret, RCUTILS_RET_OK);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
   const char * test_message = "this is expected to cause a warning from error_handling.c";
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(test_message);
   });
   using ::testing::HasSubstr;
@@ -302,11 +324,13 @@ TEST(test_error_handling, overwrite) {
   // force an overwrite error
   const char * test_message2 = "and this too";
   printf("The following warning from error_handling.c is expected...\n");
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     RCUTILS_SET_ERROR_MSG(test_message2);
   });
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rcutils_reset_error();
   });
 }

--- a/test/test_error_handling_helpers.cpp
+++ b/test/test_error_handling_helpers.cpp
@@ -27,7 +27,8 @@ TEST(test_error_handling, copy_string) {
   size_t written;
 
   // normal truncation
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     written = __rcutils_copy_string(buffer, 3, "0123456789");
   });
   EXPECT_EQ(written, 2u);
@@ -35,7 +36,8 @@ TEST(test_error_handling, copy_string) {
   EXPECT_STREQ(buffer, "01");
 
   // normal truncation, 1 short of buffer length
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     written = __rcutils_copy_string(buffer, 9, "0123456789");
   });
   EXPECT_EQ(written, 8u);
@@ -43,7 +45,8 @@ TEST(test_error_handling, copy_string) {
   EXPECT_STREQ(buffer, "01234567");
 
   // input smaller than buffer, 1 short of buffer length
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     written = __rcutils_copy_string(buffer, 9, "");
   });
   EXPECT_EQ(written, 0u);
@@ -51,12 +54,14 @@ TEST(test_error_handling, copy_string) {
   EXPECT_STREQ(buffer, "");
 
   // copy where src and dst overlap (testing use of memmove vs memcpy)
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     written = __rcutils_copy_string(buffer, sizeof(buffer), "1234567890");
   });
   EXPECT_EQ(written, 9u);
   EXPECT_STREQ(buffer, "123456789");
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     written = __rcutils_copy_string(buffer, sizeof(buffer), buffer + 3);
   });
   EXPECT_EQ(written, 6u);
@@ -68,35 +73,40 @@ TEST(test_error_handling, reverse_str) {
   osrf_testing_tools_cpp::memory_tools::ScopedQuickstartGtest scoped_quickstart_gtest;
   {
     char buffer[] = "even";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_reverse_str(buffer, strnlen(buffer, sizeof(buffer)));
     });
     EXPECT_STREQ(buffer, "neve");
   }
   {
     char buffer[] = "reverseme";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_reverse_str(buffer, strnlen(buffer, sizeof(buffer)));
     });
     EXPECT_STREQ(buffer, "emesrever");
   }
   {
     char buffer[] = "a";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_reverse_str(buffer, strnlen(buffer, sizeof(buffer)));
     });
     EXPECT_STREQ(buffer, "a");
   }
   {
     char buffer[] = "reverseme";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_reverse_str(buffer, 3);
     });
     EXPECT_STREQ(buffer, "vererseme");
   }
   {
     char buffer[] = "doesntmatter";
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_reverse_str(buffer, 0);
     });
     EXPECT_STREQ(buffer, "doesntmatter");
@@ -108,7 +118,8 @@ TEST(test_error_handling, convert_uint64_t_into_c_str) {
   {
     uint64_t number = UINT64_MAX;
     char buffer[21];
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_convert_uint64_t_into_c_str(number, buffer, sizeof(buffer));
     });
     EXPECT_STREQ(buffer, "18446744073709551615");
@@ -116,7 +127,8 @@ TEST(test_error_handling, convert_uint64_t_into_c_str) {
   {
     uint64_t number = 0;
     char buffer[21];
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_convert_uint64_t_into_c_str(number, buffer, sizeof(buffer));
     });
     EXPECT_STREQ(buffer, "0");
@@ -124,7 +136,8 @@ TEST(test_error_handling, convert_uint64_t_into_c_str) {
   {
     uint64_t number = 42;
     char buffer[21];
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_convert_uint64_t_into_c_str(number, buffer, sizeof(buffer));
     });
     EXPECT_STREQ(buffer, "42");
@@ -132,7 +145,8 @@ TEST(test_error_handling, convert_uint64_t_into_c_str) {
   {
     uint64_t number = INT64_MAX;
     char buffer[21];
-    EXPECT_NO_MEMORY_OPERATIONS({
+    EXPECT_NO_MEMORY_OPERATIONS(
+    {
       __rcutils_convert_uint64_t_into_c_str(number, buffer, sizeof(buffer));
     });
     EXPECT_STREQ(buffer, "9223372036854775807");
@@ -144,7 +158,8 @@ TEST(test_error_handling, format_error_string) {
   rcutils_error_string_t error_string {""};
   rcutils_error_state_t error_state {"test error message", "/path/to/source", 42};
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     __rcutils_format_error_string(&error_string, &error_state);
   });
 }

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -47,7 +47,8 @@ TEST_F(TestFilesystemFixture, get_cwd_nullptr) {
 
 TEST_F(TestFilesystemFixture, join_path) {
   char * path = rcutils_join_path("foo", "bar", g_allocator);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     g_allocator.deallocate(path, g_allocator.state);
   });
 #ifdef _WIN32
@@ -62,7 +63,8 @@ TEST_F(TestFilesystemFixture, join_path) {
 TEST_F(TestFilesystemFixture, to_native_path) {
   {
     char * path = rcutils_to_native_path("/foo/bar/baz", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
 #ifdef _WIN32
@@ -75,7 +77,8 @@ TEST_F(TestFilesystemFixture, to_native_path) {
   }
   {
     char * path = rcutils_to_native_path("/foo//bar/baz", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
 #ifdef _WIN32
@@ -91,7 +94,8 @@ TEST_F(TestFilesystemFixture, to_native_path) {
 TEST_F(TestFilesystemFixture, exists) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -99,7 +103,8 @@ TEST_F(TestFilesystemFixture, exists) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -110,7 +115,8 @@ TEST_F(TestFilesystemFixture, exists) {
 TEST_F(TestFilesystemFixture, is_directory) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -118,7 +124,8 @@ TEST_F(TestFilesystemFixture, is_directory) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -129,7 +136,8 @@ TEST_F(TestFilesystemFixture, is_directory) {
 TEST_F(TestFilesystemFixture, is_file) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -137,7 +145,8 @@ TEST_F(TestFilesystemFixture, is_file) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -148,7 +157,8 @@ TEST_F(TestFilesystemFixture, is_file) {
 TEST_F(TestFilesystemFixture, is_readable) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -156,7 +166,8 @@ TEST_F(TestFilesystemFixture, is_readable) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -165,7 +176,8 @@ TEST_F(TestFilesystemFixture, is_readable) {
   {
     char * path =
       rcutils_join_path(this->test_path, "dummy_readable_writable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -173,7 +185,8 @@ TEST_F(TestFilesystemFixture, is_readable) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_nonexisting_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -184,7 +197,8 @@ TEST_F(TestFilesystemFixture, is_readable) {
 TEST_F(TestFilesystemFixture, is_writable) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -193,7 +207,8 @@ TEST_F(TestFilesystemFixture, is_writable) {
   {
     char * path =
       rcutils_join_path(this->test_path, "dummy_readable_writable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -201,7 +216,8 @@ TEST_F(TestFilesystemFixture, is_writable) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_nonexisting_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -212,7 +228,8 @@ TEST_F(TestFilesystemFixture, is_writable) {
 TEST_F(TestFilesystemFixture, is_readable_and_writable) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -221,7 +238,8 @@ TEST_F(TestFilesystemFixture, is_readable_and_writable) {
   {
     char * path =
       rcutils_join_path(this->test_path, "dummy_readable_writable_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -229,7 +247,8 @@ TEST_F(TestFilesystemFixture, is_readable_and_writable) {
   }
   {
     char * path = rcutils_join_path(this->test_path, "dummy_nonexisting_file.txt", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_FALSE(nullptr == path);
@@ -243,7 +262,8 @@ TEST_F(TestFilesystemFixture, mkdir) {
     char * path =
       rcutils_join_path(BUILD_DIR, "mkdir_test_dir", g_allocator);
     ASSERT_FALSE(nullptr == path);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_TRUE(rcutils_mkdir(path));
@@ -254,7 +274,8 @@ TEST_F(TestFilesystemFixture, mkdir) {
     char * path =
       rcutils_join_path(BUILD_DIR, "mkdir_test_dir", g_allocator);
     ASSERT_FALSE(nullptr == path);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path, g_allocator.state);
     });
     ASSERT_TRUE(rcutils_mkdir(path));
@@ -272,7 +293,8 @@ TEST_F(TestFilesystemFixture, mkdir) {
     ASSERT_FALSE(nullptr == path);
     char * path2 =
       rcutils_join_path(path, "mkdir_test_dir3", g_allocator);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       g_allocator.deallocate(path2, g_allocator.state);
       g_allocator.deallocate(path, g_allocator.state);
     });
@@ -292,14 +314,16 @@ TEST_F(TestFilesystemFixture, calculate_directory_size) {
 #else
   ASSERT_EQ(5u, size);
 #endif
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     g_allocator.deallocate(path, g_allocator.state);
   });
 
   char * non_existing_path = rcutils_join_path(this->test_path, "non_existing_folder", g_allocator);
   size = rcutils_calculate_directory_size(non_existing_path, g_allocator);
   ASSERT_EQ(0u, size);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     g_allocator.deallocate(non_existing_path, g_allocator.state);
   });
 }
@@ -308,7 +332,8 @@ TEST_F(TestFilesystemFixture, calculate_file_size) {
   char * path =
     rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
   size_t size = rcutils_get_file_size(path);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     g_allocator.deallocate(path, g_allocator.state);
   });
 #ifdef WIN32
@@ -323,7 +348,8 @@ TEST_F(TestFilesystemFixture, calculate_file_size) {
     rcutils_join_path(this->test_path, "non_existing_file.txt", g_allocator);
   size = rcutils_get_file_size(non_existing_path);
   ASSERT_EQ(0u, size);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     g_allocator.deallocate(non_existing_path, g_allocator.state);
   });
 }

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -64,8 +64,9 @@ protected:
   {
     allocator = rcutils_get_default_allocator();
     map = rcutils_get_zero_initialized_hash_map();
-    rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-        test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+    rcutils_ret_t ret = rcutils_hash_map_init(
+      &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
     EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
     rcutils_reset_error();
   }
@@ -81,58 +82,67 @@ protected:
 };
 
 TEST_F(HashMapBaseTest, init_map_NULL_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(NULL, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    NULL, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_initial_capacity_zero_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 0, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 0, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_key_size_zero_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, 0, sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, 0, sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_data_size_zero_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), 0,
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), 0,
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_hash_func_NULL_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      NULL, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    NULL, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_cmp_func_NULL_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, NULL, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, NULL, &allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_allocator_NULL_fails) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, NULL);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, NULL);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, init_map_success) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_hash_map_fini(&map);
 }
 
 TEST_F(HashMapBaseTest, fini_map_success) {
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_hash_map_fini(&map);
@@ -398,8 +408,9 @@ TEST_F(HashMapPreInitTest, get_next_key_and_data_working) {
 TEST_F(HashMapBaseTest, growing_the_map_beyond_initial_capacity) {
   size_t capacity = 0;
   uint32_t key = 22, data = 0;
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 2, sizeof(uint32_t), sizeof(uint32_t),
-      test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 2, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   for (uint32_t i = 0; i < 50; ++i) {
@@ -431,9 +442,10 @@ TEST_F(HashMapBaseTest, string_keys) {
   const char * key1 = "one";
   const char * key2 = "two";
   const char * lookup_key = "one";
-  rcutils_ret_t ret = rcutils_hash_map_init(&map, 10, sizeof(char *), sizeof(uint32_t),
-      rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func,
-      &allocator);
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, 10, sizeof(char *), sizeof(uint32_t),
+    rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func,
+    &allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_hash_map_set(&map, &key1, &data);

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -30,7 +30,8 @@
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging_initialization) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
   });
   EXPECT_TRUE(g_rcutils_logging_initialized);
@@ -53,7 +54,8 @@ LogEvent g_last_log_event;
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
   });
   EXPECT_TRUE(g_rcutils_logging_initialized);
@@ -167,7 +169,8 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
   });
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);
@@ -225,7 +228,8 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
 
 TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severity_hierarchy) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
   });
 

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -141,9 +141,11 @@ TEST_F(TestStringMap, getters_capacity_null_capacity) {
   ASSERT_EQ(RCUTILS_RET_OK, ret);
   rcutils_reset_error();
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    EXPECT_EQ(RCUTILS_RET_OK,
-    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(
+      RCUTILS_RET_OK,
+      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
     rcutils_reset_error();
   });
 
@@ -158,9 +160,11 @@ TEST_F(TestStringMap, getters_size_null_size) {
   ASSERT_EQ(RCUTILS_RET_OK, ret);
   rcutils_reset_error();
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    EXPECT_EQ(RCUTILS_RET_OK,
-    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(
+      RCUTILS_RET_OK,
+      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
     rcutils_reset_error();
   });
 
@@ -174,9 +178,11 @@ TEST_F(TestStringMap, getters_initialize_to_zero) {
   ret = rcutils_string_map_init(&string_map, 0, allocator);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    EXPECT_EQ(RCUTILS_RET_OK,
-    rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(
+      RCUTILS_RET_OK,
+      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
     rcutils_reset_error();
   });
 
@@ -202,9 +208,11 @@ TEST(test_string_map, reserve_and_clear) {
     ret = rcutils_string_map_init(&string_map, 10, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -227,9 +235,11 @@ TEST(test_string_map, reserve_and_clear) {
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -271,9 +281,11 @@ TEST(test_string_map, reserve_and_clear) {
     ret = rcutils_string_map_init(&string_map, 10, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -366,9 +378,11 @@ TEST(test_string_map, reserve_and_clear) {
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -410,9 +424,11 @@ TEST(test_string_map, reserve_and_clear) {
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -490,9 +506,11 @@ TEST(test_string_map, set_no_resize) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 1, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -539,9 +557,11 @@ TEST(test_string_map, set_no_resize) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -623,10 +643,12 @@ TEST(test_string_map, set_no_resize) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 1, failing_allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       set_failing_allocator_is_failing(failing_allocator, false);
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -648,9 +670,11 @@ TEST(test_string_map, set_no_resize) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -665,9 +689,11 @@ TEST(test_string_map, set_no_resize) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -687,9 +713,11 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -732,9 +760,11 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 1, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -815,9 +845,11 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -899,10 +931,12 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 1, failing_allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       set_failing_allocator_is_failing(failing_allocator, false);
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -924,9 +958,11 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -940,9 +976,11 @@ TEST(test_string_map, set) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -961,9 +999,11 @@ TEST(test_string_map, key_exists) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -998,9 +1038,11 @@ TEST(test_string_map, key_exists) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1013,9 +1055,11 @@ TEST(test_string_map, key_exists) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1033,9 +1077,11 @@ TEST(test_string_map, key_existsn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1059,9 +1105,11 @@ TEST(test_string_map, unset) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 3, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1178,9 +1226,11 @@ TEST(test_string_map, unset) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 10, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1194,9 +1244,11 @@ TEST(test_string_map, unset) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1210,9 +1262,11 @@ TEST(test_string_map, unset) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1236,9 +1290,11 @@ TEST(test_string_map, get) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1256,9 +1312,11 @@ TEST(test_string_map, get) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1273,9 +1331,11 @@ TEST(test_string_map, get) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1287,9 +1347,11 @@ TEST(test_string_map, get) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1306,9 +1368,11 @@ TEST(test_string_map, get) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1328,9 +1392,11 @@ TEST(test_string_map, getn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1348,9 +1414,11 @@ TEST(test_string_map, getn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1365,9 +1433,11 @@ TEST(test_string_map, getn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1379,9 +1449,11 @@ TEST(test_string_map, getn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1398,9 +1470,11 @@ TEST(test_string_map, getn) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1420,9 +1494,11 @@ TEST(test_string_map, get_next_key) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 4, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1444,9 +1520,11 @@ TEST(test_string_map, get_next_key) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1468,9 +1546,11 @@ TEST(test_string_map, get_next_key) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1483,9 +1563,11 @@ TEST(test_string_map, get_next_key) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 4, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1518,9 +1600,11 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t src_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&src_string_map, 4, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1532,9 +1616,11 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t dst_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&dst_string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1550,18 +1636,22 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t src_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&src_string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
     rcutils_string_map_t dst_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&dst_string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1574,18 +1664,22 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t src_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&src_string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
     rcutils_string_map_t dst_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&dst_string_map, 4, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1606,9 +1700,11 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t src_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&src_string_map, 0, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&src_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1620,9 +1716,11 @@ TEST(test_string_map, copy) {
     rcutils_string_map_t dst_string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&dst_string_map, 4, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&dst_string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1649,9 +1747,11 @@ TEST(test_string_map, strange_keys) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 
@@ -1666,9 +1766,11 @@ TEST(test_string_map, strange_keys) {
     rcutils_string_map_t string_map = rcutils_get_zero_initialized_string_map();
     ret = rcutils_string_map_init(&string_map, 2, allocator);
     ASSERT_EQ(RCUTILS_RET_OK, ret);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-      EXPECT_EQ(RCUTILS_RET_OK,
-      rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(
+        RCUTILS_RET_OK,
+        rcutils_string_map_fini(&string_map)) << rcutils_get_error_string().str;
       rcutils_reset_error();
     });
 

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -59,7 +59,8 @@ TEST_F(TestTimeFixture, test_rcutils_system_time_now) {
   rcutils_reset_error();
   // Check for normal operation (not allowed to alloc).
   rcutils_time_point_value_t now = 0;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     ret = rcutils_system_time_now(&now);
   });
   EXPECT_EQ(ret, RCUTILS_RET_OK) << rcutils_get_error_string().str;
@@ -86,14 +87,16 @@ TEST_F(TestTimeFixture, test_rcutils_steady_time_now) {
   rcutils_reset_error();
   // Check for normal operation (not allowed to alloc).
   rcutils_time_point_value_t now = 0;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     ret = rcutils_steady_time_now(&now);
   });
   EXPECT_EQ(ret, RCUTILS_RET_OK) << rcutils_get_error_string().str;
   EXPECT_NE(0u, now);
   // Compare to std::chrono::steady_clock difference of two times (within a second).
   now = 0;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     ret = rcutils_steady_time_now(&now);
   });
   std::chrono::steady_clock::time_point now_sc = std::chrono::steady_clock::now();
@@ -102,7 +105,8 @@ TEST_F(TestTimeFixture, test_rcutils_steady_time_now) {
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   // Then take a new timestamp with each and compare.
   rcutils_time_point_value_t later;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     ret = rcutils_steady_time_now(&later);
   });
   std::chrono::steady_clock::time_point later_sc = std::chrono::steady_clock::now();


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.