### PR TITLE
Added debug version for library names

### DIFF
--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -148,6 +148,8 @@ rcutils_is_shared_library_loaded(rcutils_shared_library_t * lib);
  * \param[in] library_name library base name (without prefix and extension)
  * \param[out] library_name_platform library name for the compiled platform
  * \param[in] buffer_size size of library_name_platform buffer
+ * \param[in] debug if true the library will return a debug library name, otherwise
+ * it returns a normal library path
  * \return `RCUTILS_RET_OK` if successful, or
  * \return `RCUTILS_RET_ERROR` if an unknown error occurs
  */
@@ -157,7 +159,8 @@ rcutils_ret_t
 rcutils_get_platform_library_name(
   const char * library_name,
   char * library_name_platform,
-  unsigned int buffer_size);
+  unsigned int buffer_size,
+  bool debug);
 
 #ifdef __cplusplus
 }

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -160,7 +160,8 @@ rcutils_ret_t
 rcutils_get_platform_library_name(
   const char * library_name,
   char * library_name_platform,
-  unsigned int buffer_size)
+  unsigned int buffer_size,
+  bool debug)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_name_platform, RCUTILS_RET_INVALID_ARGUMENT);
@@ -168,19 +169,40 @@ rcutils_get_platform_library_name(
   int written = 0;
 
 #ifdef __linux__
-  if (buffer_size >= (strlen(library_name) + 7)) {
-    written = rcutils_snprintf(
-      library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
+  if (debug) {
+    if (buffer_size >= (strlen(library_name) + 8)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 8, "lib%sd.so", library_name);
+    }
+  } else {
+    if (buffer_size >= (strlen(library_name) + 7)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 7, "lib%s.so", library_name);
+    }
   }
 #elif __APPLE__
-  if (buffer_size >= (strlen(library_name) + 10)) {
-    written = rcutils_snprintf(
-      library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
+  if (debug) {
+    if (buffer_size >= (strlen(library_name) + 11)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 11, "lib%sd.dylib", library_name);
+    }
+  } else {
+    if (buffer_size >= (strlen(library_name) + 10)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 10, "lib%s.dylib", library_name);
+    }
   }
 #elif _WIN32
-  if (buffer_size >= (strlen(library_name) + 7)) {
-    written = rcutils_snprintf(
-      library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
+  if (debug) {
+    if (buffer_size >= (strlen(library_name) + 6)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 6, "%sd.dll", library_name);
+    }
+  } else {
+    if (buffer_size >= (strlen(library_name) + 5)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
+    }
   }
 #endif
   if (written <= 0) {

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -46,7 +46,7 @@ TEST_F(TestSharedLibrary, basic_load) {
   EXPECT_TRUE(lib.lib_pointer == NULL);
   EXPECT_FALSE(rcutils_is_shared_library_loaded(&lib));
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library
@@ -66,7 +66,7 @@ TEST_F(TestSharedLibrary, basic_load) {
 TEST_F(TestSharedLibrary, load_two_times) {
   rcutils_ret_t ret;
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library
@@ -93,7 +93,7 @@ TEST_F(TestSharedLibrary, error_load) {
   ret = rcutils_load_shared_library(&lib_empty, NULL, rcutils_get_zero_initialized_allocator());
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   ret = rcutils_load_shared_library(
@@ -105,7 +105,7 @@ TEST_F(TestSharedLibrary, error_load) {
 TEST_F(TestSharedLibrary, error_unload) {
   rcutils_ret_t ret;
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   ret = rcutils_load_shared_library(&lib, library_path, rcutils_get_default_allocator());
@@ -138,7 +138,7 @@ TEST_F(TestSharedLibrary, basic_symbol) {
   ret = rcutils_has_symbol(nullptr, "symbol");
   EXPECT_FALSE(ret);
 
-  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024);
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   // getting shared library


### PR DESCRIPTION
I have seen this error on the buildfarm in PluginLib. Requesting for a missing reference `class_loader::systemLibrarySuffix` this function was removed from class_loader. I integrate this on rcutils

```
(.text._ZN9pluginlib11ClassLoaderIN9test_base5FubarEE23getAllLibraryPathsToTryERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESB_[_ZN9pluginlib11ClassLoaderIN9test_base5FubarEE23getAllLibraryPathsToTryERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESB_]+0x415): undefined reference to `class_loader::systemLibrarySuffix[abi:cxx11]()'
21:35:03 /usr/bin/ld: unique_ptr_test.cpp:
```

Signed-off-by: ahcorde <ahcorde@gmail.com>