### PR TITLE
Make sure to initialize buffers for logging testing.

### DIFF
--- a/src/char_array.c
+++ b/src/char_array.c
@@ -56,6 +56,7 @@ rcutils_char_array_init(
       char_array->buffer_capacity = 0lu;
       char_array->buffer_length = 0lu;
       return RCUTILS_RET_BAD_ALLOC);
+    char_array->buffer[0] = '\0';
   }
 
   return RCUTILS_RET_OK;

--- a/test/test_logging_custom_env.cpp
+++ b/test/test_logging_custom_env.cpp
@@ -42,9 +42,7 @@ TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcutils_char_array_t msg_buf, output_buf;
   ret = rcutils_char_array_init(&msg_buf, 1024, &allocator);
-  msg_buf.buffer[0] = '\0';
   ret = rcutils_char_array_init(&output_buf, 1024, &allocator);
-  output_buf.buffer[0] = '\0';
   rcutils_time_point_value_t now = 0;
 
   ret = rcutils_logging_format_message(

--- a/test/test_logging_custom_env.cpp
+++ b/test/test_logging_custom_env.cpp
@@ -42,10 +42,15 @@ TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcutils_char_array_t msg_buf, output_buf;
   ret = rcutils_char_array_init(&msg_buf, 1024, &allocator);
+  msg_buf.buffer[0] = '\0';
   ret = rcutils_char_array_init(&output_buf, 1024, &allocator);
+  output_buf.buffer[0] = '\0';
   rcutils_time_point_value_t now = 0;
 
   ret = rcutils_logging_format_message(
     NULL, RCUTILS_LOG_SEVERITY_FATAL, NULL, now, msg_buf.buffer, &output_buf);
   EXPECT_EQ(RCUTILS_RET_OK, ret);
+
+  EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_fini(&output_buf));
+  EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_fini(&msg_buf));
 }


### PR DESCRIPTION
Also ensure that we cleanup afterwards.  This removes warnings
on asan where we were accessing invalid memory, and also warnings
that this was leaking memory.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Along with #232, solves #231