### PR TITLE
[Eloquent] check and link against libatomic (#172) (#178)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+include(CheckLibraryExists)
+
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 
@@ -121,6 +123,13 @@ if(BUILD_TESTING)
 
   find_package(launch_testing_ament_cmake REQUIRED)
 
+  check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
+
+  if(HAVE_LIBATOMICS AND NOT WIN32)
+    # Exporting link flag since it won't pass ament_export_libraries() existance check
+    ament_export_link_flags("-latomic")
+  endif()
+
   if(ament_cmake_cppcheck_FOUND)
     ament_cppcheck(
       TESTNAME "cppcheck_logging_macros"
@@ -214,6 +223,10 @@ if(BUILD_TESTING)
       LANGUAGE C
   )
   target_link_libraries(test_atomics_executable ${PROJECT_NAME})
+  if(HAVE_LIBATOMICS)
+    target_link_libraries(test_atomics_executable atomic)
+  endif()
+
   add_test(NAME test_atomics COMMAND test_atomics_executable)
 
   rcutils_custom_add_gmock(test_error_handling test/test_error_handling.cpp


### PR DESCRIPTION
Cherry-pick #178 to `eloquent`.