### PR TITLE
Assume WIN32 HINSTANCE is a void *

### DIFF
--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -22,17 +22,6 @@ extern "C"
 
 #include <string.h>
 
-#ifndef _WIN32
-#include <dlfcn.h>
-typedef void * rcutils_shared_library_handle_t;
-#else
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-typedef HINSTANCE rcutils_shared_library_handle_t;
-#endif  // _WIN32
-
 #include "rcutils/allocator.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/macros.h"
@@ -41,8 +30,8 @@ typedef HINSTANCE rcutils_shared_library_handle_t;
 /// Handle to a loaded shared library.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
 {
-  /// The pointer to the shared library
-  rcutils_shared_library_handle_t lib_pointer;
+  /// The platform-specific pointer to the shared library
+  void * lib_pointer;
   /// The path of the shared_library
   char * library_path;
   /// allocator

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -19,6 +19,13 @@ extern "C"
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#else
+#include <windows.h>
+C_ASSERT(sizeof(void *) == sizeof(HINSTANCE));
+#endif  // _WIN32
+
 #include "rcutils/error_handling.h"
 #include "rcutils/shared_library.h"
 #include "rcutils/strdup.h"
@@ -60,7 +67,7 @@ rcutils_load_shared_library(
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %s", dlerror());
 #else
-  lib->lib_pointer = LoadLibrary(lib->library_path);
+  lib->lib_pointer = (void *)(LoadLibrary(lib->library_path));
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %lu", GetLastError());
 #endif  // _WIN32
@@ -89,7 +96,7 @@ rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
     return NULL;
   }
 #else
-  void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
+  void * lib_symbol = GetProcAddress((HINSTANCE)(lib->lib_pointer), symbol_name);
   if (lib_symbol == NULL) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting the symbol '%s'. Error '%d'",
@@ -121,7 +128,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
   void * lib_symbol = dlsym(lib->lib_pointer, symbol_name);
   return dlerror() == NULL && lib_symbol != 0;
 #else
-  void * lib_symbol = GetProcAddress(lib->lib_pointer, symbol_name);
+  void * lib_symbol = GetProcAddress((HINSTANCE)(lib->lib_pointer), symbol_name);
   return GetLastError() == 0 && lib_symbol != 0;
 #endif  // _WIN32
 }
@@ -142,7 +149,7 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib)
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("dlclose error: %s", dlerror());
 #else
   // If the function succeeds, the return value is nonzero.
-  int error_code = FreeLibrary(lib->lib_pointer);
+  int error_code = FreeLibrary((HINSTANCE)(lib->lib_pointer));
   if (!error_code) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("FreeLibrary error: %lu", GetLastError());
 #endif  // _WIN32


### PR DESCRIPTION
According to [MSDN](https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types), `HINSTANCE` is a `HANDLE` is a `PVOID` is a `void *` everywhere on Windows. If we assume this, we can drop the problematic Windows.h include from our header and contain it to a single source file.

I included a sanity check that will break if this assumption is ever broken.

Alternative to #229
Inspired by https://github.com/ros2/geometry2/pull/247/#issuecomment-611665009
