### PR TITLE
Don't assume errno is set to 0 on success on Windows

### DIFF
--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -56,12 +56,13 @@ rcutils_vsnprintf(char * buffer, size_t buffer_size, const char * format, va_lis
 #ifndef _WIN32
   ret = vsnprintf(buffer, buffer_size, format, args);
 #else
-  errno_t errno_ret = _vsnprintf_s(buffer, buffer_size, _TRUNCATE, format, args);
-  if (-1 == errno_ret && 0 == errno) {
+  // errno isn't explicitly set to 0 when truncation occurs.
+  errno = 0;
+  ret = _vsnprintf_s(buffer, buffer_size, _TRUNCATE, format, args);
+  if (-1 == ret && 0 == errno) {
     // This is the case where truncation has occurred, return how long it would have been.
     return _vscprintf(format, args);
   }
-  ret = errno_ret;
 #endif
   return ret;
 }

--- a/test/test_snprintf.cpp
+++ b/test/test_snprintf.cpp
@@ -47,5 +47,13 @@ TEST(TestSnprintf, test_snprintf) {
   EXPECT_EQ(static_cast<int>(strlen(test_str)), ret);
   EXPECT_STREQ("0", buffer);
 
+  ret = rcutils_snprintf(buffer, strlen(test_str), "%s", test_str);
+  EXPECT_EQ(static_cast<int>(strlen(test_str)), ret);
+  EXPECT_STREQ("012345678", buffer);
+
+  ret = rcutils_snprintf(buffer, strlen(test_str) + 1, "%s", test_str);
+  EXPECT_EQ(static_cast<int>(strlen(test_str)), ret);
+  EXPECT_STREQ(test_str, buffer);
+
   EXPECT_EQ(-1, rcutils_snprintf(buffer, 2, NULL));  // NOLINT(runtime/printf)
 }


### PR DESCRIPTION
Many Windows functions don't set `errno` or call `SetLastError(0)` when they are successful. This particular case is special because the return value is the same when the output string is truncated as when an error occurs.

However, the output string truncation isn't an error itself, and so `errno` is not explicitly set to 0.

Credit to @brawner for narrowing down the bug.