### PR TITLE
Added directory and file utils to replace tinydir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set(rcutils_sources
   src/array_list.c
   src/char_array.c
   src/cmdline_parser.c
+  src/directory_and_file_reader.c
   src/error_handling.c
   src/filesystem.c
   src/find.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_error_handling ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
+  rcutils_custom_add_gtest(test_directory_and_file_reader
+    test/test_directory_and_file_reader.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  if(TARGET test_directory_and_file_reader)
+    target_link_libraries(test_directory_and_file_reader ${PROJECT_NAME})
+  endif()
+
   rcutils_custom_add_gmock(test_error_handling_helpers test/test_error_handling_helpers.cpp
     # Append the directory of librcutils so it is found at test time.
     APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"

--- a/include/rcutils/directory_and_file_reader.h
+++ b/include/rcutils/directory_and_file_reader.h
@@ -1,0 +1,198 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__DIRECTORY_AND_FILE_READER_H_
+#define RCUTILS__DIRECTORY_AND_FILE_READER_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <limits.h>
+# define RCUTILS_DIR_PATH_MAX PATH_MAX
+#else
+#include <windows.h>
+#include <tchar.h>
+#include <direct.h>
+# define RCUTILS_DIR_PATH_MAX MAX_PATH
+#endif  // _WIN32
+
+#ifndef RCUTILS_DIR_PATH_MAX
+#define RCUTILS_DIR_PATH_MAX 4096
+#endif
+#define RCUTILS_FILENAME_MAX 256
+/// Handle directories library.
+
+/// Handle files.
+typedef struct rcutils_file_t
+{
+  /// path of the file
+  char * path;
+  /// filename
+  char * name;
+  /// is the file a directory ?
+  int is_dir;
+  //  information about the file
+  #ifndef _WIN32
+  struct stat _s;
+  #else
+  struct _stat _s;
+  #endif
+} rcutils_file_t;
+
+/// Handle directories.
+typedef struct rcutils_dir_t
+{
+  /// path of the directory
+  char * path;
+  // is there any file in the folder.
+  int has_next;
+
+  #ifndef _WIN32
+  /// Directory struct
+  DIR * dir;
+  struct dirent * f;
+  #else
+  HANDLE dir;
+  WIN32_FIND_DATA f;
+  #endif
+
+  /// allocator
+  rcutils_allocator_t allocator;
+} rcutils_dir_t;
+
+
+/// Return an empty dir struct.
+/*
+ * This function returns an empty and zero initialized directory struct.
+ *
+ * Example:
+ * // Do not do this:
+ * // rcutils_dir_t foo;
+ * // rcutils_open_dir(&foo, "directory", rcutils_get_default_allocator()); // undefined behavior!
+ * // rcutils_ret_t ret = retrcutils_next_dir(&foo); // undefined behavior!
+ *
+ * // Do this instead:
+ * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
+ * rcutils_ret_t ret = rcutils_open_dir(&bar, "directory", rcutils_get_default_allocator());
+ * ret = retrcutils_next_dir(&bar);
+ * ret = rcutils_close_dir(&bar);
+ *
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_dir_t
+rcutils_get_zero_initialized_dir(void);
+
+/// Return an empty file struct.
+/*
+ * This function returns an empty and zero initialized file struct.
+ *
+ * Example:
+ * // Do not do this:
+ * // rcutils_dir_t foo =  rcutils_get_zero_initialized_dir();
+ * // rcutils_file_t file;
+ * // rcutils_open_dir(&foo, "directory", rcutils_get_default_allocator());
+ * // rcutils_ret_t ret = rcutils_readfile(&foo, &file); // undefined behavior!
+ *
+ * // Do this instead:
+ * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
+ * rcutils_file_t foo = rcutils_get_zero_initialized_file();
+ * rcutils_ret_t ret = rcutils_open_dir(&bar, "directory", rcutils_get_default_allocator());
+ * rcutils_ret_t ret = rcutils_readfile(&bar, &foo)
+ * ret = retrcutils_next_dir(&bar);
+ * ret = rcutils_close_dir(&bar);
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_file_t
+rcutils_get_zero_initialized_file(void);
+
+/// Destroy a file struct
+/*
+* \param[in] file struct with file information
+* \param[in] allocator to be used to deallocate memory
+*/
+RCUTILS_PUBLIC
+void
+rcutils_file_fini(rcutils_file_t * file, rcutils_allocator_t allocator);
+
+/// Open a directory
+/**
+ * \param[inout] dir struct with directory information
+ * \param[in] path string with the path of the directory
+ * \param[in] allocator to be used to allocate and deallocate memory
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_open_dir(rcutils_dir_t * dir, const char * path, rcutils_allocator_t allocator);
+
+/// Get next file in the directory.
+/**
+ * \param[inout] dir struct with directory information
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_next_dir(rcutils_dir_t * dir);
+
+/// Read file information
+/**
+* \param[inout] dir struct with directory information
+* \param[inout] dile struct with file information
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_readfile(rcutils_dir_t * dir, rcutils_file_t * file);
+
+/// Close the directory
+/**
+* \param[inout] dir struct with directory information
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_close_dir(rcutils_dir_t * dir);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__DIRECTORY_AND_FILE_READER_H_

--- a/include/rcutils/directory_and_file_reader.h
+++ b/include/rcutils/directory_and_file_reader.h
@@ -20,11 +20,6 @@ extern "C"
 {
 #endif
 
-#include "rcutils/allocator.h"
-#include "rcutils/types/rcutils_ret.h"
-#include "rcutils/macros.h"
-#include "rcutils/visibility_control.h"
-
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -43,7 +38,11 @@ extern "C"
 #define RCUTILS_DIR_PATH_MAX 4096
 #endif
 #define RCUTILS_FILENAME_MAX 256
-/// Handle directories library.
+
+#include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
 
 /// Handle files.
 typedef struct rcutils_file_t
@@ -89,17 +88,15 @@ typedef struct rcutils_dir_t
  * This function returns an empty and zero initialized directory struct.
  *
  * Example:
+ * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
+ * rcutils_ret_t ret = rcutils_open_dir(&bar, "directory", rcutils_get_default_allocator());
+ * ret = rcutils_next_dir(&bar);
+ * ret = rcutils_close_dir(&bar);
+ *
  * // Do not do this:
  * // rcutils_dir_t foo;
  * // rcutils_open_dir(&foo, "directory", rcutils_get_default_allocator()); // undefined behavior!
  * // rcutils_ret_t ret = retrcutils_next_dir(&foo); // undefined behavior!
- *
- * // Do this instead:
- * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
- * rcutils_ret_t ret = rcutils_open_dir(&bar, "directory", rcutils_get_default_allocator());
- * ret = retrcutils_next_dir(&bar);
- * ret = rcutils_close_dir(&bar);
- *
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -111,19 +108,20 @@ rcutils_get_zero_initialized_dir(void);
  * This function returns an empty and zero initialized file struct.
  *
  * Example:
+ * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
+ * rcutils_file_t foo = rcutils_get_zero_initialized_file();
+ * rcutils_ret_t ret = rcutils_open_dir(
+ *          &bar, "directory", rcutils_get_default_allocator());
+ * ret = rcutils_readfile(&bar, &foo)
+ * ret = rcutils_next_dir(&bar);
+ * ret = rcutils_close_dir(&bar);
+ *
  * // Do not do this:
  * // rcutils_dir_t foo =  rcutils_get_zero_initialized_dir();
  * // rcutils_file_t file;
- * // rcutils_open_dir(&foo, "directory", rcutils_get_default_allocator());
+ * // rcutils_ret_t ret =rcutils_open_dir(
+ *         &foo, "directory", rcutils_get_default_allocator());
  * // rcutils_ret_t ret = rcutils_readfile(&foo, &file); // undefined behavior!
- *
- * // Do this instead:
- * rcutils_dir_t bar = rcutils_get_zero_initialized_dir();
- * rcutils_file_t foo = rcutils_get_zero_initialized_file();
- * rcutils_ret_t ret = rcutils_open_dir(&bar, "directory", rcutils_get_default_allocator());
- * rcutils_ret_t ret = rcutils_readfile(&bar, &foo)
- * ret = retrcutils_next_dir(&bar);
- * ret = rcutils_close_dir(&bar);
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -131,12 +129,15 @@ rcutils_file_t
 rcutils_get_zero_initialized_file(void);
 
 /// Destroy a file struct
-/*
-* \param[in] file struct with file information
-* \param[in] allocator to be used to deallocate memory
-*/
+/**
+ * \param[in] file struct with file information
+ * \param[in] allocator to be used to deallocate memory
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ */
 RCUTILS_PUBLIC
-void
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
 rcutils_file_fini(rcutils_file_t * file, rcutils_allocator_t allocator);
 
 /// Open a directory
@@ -182,8 +183,9 @@ rcutils_readfile(rcutils_dir_t * dir, rcutils_file_t * file);
 
 /// Close the directory
 /**
-* \param[inout] dir struct with directory information
+* \param[in] dir struct with directory information
  * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_ERROR` if close fails, or
  * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
  */
 RCUTILS_PUBLIC

--- a/src/directory_and_file_reader.c
+++ b/src/directory_and_file_reader.c
@@ -1,0 +1,249 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <errno.h>
+
+#include "rcutils/directory_and_file_reader.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/filesystem.h"
+#include "rcutils/strdup.h"
+
+rcutils_dir_t
+rcutils_get_zero_initialized_dir(void)
+{
+  rcutils_dir_t zero_initialized_dir;
+  zero_initialized_dir.path = NULL;
+  zero_initialized_dir.has_next = 0;
+  zero_initialized_dir.dir = NULL;
+  #ifndef _WIN32
+  zero_initialized_dir.f = NULL;
+  #endif
+  zero_initialized_dir.allocator = rcutils_get_zero_initialized_allocator();
+  return zero_initialized_dir;
+}
+
+rcutils_file_t
+rcutils_get_zero_initialized_file(void)
+{
+  rcutils_file_t zero_initialized_file;
+  zero_initialized_file.path = NULL;
+  zero_initialized_file.name = NULL;
+  zero_initialized_file.is_dir = 0;
+  return zero_initialized_file;
+}
+
+void
+rcutils_file_fini(rcutils_file_t * file, rcutils_allocator_t allocator)
+{
+  allocator.deallocate(file->path, allocator.state);
+  allocator.deallocate(file->name, allocator.state);
+}
+
+rcutils_ret_t
+rcutils_open_dir(rcutils_dir_t * dir, const char * path, rcutils_allocator_t allocator)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(path, RCUTILS_RET_INVALID_ARGUMENT);
+
+  if (strlen(path) == 0) {
+    RCUTILS_SET_ERROR_MSG("The size of the path is 0");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  if (strlen(path) >= RCUTILS_DIR_PATH_MAX) {
+    RCUTILS_SET_ERROR_MSG("The size of the path is too long");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  dir->allocator = allocator;
+
+  dir->path = rcutils_strdup(path, dir->allocator);
+  if (NULL == dir->path) {
+    RCUTILS_SET_ERROR_MSG("unable to allocate memory");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  errno = 0;
+#ifndef _WIN32
+  dir->dir = opendir(dir->path);
+  if (dir->dir == NULL) {
+#else
+  char * path_buf[RCUTILS_DIR_PATH_MAX];
+  TCHAR * pathp = &dir->path[strlen(dir->path) - 1];
+  while (pathp != dir->path && (*pathp == _TEXT('\\') || *pathp == _TEXT('/')))
+	{
+		*pathp = _TEXT('\0');
+		pathp++;
+	}
+  strcpy(path_buf, dir->path);
+	strcat(path_buf, _TEXT("\\*"));
+
+  dir->dir = FindFirstFile(path_buf, &dir->f);
+  if (dir->dir == INVALID_HANDLE_VALUE) {
+#endif
+    int errsv = errno;
+    if (errsv == EACCES) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("permission denied '%s'", dir->path);
+    } else if (errsv == EBADF) {
+      RCUTILS_SET_ERROR_MSG("fd is not a valid file descriptor opened for reading.");
+    } else if (errsv == EMFILE) {
+      RCUTILS_SET_ERROR_MSG("Too many file descriptors in use by proces.");
+    } else if (errsv == ENFILE) {
+      RCUTILS_SET_ERROR_MSG("Too many files are currently open in the system.");
+    } else if (errsv == ENOENT) {
+      RCUTILS_SET_ERROR_MSG("Directory does not exist, or name is an empty string.");
+    } else if (errsv == ENOMEM) {
+      RCUTILS_SET_ERROR_MSG("Insufficient memory to complete the operation.");
+    } else if (errsv == ENOTDIR) {
+      RCUTILS_SET_ERROR_MSG("name is not a directory.");
+    }
+    dir->allocator.deallocate(dir->path, dir->allocator.state);
+    return RCUTILS_RET_ERROR;
+  }
+  dir->has_next = 1;
+
+#ifndef _WIN32
+  dir->f = readdir(dir->dir);
+  if (dir->f == NULL) {
+    dir->has_next = 0;
+  }
+#else
+  WIN32_FIND_DATA _temp_f;
+  if (!FindNextFile(dir->dir, &_temp_f)) {
+    dir->has_next = 0;
+  }
+#endif
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_readfile(rcutils_dir_t * dir, rcutils_file_t * file)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir->path, RCUTILS_RET_INVALID_ARGUMENT);
+#ifndef _WIN32
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir->f, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir->f->d_name, RCUTILS_RET_INVALID_ARGUMENT);
+#endif
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(file, RCUTILS_RET_INVALID_ARGUMENT);
+
+  const char * filename =
+#ifndef _WIN32
+    dir->f->d_name;
+#else
+    dir->f.cFileName;
+#endif
+  file->path = rcutils_strdup(dir->path, dir->allocator);
+  if (NULL == file->path) {
+    RCUTILS_SET_ERROR_MSG("unable to allocate memory");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  file->name = rcutils_strdup(filename, dir->allocator);
+  if (NULL == file->name) {
+    dir->allocator.deallocate(file->name, dir->allocator.state);
+    RCUTILS_SET_ERROR_MSG("unable to allocate memory");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+#ifndef _WIN32
+  if (lstat(
+#else
+  if (_tstat(
+#endif
+    file->path, &file->_s) == -1){
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "error reading information about the file: '%s'",
+      file->path);
+    dir->allocator.deallocate(file->path, dir->allocator.state);
+    dir->allocator.deallocate(file->name, dir->allocator.state);
+    return RCUTILS_RET_ERROR;
+  }
+
+  file->is_dir = rcutils_is_directory(file->path);
+
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_next_dir(rcutils_dir_t * dir)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir, RCUTILS_RET_INVALID_ARGUMENT);
+
+  if (!dir->has_next) {
+    return RCUTILS_RET_ERROR;
+  }
+
+#ifndef _WIN32
+  dir->f = readdir(dir->dir);
+  if (dir->f == NULL) {
+    dir->has_next = 0;
+    return RCUTILS_RET_ERROR;
+  }
+#else
+  if (!FindNextFile(dir->dir, &dir->f)) {
+    dir->has_next = 0;
+    if (GetLastError() != ERROR_SUCCESS &&
+        GetLastError() != ERROR_NO_MORE_FILES) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("error reading next directory: '%s'", dir->path);
+      if (rcutils_close_dir(dir) != RCUTILS_RET_OK) {
+        RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+          "error reading next directory and closing file: '%s'",
+          dir->path);
+      }
+      return RCUTILS_RET_ERROR;
+    }
+  }
+#endif
+  return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t
+rcutils_close_dir(rcutils_dir_t * dir)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(dir, RCUTILS_RET_INVALID_ARGUMENT);
+
+  rcutils_ret_t ret = RCUTILS_RET_OK;
+
+  dir->allocator.deallocate(dir->path, dir->allocator.state);
+  dir->path = NULL;
+
+  dir->has_next = 0;
+  errno = 0;
+#ifndef _WIN32
+  int error = closedir(dir->dir);
+  // The closedir() function returns 0 on success
+  if (error) {
+#else
+  // If the function succeeds, the return value is nonzero.
+  if (!FindClose(dir->dir)) {
+#endif
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("error closing the directory: '%s'", dir->path);
+    ret = RCUTILS_RET_ERROR;
+  }
+  dir->dir = NULL;
+#ifndef _WIN32
+  dir->f = NULL;
+#endif
+  dir->allocator = rcutils_get_zero_initialized_allocator();
+  return ret;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/test_directory_and_file_reader.cpp
+++ b/test/test_directory_and_file_reader.cpp
@@ -1,0 +1,230 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcutils/directory_and_file_reader.h"
+#include "rcutils/filesystem.h"
+
+class TestDirectoryAndFileReader : public ::testing::Test
+{
+public:
+  void SetUp()
+  {
+    allocator = rcutils_get_default_allocator();
+    g_allocator = rcutils_get_default_allocator();
+    EXPECT_TRUE(rcutils_get_cwd(this->cwd, sizeof(this->cwd)));
+
+    test_path = rcutils_join_path(this->cwd, "test/dummy_folder", g_allocator);
+    ASSERT_FALSE(nullptr == test_path);
+
+    dir = rcutils_get_zero_initialized_dir();
+  }
+
+  void TearDown()
+  {
+    g_allocator.deallocate(test_path, g_allocator.state);
+  }
+
+  rcutils_allocator_t g_allocator;
+
+  rcutils_allocator_t allocator;
+  char cwd[1024];
+  char * test_path = nullptr;
+  rcutils_dir_t dir;
+};
+
+TEST_F(TestDirectoryAndFileReader, basic_open) {
+  rcutils_ret_t ret;
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ASSERT_TRUE(dir.has_next);
+
+  rcutils_file_t dummy_file = rcutils_get_zero_initialized_file();
+  ret = rcutils_readfile(&dir, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ASSERT_STRNE(dummy_file.name, "");
+  ASSERT_TRUE(dir.has_next);
+
+  ret = rcutils_next_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ret = rcutils_readfile(&dir, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ASSERT_STRNE(dummy_file.name, "");
+  ASSERT_TRUE(dir.has_next);
+
+  ret = rcutils_next_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ret = rcutils_readfile(&dir, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ASSERT_STRNE(dummy_file.name, "");
+  ASSERT_TRUE(dir.has_next);
+
+  ret = rcutils_next_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_ERROR, ret);
+  ASSERT_FALSE(dir.has_next);
+
+  ret = rcutils_file_fini(&dummy_file, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+}
+
+TEST_F(TestDirectoryAndFileReader, open_two_times) {
+  rcutils_ret_t ret;
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+  ASSERT_TRUE(dir.has_next);
+
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  allocator.deallocate(dir.path, allocator.state);
+  dir.path = NULL;
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+}
+
+TEST_F(TestDirectoryAndFileReader, unload_two_times) {
+  rcutils_ret_t ret;
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_ERROR, ret);
+
+  rcutils_dir_t * dir_null = NULL;
+  ret = rcutils_close_dir(dir_null);
+  EXPECT_TRUE(dir_null == NULL);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+}
+
+TEST_F(TestDirectoryAndFileReader, readdir_failures) {
+  rcutils_ret_t ret;
+  rcutils_dir_t dir_null;
+  rcutils_file_t dummy_file = rcutils_get_zero_initialized_file();
+  ret = rcutils_readfile(&dir_null, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  rcutils_dir_t * dir_null2 = NULL;
+  ret = rcutils_readfile(dir_null2, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  rcutils_file_t * dummy_file2 = NULL;
+  ret = rcutils_readfile(dir_null2, dummy_file2);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  allocator.deallocate(dir.path, allocator.state);
+  dir.path = NULL;
+  ret = rcutils_readfile(&dir, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  ret = rcutils_file_fini(&dummy_file, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+}
+
+TEST_F(TestDirectoryAndFileReader, readfile_failures) {
+  rcutils_ret_t ret;
+  rcutils_dir_t dir_null;
+  rcutils_file_t dummy_file = rcutils_get_zero_initialized_file();
+  ret = rcutils_readfile(&dir_null, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  rcutils_dir_t * dir_null2 = NULL;
+  ret = rcutils_readfile(dir_null2, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  rcutils_file_t * dummy_file2 = NULL;
+  ret = rcutils_readfile(dir_null2, dummy_file2);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  ret = rcutils_open_dir(&dir, test_path, allocator);
+  allocator.deallocate(dir.path, allocator.state);
+  dir.path = NULL;
+  ret = rcutils_readfile(&dir, &dummy_file);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  ret = rcutils_file_fini(&dummy_file, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(&dir);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+}
+
+TEST_F(TestDirectoryAndFileReader, next_dir_failures) {
+  rcutils_ret_t ret;
+  rcutils_dir_t * dir_null = NULL;
+  ret = rcutils_next_dir(dir_null);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  dir_null = reinterpret_cast<rcutils_dir_t*>(
+    g_allocator.allocate(sizeof(rcutils_dir_t), allocator.state));
+  if (dir_null == NULL) {
+    FAIL() << "bad alloc";
+  }
+  *dir_null = rcutils_get_zero_initialized_dir();
+  ret = rcutils_open_dir(dir_null, test_path, allocator);
+  allocator.deallocate(dir_null->path, allocator.state);
+  dir_null->path = NULL;
+  ret = rcutils_next_dir(dir_null);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  ret = rcutils_close_dir(dir_null);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  g_allocator.deallocate(dir_null, g_allocator.state);
+}
+
+TEST_F(TestDirectoryAndFileReader, file_struct_tests) {
+  rcutils_ret_t ret;
+  rcutils_file_t * dummy_file = NULL;
+
+  ret = rcutils_file_fini(dummy_file, allocator);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+
+  dummy_file = reinterpret_cast<rcutils_file_t*>(
+    g_allocator.allocate(sizeof(rcutils_file_t), allocator.state));
+  if (dummy_file == NULL) {
+    FAIL() << "bad alloc";
+  }
+
+  *dummy_file = rcutils_get_zero_initialized_file();
+  ret = rcutils_file_fini(dummy_file, allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
+  g_allocator.deallocate(dummy_file, g_allocator.state);
+}
+
+TEST_F(TestDirectoryAndFileReader, check_init_struct_tests) {
+  ASSERT_STRNE(dir.path, "");
+  EXPECT_TRUE(dir.has_next == 0);
+  EXPECT_TRUE(dir.dir == NULL);
+  EXPECT_TRUE(dir.f == NULL);
+
+  rcutils_file_t dummy_file = rcutils_get_zero_initialized_file();
+  ASSERT_STRNE(dummy_file.path, "");
+  ASSERT_STRNE(dummy_file.name, "");
+  EXPECT_TRUE(dummy_file.is_dir == 0);
+}


### PR DESCRIPTION
This PR is part of the effort to reduce the number of dependencies in ROS 2. Tinydir is only used in RCL in [one place](https://github.com/ros2/rcl/blob/master/rcl/src/rcl/security_directory.c#L87) to find a folder that match with a string.

I have created a new file `directory_and_file_reader.[hc]` maybe I can include this code in `filesystem.[hc]`.

Signed-off-by: ahcorde <ahcorde@gmail.com>