### PR TITLE
Added rcutils_is_shared_library_loaded function

### DIFF
--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -130,8 +130,11 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_unload_shared_library(rcutils_shared_library_t * lib);
 
-/// check if the library is loaded
+/// Check if the library is loaded.
 /**
+ * This function only determines if "unload" has been called on the current shared library handle.
+ * It could very well be that a second shared library handle is still open and therefore the library
+ * being loaded.
  * \param[in] lib rcutils_shared_library_t  to check
  * \return true if library is loaded, false otherwise
  */

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -130,6 +130,16 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_unload_shared_library(rcutils_shared_library_t * lib);
 
+/// check if the library is loaded
+/**
+ * \param[in] lib rcutils_shared_library_t  to check
+ * \return true if library is loaded, false otherwise
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+bool
+rcutils_is_shared_library_loaded(rcutils_shared_library_t * lib);
+
 /// Get the library name for the compiled platform
 /**
  * \param[in] library_name library base name (without prefix and extension)

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -192,6 +192,12 @@ rcutils_get_platform_library_name(
   return RCUTILS_RET_OK;
 }
 
+bool
+rcutils_is_shared_library_loaded(rcutils_shared_library_t * lib)
+{
+  return lib->lib_pointer != NULL;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -44,6 +44,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   // checking rcutils_get_zero_initialized_shared_library
   ASSERT_STRNE(lib.library_path, "");
   EXPECT_TRUE(lib.lib_pointer == NULL);
+  EXPECT_FALSE(rcutils_is_shared_library_loaded(&lib));
 
   ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
@@ -51,6 +52,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   // getting shared library
   ret = rcutils_load_shared_library(&lib, library_path, rcutils_get_default_allocator());
   ASSERT_EQ(RCUTILS_RET_OK, ret);
+  EXPECT_TRUE(rcutils_is_shared_library_loaded(&lib));
 
   // unload shared_library
   ret = rcutils_unload_shared_library(&lib);


### PR DESCRIPTION
Added `rcutils_is_shared_library_loaded` function to avoid breaking the encapsulation https://github.com/ros2/rcpputils/pull/50#discussion_r403303986
 
Signed-off-by: ahcorde <ahcorde@gmail.com>