### PR TITLE
export interfaces in a addition to include directories / libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,6 @@ find_package(ament_cmake_ros REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-include_directories(include)
-
 if(NOT WIN32)
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
@@ -92,11 +90,14 @@ add_custom_command(OUTPUT include/rcutils/logging_macros.h
 )
 list(APPEND rcutils_sources
   include/rcutils/logging_macros.h)
-include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
 add_library(
   ${PROJECT_NAME}
   ${rcutils_sources})
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>")
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
@@ -109,7 +110,7 @@ if(IOS AND IOS_SDK_VERSION LESS 10.0)
   ament_export_libraries(pthread)
 endif()
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
@@ -248,6 +249,7 @@ if(BUILD_TESTING)
     ENV ${memory_tools_test_env_vars}
   )
   if(TARGET test_error_handling_helpers)
+    target_include_directories(test_error_handling_helpers PUBLIC include)
     target_link_libraries(test_error_handling_helpers osrf_testing_tools_cpp::memory_tools)
   endif()
 
@@ -407,6 +409,7 @@ endif()
 
 ament_export_dependencies(ament_cmake)
 ament_export_include_directories(include)
+ament_export_interfaces(${PROJECT_NAME})
 ament_export_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
 ament_package()
 


### PR DESCRIPTION
The CI builds include ament/ament_cmake#235:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=9925)](http://ci.ros2.org/job/ci_linux/9925/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5535)](http://ci.ros2.org/job/ci_linux-aarch64/5535/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8073)](http://ci.ros2.org/job/ci_osx/8073/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9771)](http://ci.ros2.org/job/ci_windows/9771/)