### PR TITLE
Add in a concurrent test to test_logging_output_format.py

### DIFF
--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -80,6 +80,7 @@ def generate_test_description():
 
 
 class TestLoggingOutputFormat(unittest.TestCase):
+
     def test_logging_output(self, proc_info, proc_output, processes_to_test):
         for process_name in processes_to_test:
             proc_info.assertWaitForShutdown(process=process_name, timeout=10)

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -79,6 +79,12 @@ def generate_test_description():
     return launch_description, {'processes_to_test': processes_to_test}
 
 
+class TestLoggingOutputFormat(unittest.TestCase):
+    def test_logging_output(self, proc_info, proc_output, processes_to_test):
+        for process_name in processes_to_test:
+            proc_info.assertWaitForShutdown(process=process_name, timeout=10)
+
+
 @launch_testing.post_shutdown_test()
 class TestLoggingOutputFormatAfterShutdown(unittest.TestCase):
 


### PR DESCRIPTION
Before this PR, there was only a post_shutdown_test.  Due
to a bug in launch_testing, having only a post_shutdown test
causes stack traces to be printed while starting up the tests.
Add in this workaround to quiet the problem until the bug
is fixed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #204 