### PR TITLE
Included utils to load, unload and get symbols from shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,7 @@ endif()
 
 ament_export_dependencies(ament_cmake)
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME})
+ament_export_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
 ament_package()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ if(BUILD_TESTING)
   )
 
   if(TARGET test_shared_library)
-    add_library(dummy_shared_library test/dummy_shared_library/dummy_shared_library.cpp)
+    add_library(dummy_shared_library test/dummy_shared_library/dummy_shared_library.c)
     target_link_libraries(test_shared_library ${PROJECT_NAME})
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,11 +315,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_repl_str ${PROJECT_NAME})
   endif()
 
-  if(WIN32)
-    set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-  else()
-    set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
-  endif()
+  set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
   ament_add_gtest(test_shared_library test/test_shared_library.cpp
     APPEND_LIBRARY_DIRS "${append_library_dirs}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(rcutils_sources
   src/logging.c
   src/process.c
   src/repl_str.c
+  src/shared_library.c
   src/snprintf.c
   src/split.c
   src/strdup.c
@@ -98,6 +99,8 @@ add_library(
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCUTILS_BUILDING_DLL")
+
+target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
 
 # Needed if pthread is used for thread local storage.
 if(IOS AND IOS_SDK_VERSION LESS 10.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,21 @@ if(BUILD_TESTING)
     target_link_libraries(test_repl_str ${PROJECT_NAME})
   endif()
 
+  if(WIN32)
+    set(append_library_dirs "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
+  else()
+    set(append_library_dirs "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+
+  ament_add_gtest(test_shared_library test/test_shared_library.cpp
+    APPEND_LIBRARY_DIRS "${append_library_dirs}"
+  )
+
+  if(TARGET test_shared_library)
+    add_library(dummy_shared_library test/dummy_shared_library/dummy_shared_library.cpp)
+    target_link_libraries(test_shared_library ${PROJECT_NAME})
+  endif()
+
   rcutils_custom_add_gtest(test_time
     test/test_time.cpp
     ENV ${memory_tools_test_env_vars})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,11 @@ if(BUILD_TESTING)
 
   if(TARGET test_shared_library)
     add_library(dummy_shared_library test/dummy_shared_library/dummy_shared_library.c)
+    if(WIN32)
+      # Causes the visibility macros to use dllexport rather than dllimport
+      # which is appropriate when building the dll but not consuming it.
+      target_compile_definitions(dummy_shared_library PRIVATE "DUMMY_SHARED_LIBRARY_BUILDING_DLL")
+    endif()
     target_link_libraries(test_shared_library ${PROJECT_NAME})
   endif()
 

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -130,6 +130,18 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_unload_shared_library(rcutils_shared_library_t * lib);
 
+/// Get the library name for the compiled platform
+/**
+ * \param[in] library_name library base name (without prefix and extension)
+ * \param[out] library_name_platform library name for the compiled platform
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_get_platform_library_name(const char * library_name, char * library_name_platform);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -49,7 +49,6 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
 /// Return an empty shared library struct.
 /*
  * This function returns an empty and zero initialized shared library struct.
- * The default allocator is set.
  *
  * Example:
  *

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -120,7 +120,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 
 /// Unload the shared library.
 /**
- * \param[inout] lib rcutils_shared_library_t to be finalized
+ * \param[in] lib rcutils_shared_library_t to be finalized
  * \return `RCUTILS_RET_OK` if successful, or
  * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
  * \return `RCUTILS_RET_ERROR` if an unknown error occurs

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -56,13 +56,16 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
  * ```c
  * // Do not do this:
  * // rcutils_shared_library_t foo;
- * // rcutils_load_shared_library(&foo, "library_name"); // undefined behavior!
+ * // rcutils_load_shared_library(
+ * //     &foo,
+ * //    "library_name",
+ * //    rcutils_get_default_allocator()); // undefined behavior!
  * // or
  * // rcutils_unload_shared_library(&foo); // undefined behavior!
  *
  * // Do this instead:
  * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
- * rcutils_load_shared_library(&bar, "library_name"); // ok
+ * rcutils_load_shared_library(&bar, "library_name",rcutils_get_default_allocator()); // ok
  * void * symbol = rcutils_get_symbol(&bar, "bazinga"); // ok
  * bool is_bazinga_symbol = rcutils_has_symbol(&bar, "bazinga"); // ok
  * rcutils_unload_shared_library(&bar); // ok
@@ -77,6 +80,7 @@ rcutils_get_zero_initialized_shared_library(void);
 /**
  * \param[inout] lib struct with the shared library pointer and shared library path name
  * \param[in] library_path string with the path of the library
+ * \param[in] allocator to be used to allocate and deallocate memory
  * \return `RCUTILS_RET_OK` if successful, or
  * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
  * \return `RCUTILS_RET_ERROR` if an unknown error occurs, or
@@ -85,7 +89,10 @@ rcutils_get_zero_initialized_shared_library(void);
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_ret_t
-rcutils_load_shared_library(rcutils_shared_library_t * lib, const char * library_path);
+rcutils_load_shared_library(
+  rcutils_shared_library_t * lib,
+  const char * library_path,
+  rcutils_allocator_t allocator);
 
 /// Return shared library symbol pointer.
 /**

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -25,12 +25,9 @@ extern "C"
 #ifndef _WIN32
 #include <dlfcn.h>
 typedef void * rcutils_shared_library_handle_t;
-# include <limits.h>
-# define RCUTILS_DIR_PATH_MAX PATH_MAX
 #else
 #include <windows.h>
 typedef HINSTANCE rcutils_shared_library_handle_t;
-# define RCUTILS_DIR_PATH_MAX MAX_PATH
 #endif  // _WIN32
 
 #include "rcutils/allocator.h"

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -56,7 +56,7 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
  * // Do not do this:
  * // rcutils_shared_library_t foo;
  * // rcutils_allocator_t allocator = rcutils_get_default_allocator();
- * // rcutils_unload_library(&foo, allocator); // undefined behavior!
+ * // rcutils_unload_shared_library(&foo, allocator); // undefined behavior!
  *
  * // Do this instead:
  * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
@@ -115,7 +115,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_ret_t
-rcutils_unload_library(rcutils_shared_library_t * lib);
+rcutils_unload_shared_library(rcutils_shared_library_t * lib);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -55,19 +55,22 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
  * ```c
  * // Do not do this:
  * // rcutils_shared_library_t foo;
- * // rcutils_load_shared_library(
+ * // rcutils_ret_t ret = rcutils_load_shared_library(
  * //     &foo,
  * //    "library_name",
  * //    rcutils_get_default_allocator()); // undefined behavior!
  * // or
- * // rcutils_unload_shared_library(&foo); // undefined behavior!
+ * // rcutils_ret_t ret = rcutils_unload_shared_library(&foo); // undefined behavior!
  *
  * // Do this instead:
  * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
  * rcutils_load_shared_library(&bar, "library_name", rcutils_get_default_allocator()); // ok
  * void * symbol = rcutils_get_symbol(&bar, "bazinga"); // ok
  * bool is_bazinga_symbol = rcutils_has_symbol(&bar, "bazinga"); // ok
- * rcutils_unload_shared_library(&bar); // ok
+ * rcutils_ret_t ret = rcutils_unload_shared_library(&bar); // ok
+ * if (ret != RCUTILS_RET_ERROR) {
+ *   // error handling
+ * }
  * ```
  * */
 RCUTILS_PUBLIC

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -24,53 +24,98 @@ extern "C"
 
 #ifndef _WIN32
 #include <dlfcn.h>
+typedef void * shared_library_type;
 #else
 #include <windows.h>
+typedef HINSTANCE shared_library_type;
 #endif  // _WIN32
 
+#include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
 #include "rcutils/macros.h"
 #include "rcutils/visibility_control.h"
 
-/// The structure
-typedef struct rcutils_shared_library_t
+/// Handle to a loaded shared library.
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
 {
-  /// The pointer to the shared library.
-  #ifndef _WIN32
-  void * lib_pointer;
-  #else
-  HINSTANCE lib_pointer;
-  #endif
+  /// The pointer to the shared library
+  shared_library_type lib_pointer;
   /// The path of the shared_library
   char * library_path;
 } rcutils_shared_library_t;
 
+/// Return an empty shared library struct.
+/*
+ * This function returns an empty and zero initialized shared library struct.
+ *
+ * Example:
+ *
+ * ```c
+ * // Do not do this:
+ * // rcutils_shared_library_t foo;
+ * // rcutils_allocator_t allocator = rcutils_get_default_allocator();
+ * // rcutils_unload_library(&foo, allocator); // undefined behavior!
+ *
+ * // Do this instead:
+ * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
+ * rcutils_allocator_t allocator = rcutils_get_default_allocator();
+ * rcutils_unload_library(&bar, allocator); // ok
+ * ```
+ * */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_shared_library_t
+rcutils_get_zero_initialized_shared_library(void);
+
 /// Return shared library pointer.
 /**
- * \param[in] library_path path to the library
- * \return void* shared library pointer.
- *                nullptr if library doesn't exist
+ *
+ * the memory of the library path inside the rcutils_shared_library_t struct should be
+ * reserved and defined outside this function
+ *
+ * \param[in] lib struct with the shared library pointer and shared library path name
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
  */
 RCUTILS_PUBLIC
-rcutils_shared_library_t *
-rcutils_get_shared_library(const char * library_path);
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_get_shared_library(rcutils_shared_library_t * lib);
 
 /// Return shared library symbol pointer.
 /**
+ * \param[in] lib struct with the shared library pointer and shared library path name
  * \param[in] symbol_name name of the symbol inside the shared library
- * \return void* symbol pointer.
- *                nullptr if symbol doesn't exist
+ * \return shared library symbol pointer.
  */
 RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
 void *
 rcutils_get_symbol(rcutils_shared_library_t * lib, const char * symbol_name);
 
-/// Unload the shared library.
+/// Return if the shared library contains a specific symbolname .
 /**
- * \param[in] lib struct to the shared library
+ * \param[in] lib struct with the shared library pointer and shared library path name
+ * \param[in] symbol_name name of the symbol inside the shared library
+ * \return returns true on success, and false otherwise.
  */
 RCUTILS_PUBLIC
-void
-rcutils_unload_library(rcutils_shared_library_t * lib);
+RCUTILS_WARN_UNUSED
+bool
+rcutils_has_symbol(rcutils_shared_library_t * lib, const char * symbol_name);
+
+/// Unload the shared library.
+/**
+ * \param[inout] lib rcutils_shared_library_t to be finalized
+ * \param[in] allocator the allocator to use for allocation
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_unload_library(rcutils_shared_library_t * lib, rcutils_allocator_t allocator);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -25,9 +25,12 @@ extern "C"
 #ifndef _WIN32
 #include <dlfcn.h>
 typedef void * rcutils_shared_library_handle_t;
+# include <limits.h>
+# define RCUTILS_DIR_PATH_MAX PATH_MAX
 #else
 #include <windows.h>
 typedef HINSTANCE rcutils_shared_library_handle_t;
+# define RCUTILS_DIR_PATH_MAX MAX_PATH
 #endif  // _WIN32
 
 #include "rcutils/allocator.h"
@@ -134,13 +137,17 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib);
 /**
  * \param[in] library_name library base name (without prefix and extension)
  * \param[out] library_name_platform library name for the compiled platform
+ * \param[in] buffer_size size of library_name_platform buffer
  * \return `RCUTILS_RET_OK` if successful, or
  * \return `RCUTILS_RET_ERROR` if an unknown error occurs
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_ret_t
-rcutils_get_platform_library_name(const char * library_name, char * library_name_platform);
+rcutils_get_platform_library_name(
+  const char * library_name,
+  char * library_name_platform,
+  unsigned int buffer_size);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -49,19 +49,23 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
 /// Return an empty shared library struct.
 /*
  * This function returns an empty and zero initialized shared library struct.
+ * The default allocator is set.
  *
  * Example:
  *
  * ```c
  * // Do not do this:
  * // rcutils_shared_library_t foo;
- * // rcutils_allocator_t allocator = rcutils_get_default_allocator();
- * // rcutils_unload_shared_library(&foo, allocator); // undefined behavior!
+ * // rcutils_load_shared_library(&foo, "library_name"); // undefined behavior!
+ * // or
+ * // rcutils_unload_shared_library(&foo); // undefined behavior!
  *
  * // Do this instead:
  * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
- * rcutils_allocator_t allocator = rcutils_get_default_allocator();
  * rcutils_load_shared_library(&bar, "library_name"); // ok
+ * void * symbol = rcutils_get_symbol(&bar, "bazinga"); // ok
+ * bool is_bazinga_symbol = rcutils_has_symbol(&bar, "bazinga"); // ok
+ * rcutils_unload_shared_library(&bar); // ok
  * ```
  * */
 RCUTILS_PUBLIC
@@ -94,7 +98,7 @@ RCUTILS_WARN_UNUSED
 void *
 rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_name);
 
-/// Return if the shared library contains a specific symbolname .
+/// Return true if the shared library contains a specific symbol name otherwise returns false.
 /**
  * \param[in] lib struct with the shared library pointer and shared library path name
  * \param[in] symbol_name name of the symbol inside the shared library

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -1,0 +1,79 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__SHARED_LIBRARY_H_
+#define RCUTILS__SHARED_LIBRARY_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#else
+#include <windows.h>
+#endif  // _WIN32
+
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+/// The structure
+typedef struct rcutils_shared_library_t
+{
+  /// The pointer to the shared library.
+  #ifndef _WIN32
+  void * lib_pointer;
+  #else
+  HINSTANCE lib_pointer;
+  #endif
+  /// The path of the shared_library
+  char * library_path;
+} rcutils_shared_library_t;
+
+/// Return shared library pointer.
+/**
+ * \param[in] library_path path to the library
+ * \return void* shared library pointer.
+ *                nullptr if library doesn't exist
+ */
+RCUTILS_PUBLIC
+rcutils_shared_library_t *
+rcutils_get_shared_library(const char * library_path);
+
+/// Return shared library symbol pointer.
+/**
+ * \param[in] symbol_name name of the symbol inside the shared library
+ * \return void* symbol pointer.
+ *                nullptr if symbol doesn't exist
+ */
+RCUTILS_PUBLIC
+void *
+rcutils_get_symbol(rcutils_shared_library_t * lib, const char * symbol_name);
+
+/// Unload the shared library.
+/**
+ * \param[in] lib struct to the shared library
+ */
+RCUTILS_PUBLIC
+void
+rcutils_unload_library(rcutils_shared_library_t * lib);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__SHARED_LIBRARY_H_

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -64,7 +64,7 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
  *
  * // Do this instead:
  * rcutils_shared_library_t bar = rcutils_get_zero_initialized_shared_library();
- * rcutils_load_shared_library(&bar, "library_name",rcutils_get_default_allocator()); // ok
+ * rcutils_load_shared_library(&bar, "library_name", rcutils_get_default_allocator()); // ok
  * void * symbol = rcutils_get_symbol(&bar, "bazinga"); // ok
  * bool is_bazinga_symbol = rcutils_has_symbol(&bar, "bazinga"); // ok
  * rcutils_unload_shared_library(&bar); // ok

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -1,0 +1,93 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+#include "rcutils/shared_library.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+rcutils_shared_library_t *
+rcutils_get_shared_library(const char * library_path)
+{
+  rcutils_shared_library_t * lib = (rcutils_shared_library_t *)
+    malloc(sizeof(rcutils_shared_library_t));
+
+#ifndef _WIN32
+  lib->lib_pointer = dlopen(library_path, RTLD_LAZY);
+#else
+  lib->lib_pointer = LoadLibrary(library_path);
+#endif  // _WIN32
+  if (!lib->lib_pointer) {
+    free(lib);
+    return NULL;
+  }
+
+  // +1 to accomodate for the null terminator
+  lib->library_path = (char *) malloc((strlen(library_path) + 1) * sizeof(char));
+  snprintf(lib->library_path, strlen(library_path), "%s", library_path);
+
+  return lib;
+}
+
+void *
+rcutils_get_symbol(rcutils_shared_library_t * lib, const char * symbol_name)
+{
+#ifndef _WIN32
+  void * lib_symbol = dlsym(lib->lib_pointer, symbol_name);
+  const char * dlsym_error = dlerror();
+  if (dlsym_error) {
+    fprintf(
+      stderr, "Cannot load symbol '%s' in shared library '%s'",
+      symbol_name, lib->library_path);
+    dlclose(lib->lib_pointer);
+    free(lib->library_path);
+    free(lib);
+    return NULL;
+  }
+#else
+  void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
+  if (!lib_symbol) {
+    fprintf(
+      stderr, "Cannot load symbol '%s' in shared library '%s'",
+      symbol_name, lib->library_path);
+    FreeLibrary(lib->lib_pointer);
+    free(lib->library_path);
+    free(lib);
+    return NULL;
+  }
+#endif  // _WIN32
+  return lib_symbol;
+}
+
+void
+rcutils_unload_library(rcutils_shared_library_t * lib)
+{
+#ifndef _WIN32
+  dlclose(lib->lib_pointer);
+  free(lib->library_path);
+  free(lib);
+#else
+  FreeLibrary(lib->lib_pointer);
+  free(lib->library_path);
+  free(lib);
+#endif  // _WIN32
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -79,15 +79,15 @@ rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting the symbol '%s'. Error '%s'",
       symbol_name, error);
-      return NULL;
-   }
+    return NULL;
+  }
 #else
   void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
-  if ( lib_symbol == NULL) {
+  if (lib_symbol == NULL) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting the symbol '%s'. Error '%d'",
       symbol_name, GetLastError());
-      return NULL;
+    return NULL;
   }
 #endif  // _WIN32
   if (!lib_symbol) {
@@ -116,7 +116,6 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 #else
   void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
   return GetLastError() == 0 && lib_symbol != 0;
-  }
 #endif  // _WIN32
 }
 

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -95,7 +95,7 @@ rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 #endif  // _WIN32
   if (!lib_symbol) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "symbol '%s' doesnt' exit in library '%s'",
+      "symbol '%s' does not exist in the library '%s'",
       symbol_name, lib->library_path);
     return NULL;
   }

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -92,7 +92,7 @@ rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 bool
 rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_name)
 {
-  if (!lib || !lib->lib_pointer || symbol_name) {
+  if (!lib || !lib->lib_pointer || symbol_name == NULL) {
     return false;
   }
 

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -29,14 +29,18 @@ rcutils_get_zero_initialized_shared_library(void)
   rcutils_shared_library_t zero_initialized_shared_library;
   zero_initialized_shared_library.library_path = NULL;
   zero_initialized_shared_library.lib_pointer = NULL;
-  zero_initialized_shared_library.allocator = rcutils_get_default_allocator();
   return zero_initialized_shared_library;
 }
 
 rcutils_ret_t
-rcutils_load_shared_library(rcutils_shared_library_t * lib, const char * library_path)
+rcutils_load_shared_library(
+  rcutils_shared_library_t * lib,
+  const char * library_path,
+  rcutils_allocator_t allocator)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(lib, RCUTILS_RET_INVALID_ARGUMENT);
+
+  lib->allocator = allocator;
 
   lib->library_path = rcutils_strdup(library_path, lib->allocator);
   if (NULL == lib->library_path) {

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -45,6 +45,10 @@ rcutils_load_shared_library(
 
   lib->allocator = allocator;
 
+  if (lib->library_path != NULL) {
+    lib->allocator.deallocate(lib->library_path, lib->allocator.state);
+  }
+
   lib->library_path = rcutils_strdup(library_path, lib->allocator);
   if (NULL == lib->library_path) {
     RCUTILS_SET_ERROR_MSG("unable to allocate memory");

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -168,17 +168,17 @@ rcutils_get_platform_library_name(
   int written = 0;
 
 #ifdef __linux__
-  if (buffer_size > (strlen(library_name) + 7)) {
+  if (buffer_size >= (strlen(library_name) + 7)) {
     written = rcutils_snprintf(
       library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
   }
 #elif __APPLE__
-  if (buffer_size > (strlen(library_name) + 10)) {
+  if (buffer_size >= (strlen(library_name) + 10)) {
     written = rcutils_snprintf(
       library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
   }
 #elif _WIN32
-  if (buffer_size > (strlen(library_name) + 7)) {
+  if (buffer_size >= (strlen(library_name) + 7)) {
     written = rcutils_snprintf(
       library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
   }

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -165,13 +165,6 @@ rcutils_get_platform_library_name(
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name_platform, RCUTILS_RET_INVALID_ARGUMENT);
 
-  if (strlen(library_name) > RCUTILS_DIR_PATH_MAX)
-  {
-    RCUTILS_SET_ERROR_MSG(
-      "library_name is too long more than the maximum allowed size\n");
-    return RCUTILS_RET_ERROR;
-  }
-
   int written = 0;
 
 #ifdef __linux__

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -108,7 +108,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 }
 
 rcutils_ret_t
-rcutils_unload_library(rcutils_shared_library_t * lib)
+rcutils_unload_shared_library(rcutils_shared_library_t * lib)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(lib, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(lib->lib_pointer, RCUTILS_RET_INVALID_ARGUMENT);

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -101,10 +101,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 #else
   void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
 #endif  // _WIN32
-  if (!lib_symbol) {
-    return false;
-  }
-  return true;
+  return lib_symbol != 0;
 }
 
 rcutils_ret_t
@@ -123,7 +120,7 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib)
     ret = RCUTILS_RET_ERROR;
   }
 #else
-  // zero if the function succeeds
+  // If the function succeeds, the return value is nonzero.
   int error_code = FreeLibrary(lib->lib_pointer);
   if (!error_code) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("FreeLibrary error: %lu", GetLastError());

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -157,19 +157,38 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib)
 }
 
 rcutils_ret_t
-rcutils_get_platform_library_name(const char * library_name, char * library_name_platform)
+rcutils_get_platform_library_name(
+  const char * library_name,
+  char * library_name_platform,
+  unsigned int buffer_size)
 {
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name_platform, RCUTILS_RET_INVALID_ARGUMENT);
+
+  if (strlen(library_name) > RCUTILS_DIR_PATH_MAX)
+  {
+    RCUTILS_SET_ERROR_MSG(
+      "library_name is too long more than the maximum allowed size\n");
+    return RCUTILS_RET_ERROR;
+  }
+
   int written = 0;
 
 #ifdef __linux__
-  written = rcutils_snprintf(
-    library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
+  if (buffer_size > (strlen(library_name) + 7)) {
+    written = rcutils_snprintf(
+      library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
+  }
 #elif __APPLE__
-  written = rcutils_snprintf(
-    library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
+  if (buffer_size > (strlen(library_name) + 10)) {
+    written = rcutils_snprintf(
+      library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
+  }
 #elif _WIN32
-  written = rcutils_snprintf(
-    library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
+  if (buffer_size > (strlen(library_name) + 7)) {
+    written = rcutils_snprintf(
+      library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
+  }
 #endif
   if (written < 0) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -156,6 +156,30 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib)
   return ret;
 }
 
+rcutils_ret_t
+rcutils_get_platform_library_name(const char * library_name, char * library_name_platform)
+{
+  int written = 0;
+
+#ifdef __linux__
+  written = rcutils_snprintf(
+    library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
+#elif __APPLE__
+  written = rcutils_snprintf(
+    library_name_platform, strlen(library_name) + 8, "lib%s.dylib", library_name);
+#elif _WIN32
+  written = rcutils_snprintf(
+    library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
+#endif
+  if (written < 0) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "failed to format library name: '%s'\n",
+      library_name);
+    return RCUTILS_RET_ERROR;
+  }
+  return RCUTILS_RET_OK;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -54,12 +54,14 @@ rcutils_load_shared_library(rcutils_shared_library_t * lib, const char * library
 #ifndef _WIN32
   lib->lib_pointer = dlopen(lib->library_path, RTLD_LAZY);
   if (!lib->lib_pointer) {
+    lib->allocator.deallocate(lib->library_path, lib->allocator.state);
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("dlclose error: %s", dlerror());
     return RCUTILS_RET_ERROR;
   }
 #else
   lib->lib_pointer = LoadLibrary(lib->library_path);
   if (!lib->lib_pointer) {
+    lib->allocator.deallocate(lib->library_path, lib->allocator.state);
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %lu", GetLastError());
     return RCUTILS_RET_ERROR;
   }

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -79,13 +79,11 @@ rcutils_unload_library(rcutils_shared_library_t * lib)
 {
 #ifndef _WIN32
   dlclose(lib->lib_pointer);
-  free(lib->library_path);
-  free(lib);
 #else
   FreeLibrary(lib->lib_pointer);
+#endif  // _WIN32
   free(lib->library_path);
   free(lib);
-#endif  // _WIN32
 }
 
 #ifdef __cplusplus

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -43,11 +43,11 @@ rcutils_load_shared_library(
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_path, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
 
-  lib->allocator = allocator;
-
   if (lib->library_path != NULL) {
     lib->allocator.deallocate(lib->library_path, lib->allocator.state);
   }
+
+  lib->allocator = allocator;
 
   lib->library_path = rcutils_strdup(library_path, lib->allocator);
   if (NULL == lib->library_path) {

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -166,7 +166,7 @@ rcutils_get_platform_library_name(const char * library_name, char * library_name
     library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
 #elif __APPLE__
   written = rcutils_snprintf(
-    library_name_platform, strlen(library_name) + 8, "lib%s.dylib", library_name);
+    library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
 #elif _WIN32
   written = rcutils_snprintf(
     library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -55,6 +55,7 @@ rcutils_load_shared_library(rcutils_shared_library_t * lib, const char * library
   lib->lib_pointer = dlopen(lib->library_path, RTLD_LAZY);
   if (!lib->lib_pointer) {
     lib->allocator.deallocate(lib->library_path, lib->allocator.state);
+    lib->library_path = NULL;
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("dlclose error: %s", dlerror());
     return RCUTILS_RET_ERROR;
   }
@@ -62,6 +63,7 @@ rcutils_load_shared_library(rcutils_shared_library_t * lib, const char * library
   lib->lib_pointer = LoadLibrary(lib->library_path);
   if (!lib->lib_pointer) {
     lib->allocator.deallocate(lib->library_path, lib->allocator.state);
+    lib->library_path = NULL;
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %lu", GetLastError());
     return RCUTILS_RET_ERROR;
   }

--- a/test/dummy_shared_library/dummy_shared_library.c
+++ b/test/dummy_shared_library/dummy_shared_library.c
@@ -12,37 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_
-#define DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_
+#include "./dummy_shared_library.h" // NOLINT
 
-#include <iostream>
-
-class DummySharedLibraryBase
+void print_name()
 {
-public:
-  virtual ~DummySharedLibraryBase() {}
-  virtual void speak() = 0;
-};
-
-class Bar : public DummySharedLibraryBase
-{
-public:
-  virtual ~Bar() = default;
-  void speak()
-  {
-    printf("from plugin Bar\n");
-  }
-};
-
-class Baz : public DummySharedLibraryBase
-{
-public:
-  virtual ~Baz() = default;
-  void speak()
-  {
-    printf("from plugin Baz");
-  }
-};
-
-
-#endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_
+  printf("print_name\n");
+}

--- a/test/dummy_shared_library/dummy_shared_library.cpp
+++ b/test/dummy_shared_library/dummy_shared_library.cpp
@@ -1,0 +1,48 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_
+#define DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_
+
+#include <iostream>
+
+class DummySharedLibraryBase
+{
+public:
+  virtual ~DummySharedLibraryBase() {}
+  virtual void speak() = 0;
+};
+
+class Bar : public DummySharedLibraryBase
+{
+public:
+  virtual ~Bar() = default;
+  void speak()
+  {
+    printf("from plugin Bar\n");
+  }
+};
+
+class Baz : public DummySharedLibraryBase
+{
+public:
+  virtual ~Baz() = default;
+  void speak()
+  {
+    printf("from plugin Baz");
+  }
+};
+
+
+#endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_BASE_HPP_

--- a/test/dummy_shared_library/dummy_shared_library.h
+++ b/test/dummy_shared_library/dummy_shared_library.h
@@ -28,6 +28,6 @@
 #include <stdio.h>
 
 DUMMY_SHARED_LIBRARY_PUBLIC
-void print_foo();
+void print_name();
 
 #endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_

--- a/test/dummy_shared_library/dummy_shared_library.h
+++ b/test/dummy_shared_library/dummy_shared_library.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_
+#define DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_
+
+#if _WIN32
+#ifdef DUMMY_SHARED_LIBRARY_BUILDING_DLL
+#define DUMMY_SHARED_LIBRARY_PUBLIC __declspec(dllexport)
+#else
+#define DUMMY_SHARED_LIBRARY_PUBLIC __declspec(dllimport)
+#endif
+#else
+#define DUMMY_SHARED_LIBRARY_PUBLIC
+#endif
+
+#include <stdio.h>
+
+DUMMY_SHARED_LIBRARY_PUBLIC
+void print_foo();
+
+#endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -1,0 +1,79 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "./allocator_testing_utils.h"
+
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/shared_library.h"
+
+#include "rcutils/get_env.h"
+
+class TestSharedLibrary : public ::testing::Test
+{
+protected:
+  void SetUp() final
+  {
+    // Reset rcutil error global state in case a previously
+    // running test has failed.
+    rcutils_reset_error();
+    allocator = rcutils_get_default_allocator();
+    lib = rcutils_get_zero_initialized_shared_library();
+  }
+  rcutils_allocator_t allocator;
+  rcutils_shared_library_t lib;
+};
+
+TEST_F(TestSharedLibrary, getters_initialize_to_zero) {
+  rcutils_ret_t ret;
+
+  // checking rcutils_get_zero_initialized_shared_library
+  ASSERT_STRNE(lib.library_path, "");
+  EXPECT_TRUE(lib.lib_pointer == NULL);
+
+  // Getting RMW_IMPLEMENTATION env var to get the shared library
+  const char * env_var{};
+  const char * err = rcutils_get_env("RMW_IMPLEMENTATION", &env_var);
+  // Is there any error getting the env var?
+  ASSERT_STRNE(err, "");
+  // library path is not empty
+  const std::string library_path = std::string("libdummy_shared_library.so");
+  EXPECT_FALSE(library_path.empty());
+
+  // allocating memory to
+  lib.library_path = reinterpret_cast<char *>(allocator.allocate(
+      (library_path.length() + 1) * sizeof(char),
+      allocator.state));
+
+  // checking allocation was fine
+  ASSERT_NE(lib.library_path, nullptr);
+  // copying string
+  snprintf(lib.library_path, library_path.length() + 1, "%s", library_path.c_str());
+
+  // getting shared library
+  ret = rcutils_get_shared_library(&lib);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // unload shared_library
+  ret = rcutils_unload_library(&lib, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // checking if we have unloaded and freed memory
+  ASSERT_STRNE(lib.library_path, "");
+  EXPECT_TRUE(lib.lib_pointer == NULL);
+}

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -60,6 +60,46 @@ TEST_F(TestSharedLibrary, basic_load) {
   EXPECT_TRUE(lib.lib_pointer == NULL);
 }
 
+TEST_F(TestSharedLibrary, error_load) {
+  rcutils_ret_t ret;
+
+  rcutils_shared_library_t lib_empty;
+  ret = rcutils_load_shared_library(&lib_empty, NULL, rcutils_get_zero_initialized_allocator());
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  lib_empty = rcutils_get_zero_initialized_shared_library();
+  ret = rcutils_load_shared_library(&lib_empty, NULL, rcutils_get_zero_initialized_allocator());
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  const std::string library_path = std::string("libdummy_shared_library.so");
+  ret = rcutils_load_shared_library(&lib_empty, library_path.c_str(), rcutils_get_zero_initialized_allocator());
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+}
+
+TEST_F(TestSharedLibrary, error_unload) {
+  rcutils_ret_t ret;
+
+  const std::string library_path = std::string("libdummy_shared_library.so");
+  ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // unload shared_library
+  ret = rcutils_unload_shared_library(&lib);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // unload again shared_library
+  ret = rcutils_unload_shared_library(&lib);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+}
+
+TEST_F(TestSharedLibrary, error_symbol) {
+  bool is_symbol = rcutils_has_symbol(&lib, "symbol");
+  EXPECT_TRUE(is_symbol == false);
+
+  void * symbol = rcutils_get_symbol(&lib, "print_name");
+  EXPECT_TRUE(symbol == NULL);
+}
+
 TEST_F(TestSharedLibrary, basic_symbol) {
   void * symbol;
   bool ret;

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -34,13 +34,12 @@ protected:
     rcutils_reset_error();
     lib = rcutils_get_zero_initialized_shared_library();
 
-    library_path = std::string("libdummy_shared_library") +
     #ifdef __linux__
-      std::string(".so");
+      library_path = std::string("libdummy_shared_library.so");
     #elif __APPLE__
-      std::string(".dylib");
+      library_path = std::string("libdummy_shared_library.dylib");
     #elif _WIN32
-      std::string(".dll");
+      library_path = std::string("dummy_shared_library.dll");
     #else
       #error "Unsupported OS, dynamic library suffix is unknown."
     #endif

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -44,7 +44,6 @@ protected:
     #else
       #error "Unsupported OS, dynamic library suffix is unknown."
     #endif
-
   }
   rcutils_shared_library_t lib;
   std::string library_path;

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -52,7 +52,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // unload shared_library
-  ret = rcutils_unload_library(&lib);
+  ret = rcutils_unload_shared_library(&lib);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // checking if we have unloaded and freed memory
@@ -83,6 +83,6 @@ TEST_F(TestSharedLibrary, basic_symbol) {
   EXPECT_TRUE(symbol != NULL);
 
   // unload shared_library
-  ret = rcutils_unload_library(&lib);
+  ret = rcutils_unload_shared_library(&lib);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 }

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -45,7 +45,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   ASSERT_STRNE(lib.library_path, "");
   EXPECT_TRUE(lib.lib_pointer == NULL);
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library
@@ -64,7 +64,7 @@ TEST_F(TestSharedLibrary, basic_load) {
 TEST_F(TestSharedLibrary, load_two_times) {
   rcutils_ret_t ret;
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library
@@ -91,7 +91,7 @@ TEST_F(TestSharedLibrary, error_load) {
   ret = rcutils_load_shared_library(&lib_empty, NULL, rcutils_get_zero_initialized_allocator());
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   ret = rcutils_load_shared_library(
@@ -103,7 +103,7 @@ TEST_F(TestSharedLibrary, error_load) {
 TEST_F(TestSharedLibrary, error_unload) {
   rcutils_ret_t ret;
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   ret = rcutils_load_shared_library(&lib, library_path, rcutils_get_default_allocator());
@@ -136,7 +136,7 @@ TEST_F(TestSharedLibrary, basic_symbol) {
   ret = rcutils_has_symbol(nullptr, "symbol");
   EXPECT_FALSE(ret);
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -72,7 +72,9 @@ TEST_F(TestSharedLibrary, error_load) {
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
 
   const std::string library_path = std::string("libdummy_shared_library.so");
-  ret = rcutils_load_shared_library(&lib_empty, library_path.c_str(), rcutils_get_zero_initialized_allocator());
+  ret = rcutils_load_shared_library(
+    &lib_empty,
+    library_path.c_str(), rcutils_get_zero_initialized_allocator());
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
 }
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -34,13 +34,13 @@ protected:
     rcutils_reset_error();
     lib = rcutils_get_zero_initialized_shared_library();
 
-    #ifdef __linux__
-      library_path = std::string("libdummy_shared_library.so");
-    #elif __APPLE__
-      library_path = std::string("libdummy_shared_library.dylib");
-    #elif _WIN32
-      library_path = std::string("dummy_shared_library.dll");
-    #else
+#ifdef __linux__
+    library_path = std::string("libdummy_shared_library.so");
+#elif __APPLE__
+    library_path = std::string("libdummy_shared_library.dylib");
+#elif _WIN32
+    library_path = std::string("dummy_shared_library.dll");
+#else
       #error "Unsupported OS, dynamic library suffix is unknown."
     #endif
   }

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -48,7 +48,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   const std::string library_path = std::string("libdummy_shared_library.so");
 
   // getting shared library
-  ret = rcutils_load_shared_library(&lib, library_path.c_str());
+  ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // unload shared_library
@@ -73,7 +73,7 @@ TEST_F(TestSharedLibrary, basic_symbol) {
   const std::string library_path = std::string("libdummy_shared_library.so");
 
   // getting shared library
-  ret = rcutils_load_shared_library(&lib, library_path.c_str());
+  ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   symbol = rcutils_get_symbol(&lib, "symbol");

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -60,6 +60,23 @@ TEST_F(TestSharedLibrary, basic_load) {
   EXPECT_TRUE(lib.lib_pointer == NULL);
 }
 
+TEST_F(TestSharedLibrary, load_two_times) {
+  rcutils_ret_t ret;
+
+  const std::string library_path = std::string("libdummy_shared_library.so");
+  // getting shared library
+  ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // getting shared library
+  ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  // unload shared_library
+  ret = rcutils_unload_shared_library(&lib);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+}
+
 TEST_F(TestSharedLibrary, error_load) {
   rcutils_ret_t ret;
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -33,8 +33,21 @@ protected:
     // running test has failed.
     rcutils_reset_error();
     lib = rcutils_get_zero_initialized_shared_library();
+
+    library_path = std::string("libdummy_shared_library") +
+    #ifdef __linux__
+      std::string(".so");
+    #elif __APPLE__
+      std::string(".dylib");
+    #elif _WIN32
+      std::string(".dll");
+    #else
+      #error "Unsupported OS, dynamic library suffix is unknown."
+    #endif
+
   }
   rcutils_shared_library_t lib;
+  std::string library_path;
 };
 
 TEST_F(TestSharedLibrary, basic_load) {
@@ -43,9 +56,6 @@ TEST_F(TestSharedLibrary, basic_load) {
   // checking rcutils_get_zero_initialized_shared_library
   ASSERT_STRNE(lib.library_path, "");
   EXPECT_TRUE(lib.lib_pointer == NULL);
-
-  // library path
-  const std::string library_path = std::string("libdummy_shared_library.so");
 
   // getting shared library
   ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
@@ -63,7 +73,6 @@ TEST_F(TestSharedLibrary, basic_load) {
 TEST_F(TestSharedLibrary, load_two_times) {
   rcutils_ret_t ret;
 
-  const std::string library_path = std::string("libdummy_shared_library.so");
   // getting shared library
   ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
   ASSERT_EQ(RCUTILS_RET_OK, ret);
@@ -88,7 +97,6 @@ TEST_F(TestSharedLibrary, error_load) {
   ret = rcutils_load_shared_library(&lib_empty, NULL, rcutils_get_zero_initialized_allocator());
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
 
-  const std::string library_path = std::string("libdummy_shared_library.so");
   ret = rcutils_load_shared_library(
     &lib_empty,
     library_path.c_str(), rcutils_get_zero_initialized_allocator());
@@ -98,7 +106,6 @@ TEST_F(TestSharedLibrary, error_load) {
 TEST_F(TestSharedLibrary, error_unload) {
   rcutils_ret_t ret;
 
-  const std::string library_path = std::string("libdummy_shared_library.so");
   ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
@@ -128,8 +135,6 @@ TEST_F(TestSharedLibrary, basic_symbol) {
 
   ret = rcutils_has_symbol(nullptr, "symbol");
   EXPECT_FALSE(ret);
-
-  const std::string library_path = std::string("libdummy_shared_library.so");
 
   // getting shared library
   ret = rcutils_load_shared_library(&lib, library_path.c_str(), rcutils_get_default_allocator());


### PR DESCRIPTION
As discussed in this PR https://github.com/ros/class_loader/pull/139. It makes sense to include the logic of loading/unloading shared libraries and symbols in `rcutils` . These functions will be used in `class_loader`, `rmw_implementation`, `rosidl_typesupport` and `rosbag2`.

This other PR makes use of this new capability https://github.com/ros/class_loader/pull/139