### PR TITLE
define NOMINMAX before including windows.h

### DIFF
--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -26,6 +26,9 @@ extern "C"
 #include <dlfcn.h>
 typedef void * rcutils_shared_library_handle_t;
 #else
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 typedef HINSTANCE rcutils_shared_library_handle_t;
 #endif  // _WIN32


### PR DESCRIPTION
Trying to fix the regression causing the Windows build to fails as described in ros2/rclcpp#1053.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9919)](https://ci.ros2.org/job/ci_windows/9919/)