### PR TITLE
Don't check GetLastError() on success

### DIFF
--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -129,7 +129,7 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
   return dlerror() == NULL && lib_symbol != 0;
 #else
   void * lib_symbol = GetProcAddress((HINSTANCE)(lib->lib_pointer), symbol_name);
-  return GetLastError() == 0 && lib_symbol != 0;
+  return lib_symbol != NULL;
 #endif  // _WIN32
 }
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -135,6 +135,8 @@ TEST_F(TestSharedLibrary, basic_symbol) {
   symbol = rcutils_get_symbol(nullptr, "symbol");
   EXPECT_TRUE(symbol == NULL);
 
+  rcutils_reset_error();
+
   ret = rcutils_has_symbol(nullptr, "symbol");
   EXPECT_FALSE(ret);
 
@@ -150,6 +152,9 @@ TEST_F(TestSharedLibrary, basic_symbol) {
 
   symbol = rcutils_get_symbol(&lib, "print_name");
   EXPECT_TRUE(symbol != NULL);
+
+  ret = rcutils_has_symbol(&lib, "print_name");
+  EXPECT_TRUE(ret);
 
   // unload shared_library
   ret = rcutils_unload_shared_library(&lib);


### PR DESCRIPTION
According to MSDN, not all functions set `GetLastError` when they succeed: https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror#return-value

In particular, `GetProcAddress` only explicitly states that `GetLastError` is set when the return value is `NULL`: https://docs.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getprocaddress#return-value