### PR TITLE
Remove test for large allocation failure.

### DIFF
--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -368,12 +368,6 @@ TEST_F(ArrayListTest, init_list_bad_allocator_fail) {
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
 }
 
-TEST_F(ArrayListTest, init_list_huge_fail) {
-  rcutils_ret_t ret = rcutils_array_list_init(
-    &list, 18446744073709551615u, sizeof(uint32_t), &allocator);
-  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
-}
-
 typedef struct allocator_state
 {
   bool is_failing;


### PR DESCRIPTION
This has potential performance implications, and also causes
build warnings on 32-bit platforms since the size is too big
to fit into a size_t.  It's also a pretty artificial test,
so just remove it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix one of the build warnings in https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/409/warnings23Result/new/ .  @Blast545 FYI.