### PR TITLE
add freebsd support

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -47,7 +47,7 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
   RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
     &allocator, "invalid allocator", return NULL);
 
-#if defined __APPLE__ || (defined __ANDROID__ && __ANDROID_API__ >= 21)
+#if defined __APPLE__ || defined __FreeBSD__ || (defined __ANDROID__ && __ANDROID_API__ >= 21)
   const char * appname = getprogname();
 #elif defined __GNUC__
   const char * appname = program_invocation_name;
@@ -71,7 +71,7 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
   }
 
   // Get just the executable name (Unix may return the absolute path)
-#if defined __APPLE__ || defined __GNUC__
+#if defined __APPLE__ || defined __FreeBSD__ || defined __GNUC__
   // We need an intermediate copy because basename may modify its arguments
   char * intermediate = allocator.allocate(applen + 1, allocator.state);
   if (NULL == intermediate) {


### PR DESCRIPTION
Cross-compiling for FreeBSD often results in satisfying `__GNUC__` conditionals if no `__FreeBSD__` conditionals are provided.  In most cases, it should execute the same code as the `__APPLE__` conditionals.

This PR ensures the correct code is executed for FreeBSD.  This is necessary in one case (process.c:50).  In a second case (process.c:74), it is added for completeness, just in case the `__APPLE__` and `__GNUC__` cases diverge in the future.

macros.h:34 also checks if `__APPLE__` is defined, but separate code to support FreeBSD does not appear to be necessary in this case, as the conditional appears to be iOS-specific.