### PR TITLE
Add a RCUTILS_DEPRECATED macro to enable platform specific deprecation

### DIFF
--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -92,7 +92,7 @@ extern "C"
   __attribute__ ((format(printf, format_string_index, first_to_check_index)))
 #endif  // !defined _WIN32 || defined __CYGWIN__
 
-/// Macro to declare deprecation in the platform appropriate mannor.
+/// Macro to declare deprecation in the platform appropriate manner.
 #ifndef _WIN32
 # define RCUTILS_DEPRECATED __attribute__((deprecated))
 #else

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -92,6 +92,13 @@ extern "C"
   __attribute__ ((format(printf, format_string_index, first_to_check_index)))
 #endif  // !defined _WIN32 || defined __CYGWIN__
 
+/// Macro to declare deprecation in the platform appropriate mannor.
+#ifndef _WIN32
+# define RCUTILS_DEPRECATED __attribute__((deprecated))
+#else
+# define RCUTILS_DEPRECATED __declspec(deprecated)
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This provides an equivalent to ROS_DEPRECATED

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10081)](http://ci.ros2.org/job/ci_linux/10081/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5668)](http://ci.ros2.org/job/ci_linux-aarch64/5668/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8201)](http://ci.ros2.org/job/ci_osx/8201/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9983)](http://ci.ros2.org/job/ci_windows/9983/)