### PR TITLE
Add deprecated with message macro

### DIFF
--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -99,6 +99,13 @@ extern "C"
 # define RCUTILS_DEPRECATED __declspec(deprecated)
 #endif
 
+/// Macro to declare deprecation in the platform appropriate manner with a message.
+#ifndef _WIN32
+# define RCUTILS_DEPRECATED_WITH_MSG(msg) __attribute__((deprecated(msg)))
+#else
+# define RCUTILS_DEPRECATED_WITH_MSG(msg) __declspec(deprecated(msg))
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Following up  https://github.com/ros2/rcutils/pull/234#pullrequestreview-391627742

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10086)](http://ci.ros2.org/job/ci_linux/10086/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=5672)](http://ci.ros2.org/job/ci_linux-aarch64/5672/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8205)](http://ci.ros2.org/job/ci_osx/8205/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=9988)](http://ci.ros2.org/job/ci_windows/9988/)