### PR TITLE
Current state Quality Declaration for rcutils

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -123,3 +123,50 @@ It also has several test dependencies, which do not affect the resulting quality
 
 `rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
 
+# Current status Summary
+
+The chart below compares the requirements in the REP-2004 with the current state of the rcutils package.
+|Number|  Requirement| Current state |
+|--|--|--|
+|1| **Version policy** |---|
+|1.i|Version Policy available | ✓ |
+|1.ii|Stable version |☓|
+|1.iii|Declared public API|✓|
+|1.iv|API stability policy|✓|
+|1.v|ABI stability policy|✓|
+|1.vi_|API/ABI stable within ros distribution|✓|
+|2| **Change control proces**s |---|
+|2.i| All changes occur on change request | ✓|
+|2.ii| Contributor origin (DCO, CLA, etc) | ✓|
+|2.iii| Peer review policy | ✓ |
+|2.iv| CI policy for change requests | ✓ |
+|2.v| Documentation policy for change requests | ☓ |
+|3| **Documentation** | --- |
+|3.i| Per feature documentation | ☓ |
+|3.ii| Per public API item documentation | ☓ |
+|3.iii| Declared License(s) | ✓ |
+|3.iv| Copyright in source files| ✓ |
+|3.v.a| Quality declaration linked to README | ✓ |
+|3.v.b| Centralized declaration available for peer review |✓|
+|4| Testing | --- |
+|4.i| Feature items tests | ☓ |
+|4.ii| Public API tests | ☓ |
+|4.iii.a| Using coverage |✓ |
+|4.iii.a| Coverage policy | ✓ |
+|4.iv.a| Performance tests (if applicable) | ? |
+|4.iv.b| Performance tests policy| ✓ |
+|4.v.a| Code style enforcement (linters)| ✓ |
+|4.v.b| Use of static analysis tools | ✓ |
+|5| Dependencies | --- |
+|5.i| Must not have ROS lower level dependencies | ✓ |
+|5.ii| Optional ROS lower level dependencies| ✓ |
+|5.iii| Justifies quality use of non-ROS dependencies |✓|
+|6| Platform support | --- |
+|6.i| Support targets Tier1 ROS platforms| ✓ |
+|7| Security | --- |
+|7.i| Vulnerability Disclosure Policy | ? |
+
+Comparing this table with the [Quality Level Comparison Chart of REP2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) lead us to decide that this package qualifies to Quality Level 4. Missing to quality level 3:
+
+1.ii, Stable version
+7.i, Vulnerability Disclosure Policy (To be defined in Developer Guide for ROS2 Core packages)

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -7,7 +7,7 @@ This document is a declaration of software quality for the `rcutils` package, ba
 
 The package `rcutils` claims to be in the **Quality Level 4** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004 ](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#quality-level-1) of the ROS2 developer guide.
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Quality Categories in REP-2004](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-quality-categories) of the ROS2 developer guide.
 
 ## Version Policy [1]
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -46,7 +46,7 @@ The source templates for these generated headers are in the `resource` folder.
 All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
 ### Contributor Origin [2.ii]
-All pull requests must have confirmation of contributor origin. This repository uses DCO.
+This package uses DCO as its confirmation of contributor origin policy. More information can be found in [CONTRIBUTING](./CONTRIBUTING.md)
 
 ### Peer Review Policy [2.iii]
 All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -79,11 +79,12 @@ There is an automated test which runs a linter that ensures each file has at lea
 
 Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the [`test`](https://github.com/ros2/rcutils/tree/master/test) directory.
 New features are required to have tests before being added.
-Currently nightly results can be seen here:
+Currently nightly test results can be seen here:
 * [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcutils/)
 * [linux-arm64_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcutils/)
 * [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rcutils/)
 * [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rcutils/)
+
 ### Public API Testing [4.ii]
 
 Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
@@ -112,6 +113,12 @@ It is not yet defined if this package requires performance testing and how addre
 
 `rcutils` uses and passes all the ROS2 standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
+Currently nightly test results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcutils/)
+* [linux-arm64_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcutils/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rcutils/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rcutils/)
+
 ## Dependencies [5]
 
 ### Direct Runtime ROS Dependencies [5.i]
@@ -128,6 +135,12 @@ It has several "buildtool" dependencies, which do not affect the resulting quali
 ## Platform Support [6]
 
 `rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+Currently nightly build status can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/rcutils/)
+* [linux-arm64_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/rcutils/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/rcutils/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/rcutils/)
 
 # Current status Summary
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -65,7 +65,7 @@ All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://in
 
 The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](./LICENSE) file.
 
-There is an automated test which runs a linter that ensures each file has a license statement.
+There is an automated test which runs a linter that ensures each file has a license statement. [Here](http://build.ros2.org/view/Epr/job/Epr__rcutils__ubuntu_bionic_amd64/lastBuild/testReport/rcutils/) can be found a list with the latest results of the various linters being run on the package.
 
 ### Copyright Statements [3.iv]
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -100,7 +100,7 @@ This includes:
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
-Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/src_ros2_rcutils_src/)
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/lastBuild/cobertura/src_ros2_rcutils_src/)
 
 ### Performance [4.iv]
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,4 +1,5 @@
-This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `rcutils` Quality Declaration
 
@@ -14,7 +15,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 
 ### API Stability Within a Released ROS Distribution
 
-`rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+`rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
 
 ### ABI Stability Within a Released ROS Distribution
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -71,7 +71,7 @@ There is an automated test which runs a linter that ensures each file has a lice
 
 The copyright holders each provide a statement of copyright in each source code file in `rcutils`.
 
-There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+There is an automated test which runs a linter that ensures each file has at least one copyright statement. Latest linter result report can be seen [here](http://build.ros2.org/view/Epr/job/Epr__rcutils__ubuntu_bionic_amd64/lastBuild/testReport/rcutils/copyright/).
 
 ## Testing [4]
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,0 +1,132 @@
+This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rcutils` Quality Declaration
+
+The package `rcutils` claims to be in the **Quality Level 1** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy
+
+### Version Scheme
+
+`rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+
+### API Stability Within a Released ROS Distribution
+
+`rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution
+
+`rcutils` contains C code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+
+### Public API Declaration
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package, headers in any other folders are not installed and considered private.
+
+Additionally, there are generated header files which are installed and therefore part of the public API.
+The source templates for these generated headers are in the `resource` folder.
+
+## Change Control Process
+
+TODO fix link
+
+`rcutils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change_control_process).
+
+This includes:
+
+- all changes occur through a pull request
+- all pull request have two peer reviews
+- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+- all pull request must resolve related documentation changes before merging
+
+## Documentation
+
+### Feature Documentation
+
+TODO fix link
+
+`rcutils` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
+There is documentation for all of the features, and new features require documentation before being added.
+
+### Public API Documentation
+
+TODO fix link
+
+`rcutils` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
+There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+
+### License
+
+The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+
+There is an automated test which runs a linter that ensures each file has a license statement.
+
+### Copyright Statements
+
+The copyright holders each provide a statement of copyright in each source code file in `rcutils`.
+
+There is an automated test which runs a linter that ensures each file has at least one copyright statement.
+
+## Testing
+
+### Feature Testing
+
+Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
+New features are required to have tests before being added.
+
+### Public API Testing
+
+Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
+The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
+
+### Coverage
+
+TODO fix link
+
+`rcutils` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use branch coverage instead of line coverage.
+
+This includes:
+
+- tracking and reporting branch coverage statistics
+- achieving and maintaining branch coverage at or above 95%
+- no lines are manually skipped in coverage calculations
+
+Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
+
+Current coverage statistics can be viewed here:
+
+TODO FIXME
+
+### Performance
+
+TODO fix link
+
+`rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance-c), and opts to do performance analysis on each release rather than each change.
+
+TODO how to run perf tests, where do they live, etc.
+
+TODO exclusions of parts of the code from perf testing listed here? or linked to?
+
+### Linters and Static Analysis
+
+TODO fix link
+
+`rcutils` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis).
+
+TODO any qualifications on what "passing" means for certain linters
+
+## Dependencies
+
+`rcutils` has no run-time or build-time dependencies that need to be considered for this declaration.
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
+
+## Platform Support
+
+`rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+
+TODO make additional statements about non-tier 1 platforms?

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -25,7 +25,6 @@ All installed headers are in the `include` directory of the package, headers in 
 Additionally, there are generated header files which are installed and therefore part of the public API.
 The source templates for these generated headers are in the `resource` folder.
 
-
 ### API Stability Policy [1.iv]
 
 `rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
@@ -55,14 +54,10 @@ All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://in
 
 ### Feature Documentation [3.i]
 
-TODO fix link (Missing part)
-
 `rcutils` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
 There is documentation for all of the features, and new features require documentation before being added.
 
 ### Public API Documentation [3.ii]
-
-TODO fix link (Missing part)
 
 `rcutils` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
 There is documentation for all of the public API, and new additions to the public API require documentation before being added.
@@ -105,17 +100,9 @@ Changes are required to make a best effort to keep or increase coverage before b
 
 Current coverage statistics can be viewed here:
 
-TODO Add link to latest coverage results
-
 ### Performance [4.iv]
 
-TODO fix link (Missing part)
-
 `rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
-
-TODO how to run perf tests, where do they live, etc.
-
-TODO exclusions of parts of the code from perf testing listed here? or linked to?
 
 ### Linters and Static Analysis [4.v]
 
@@ -181,7 +168,26 @@ The chart below compares the requirements in the REP-2004 with the current state
 |7| Security | --- |
 |7.i| Vulnerability Disclosure Policy | ? |
 
-Comparing this table with the [Quality Level Comparison Chart of REP2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) lead us to decide that this package qualifies to Quality Level 4. Missing to quality level 3:
+Comparing this table with the [Quality Level Comparison Chart of REP2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) lead us to decide that this package qualifies to Quality Level 4.
+
+## Next steps
+Missing to quality level 3:
 
 1.ii, Stable version
 7.i, Vulnerability Disclosure Policy (To be defined in Developer Guide for ROS2 Core packages)
+
+## To-Do
+
+### Section [3.i]
+TODO fix link (Missing part)
+
+### Section [3.ii]
+TODO fix link (Missing part)
+
+### Section [4.iii]
+TODO Add link to latest coverage results
+
+### Section [4.iv]
+TODO fix link (Missing part)
+TODO how to run perf tests, where do they live, etc.
+TODO exclusions of parts of the code from perf testing listed here? or linked to?

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,4 +1,5 @@
 
+
 This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `rcutils` Quality Declaration
@@ -7,23 +8,16 @@ The package `rcutils` claims to be in the **Quality Level 4** category.
 
 Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004 ](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#quality-level-1) of the ROS2 developer guide.
 
-## Version Policy
+## Version Policy [1]
 
-### Version Scheme
+### Version Scheme [1.i]
+`rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning)
+
+### Version Stability [1.ii]
 (Missing part, bumping to version 1.0.0)
+Currently this package version is 0.7.5, soon to be released as 1.0.0
 
-`rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and it will be at a stable version, i.e. `>= 1.0.0`.
-
-### API Stability Within a Released ROS Distribution
-
-`rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
-
-### ABI Stability Within a Released ROS Distribution
-
-`rcutils` contains C code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
-
-### Public API Declaration
-
+### Public API Declaration [1.iii]
 All symbols in the installed headers are considered part of the public API.
 
 All installed headers are in the `include` directory of the package, headers in any other folders are not installed and considered private.
@@ -31,58 +25,73 @@ All installed headers are in the `include` directory of the package, headers in 
 Additionally, there are generated header files which are installed and therefore part of the public API.
 The source templates for these generated headers are in the `resource` folder.
 
-## Change Control Process
+
+### API Stability Policy [1.iv]
+
+`rcutils` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Policy [1.v]
+
+`rcutils` contains C code and therefore must be concerned with ABI stability, and will maintain ABI stability within a ROS distribution.
+
+### ABI and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rcutils` will not break API nor ABI within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+## Change Control Process [2]
 
 `rcutils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
 
-This includes:
+### Change Requests [2.i]
+All changes will occur through a pull request, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-- all changes occur through a pull request
-- all pull request will be peer-reviewed
-- all pull request must pass CI on all [tier 1 platforms](https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst)
-- all pull request must resolve related documentation changes before merging
+### Contributor Origin [2.ii]
+All pull requests must have confirmation of contributor origin. This repository uses DCO.
 
-## Documentation
+### Peer Review Policy [2.iii]
+All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process) for additional information.
 
-### Feature Documentation
+## Documentation [3]
+
+### Feature Documentation [3.i]
 
 TODO fix link (Missing part)
 
 `rcutils` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
 There is documentation for all of the features, and new features require documentation before being added.
 
-### Public API Documentation
+### Public API Documentation [3.ii]
 
 TODO fix link (Missing part)
 
 `rcutils` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
 There is documentation for all of the public API, and new additions to the public API require documentation before being added.
 
-### License
+### License [3.iii]
 
 The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](./LICENSE) file.
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
-### Copyright Statements
+### Copyright Statements [3.iv]
 
 The copyright holders each provide a statement of copyright in each source code file in `rcutils`.
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
 
-## Testing
+## Testing [4]
 
-### Feature Testing
+### Feature Testing [4.i]
 
 Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the [`test`](https://github.com/ros2/rcutils/tree/master/test) directory.
 New features are required to have tests before being added.
 
-### Public API Testing
+### Public API Testing [4.ii]
 
 Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
 The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
 
-### Coverage
+### Coverage [4.iii]
 
 `rcutils` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
 
@@ -98,7 +107,7 @@ Current coverage statistics can be viewed here:
 
 TODO Add link to latest coverage results
 
-### Performance
+### Performance [4.iv]
 
 TODO fix link (Missing part)
 
@@ -108,18 +117,24 @@ TODO how to run perf tests, where do they live, etc.
 
 TODO exclusions of parts of the code from perf testing listed here? or linked to?
 
-### Linters and Static Analysis
+### Linters and Static Analysis [4.v]
 
 `rcutils` uses and passes all the ROS2 standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
-## Dependencies
+## Dependencies [5]
 
+### Direct Runtime ROS Dependencies [5.i]
 `rcutils` has no run-time or build-time dependencies that need to be considered for this declaration.
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
-It also has several test dependencies, which do not affect the resulting quality of the package, because they are only used to build and run the test code.
 
-## Platform Support
+### Optional Direct Runtime ROS Dependencies [5.ii]
+`rcutils` has no run-time or build-time dependencies that need to be considered for this declaration.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+`rcutils` has no run-time or build-time dependencies that need to be considered for this declaration.
+
+## Platform Support [6]
 
 `rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,5 +1,6 @@
 
 
+
 This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `rcutils` Quality Declaration
@@ -53,13 +54,11 @@ All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://in
 
 ### Feature Documentation [3.i]
 
-`rcutils` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
-There is documentation for all of the features, and new features require documentation before being added.
+`rcutils` does not have a documented feature list. Soon to be added.
 
 ### Public API Documentation [3.ii]
 
-`rcutils` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
-There is documentation for all of the public API, and new additions to the public API require documentation before being added.
+`rcutils` does not cover a public API documentation. Soon to be added.
 
 ### License [3.iii]
 
@@ -97,11 +96,12 @@ This includes:
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
-Current coverage statistics can be viewed here:
+Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linux_coverage/85/cobertura/src_ros2_rcutils_src/)
 
 ### Performance [4.iv]
 
 `rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
+Soon to be defined if this package requires performance testing and how addresses this topic.
 
 ### Linters and Static Analysis [4.v]
 
@@ -154,7 +154,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |4.ii| Public API tests | ☓ |
 |4.iii.a| Using coverage |✓ |
 |4.iii.a| Coverage policy | ✓ |
-|4.iv.a| Performance tests (if applicable) | ? |
+|4.iv.a| Performance tests (if applicable) | ☓ |
 |4.iv.b| Performance tests policy| ✓ |
 |4.v.a| Code style enforcement (linters)| ✓ |
 |4.v.b| Use of static analysis tools | ✓ |
@@ -165,7 +165,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |6| Platform support | --- |
 |6.i| Support targets Tier1 ROS platforms| ✓ |
 |7| Security | --- |
-|7.i| Vulnerability Disclosure Policy | ? |
+|7.i| Vulnerability Disclosure Policy | ☓ |
 
 Comparing this table with the [Quality Level Comparison Chart of REP2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) lead us to decide that this package qualifies to Quality Level 4.
 
@@ -180,15 +180,15 @@ Missing to quality level 3:
 (Missing part, bumping to version 1.0.0)
 
 ### Section [3.i]
-TODO fix link (Missing part)
+TODO add feature list (Missing part)
 
 ### Section [3.ii]
 TODO fix link (Missing part)
-
-### Section [4.iii]
-TODO Add link to latest coverage results
 
 ### Section [4.iv]
 TODO fix link (Missing part)
 TODO how to run perf tests, where do they live, etc.
 TODO exclusions of parts of the code from perf testing listed here? or linked to?
+
+### Section [7.i]
+TODO add Vulnerability Disclosure Policy section

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -10,8 +10,9 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 ## Version Policy
 
 ### Version Scheme
+(Missing part, bumping to version 1.0.0)
 
-`rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and is at or above a stable version, i.e. `>= 1.0.0`.
+`rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning), and it will be at a stable version, i.e. `>= 1.0.0`.
 
 ### API Stability Within a Released ROS Distribution
 
@@ -45,14 +46,14 @@ This includes:
 
 ### Feature Documentation
 
-TODO fix link
+TODO fix link (Missing part)
 
 `rcutils` has a [feature list](TODO) and each item in the list links to the corresponding feature documentation.
 There is documentation for all of the features, and new features require documentation before being added.
 
 ### Public API Documentation
 
-TODO fix link
+TODO fix link (Missing part)
 
 `rcutils` has embedded API documentation and it is generated using doxygen and is [hosted](TODO) along side the feature documentation.
 There is documentation for all of the public API, and new additions to the public API require documentation before being added.
@@ -101,7 +102,7 @@ TODO FIXME
 
 ### Performance
 
-TODO fix link
+TODO fix link (Missing part)
 
 `rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance-c), and opts to do performance analysis on each release rather than each change.
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -78,7 +78,11 @@ There is an automated test which runs a linter that ensures each file has at lea
 
 Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the [`test`](https://github.com/ros2/rcutils/tree/master/test) directory.
 New features are required to have tests before being added.
-
+Currently nightly results can be seen here:
+* [linux-aarch64_release](https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/lastBuild/testReport/rcutils/)
+* [linux-arm64_release](https://ci.ros2.org/view/nightly/job/nightly_linux_release/lastBuild/testReport/rcutils/)
+* [mac_osx_release](https://ci.ros2.org/view/nightly/job/nightly_osx_release/lastBuild/testReport/rcutils/)
+* [windows_release](https://ci.ros2.org/view/nightly/job/nightly_win_rel/lastBuild/testReport/rcutils/)
 ### Public API Testing [4.ii]
 
 Each part of the public API has tests, and new additions or changes to the public API require tests before being added.

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -110,11 +110,7 @@ TODO exclusions of parts of the code from perf testing listed here? or linked to
 
 ### Linters and Static Analysis
 
-TODO fix link
-
-`rcutils` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis).
-
-TODO any qualifications on what "passing" means for certain linters
+`rcutils` uses and passes all the ROS2 standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters-and-static-analysis). Passing implies there are no linter/static errors when testing against CI of supported platforms.
 
 ## Dependencies
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -14,7 +14,6 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 `rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning)
 
 ### Version Stability [1.ii]
-(Missing part, bumping to version 1.0.0)
 Currently this package version is 0.7.5, soon to be released as 1.0.0
 
 ### Public API Declaration [1.iii]
@@ -177,6 +176,8 @@ Missing to quality level 3:
 7.i, Vulnerability Disclosure Policy (To be defined in Developer Guide for ROS2 Core packages)
 
 ## To-Do
+### Section [1.ii]
+(Missing part, bumping to version 1.0.0)
 
 ### Section [3.i]
 TODO fix link (Missing part)

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -3,7 +3,7 @@ This document is a declaration of software quality for the `rcutils` package, ba
 
 # `rcutils` Quality Declaration
 
-The package `rcutils` claims to be in the **Quality Level 1** category.
+The package `rcutils` claims to be in the **Quality Level 4** category.
 
 Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004 ](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#quality-level-1) of the ROS2 developer guide.
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -5,7 +5,7 @@ This document is a declaration of software quality for the `rcutils` package, ba
 
 The package `rcutils` claims to be in the **Quality Level 1** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 1 in REP-2004 ](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#quality-level-1) of the ROS2 developer guide.
 
 ## Version Policy
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -102,7 +102,7 @@ TODO Add link to latest coverage results
 
 TODO fix link (Missing part)
 
-`rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance-c), and opts to do performance analysis on each release rather than each change.
+`rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
 
 TODO how to run perf tests, where do they live, etc.
 
@@ -122,3 +122,4 @@ It also has several test dependencies, which do not affect the resulting quality
 ## Platform Support
 
 `rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
+

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -60,7 +60,7 @@ There is documentation for all of the public API, and new additions to the publi
 
 ### License
 
-The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the `package.xml` manifest file, and a full copy of the license is in the `LICENSE` file.
+The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](https://github.com/ros2/rcutils/blob/master/package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](https://github.com/ros2/rcutils/blob/master/LICENSE) file.
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
@@ -74,7 +74,7 @@ There is an automated test which runs a linter that ensures each file has at lea
 
 ### Feature Testing
 
-Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the `test` directory.
+Each feature in `rcutils` has corresponding tests which simulate typical usage, and they are located in the [`test`](https://github.com/ros2/rcutils/tree/master/test) directory.
 New features are required to have tests before being added.
 
 ### Public API Testing

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -122,5 +122,3 @@ It also has several test dependencies, which do not affect the resulting quality
 ## Platform Support
 
 `rcutils` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), and tests each change against all of them.
-
-TODO make additional statements about non-tier 1 platforms?

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -79,7 +79,7 @@ New features are required to have tests before being added.
 
 ### Public API Testing
 
-Each part of the public API have tests, and new additions or changes to the public API require tests before being added.
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
 The tests aim to cover both typical usage and corner cases, but are quantified by contributing to code coverage.
 
 ### Coverage

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -84,21 +84,19 @@ The tests aim to cover both typical usage and corner cases, but are quantified b
 
 ### Coverage
 
-TODO fix link
-
-`rcutils` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#coverage), and opts to use branch coverage instead of line coverage.
+`rcutils` follows the recommendations for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#code-coverage), and opts to use line coverage instead of branch coverage.
 
 This includes:
 
-- tracking and reporting branch coverage statistics
-- achieving and maintaining branch coverage at or above 95%
+- tracking and reporting line coverage statistics
+- achieving and maintaining a reasonable branch line coverage (90-100%)
 - no lines are manually skipped in coverage calculations
 
 Changes are required to make a best effort to keep or increase coverage before being accepted, but decreases are allowed if properly justified and accepted by reviewers.
 
 Current coverage statistics can be viewed here:
 
-TODO FIXME
+TODO Add link to latest coverage results
 
 ### Performance
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -135,7 +135,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |1.iv|API stability policy|✓|
 |1.v|ABI stability policy|✓|
 |1.vi_|API/ABI stable within ros distribution|✓|
-|2| **Change control proces**s |---|
+|2| **Change control process** |---|
 |2.i| All changes occur on change request | ✓|
 |2.ii| Contributor origin (DCO, CLA, etc) | ✓|
 |2.iii| Peer review policy | ✓ |

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -60,7 +60,7 @@ There is documentation for all of the public API, and new additions to the publi
 
 ### License
 
-The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](https://github.com/ros2/rcutils/blob/master/package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](https://github.com/ros2/rcutils/blob/master/LICENSE) file.
+The license for `rcutils` is Apache 2.0, and a summary is in each source file, the type is declared in the [`package.xml`](./package.xml) manifest file, and a full copy of the license is in the [`LICENSE`](./LICENSE) file.
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -32,15 +32,13 @@ The source templates for these generated headers are in the `resource` folder.
 
 ## Change Control Process
 
-TODO fix link
-
-`rcutils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change_control_process).
+`rcutils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#change-control-process).
 
 This includes:
 
 - all changes occur through a pull request
-- all pull request have two peer reviews
-- all pull request must pass CI on all [tier 1 platforms](https://www.ros.org/reps/rep-2000.html#support-tiers)
+- all pull request will be peer-reviewed
+- all pull request must pass CI on all [tier 1 platforms](https://github.com/ros-infrastructure/rep/blob/master/rep-2000.rst)
 - all pull request must resolve related documentation changes before merging
 
 ## Documentation

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -1,6 +1,7 @@
 
 
 
+
 This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
 
 # `rcutils` Quality Declaration
@@ -15,7 +16,7 @@ Below are the rationales, notes, and caveats for this claim, organized by each r
 `rcutils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning)
 
 ### Version Stability [1.ii]
-Currently this package version is 0.7.5, soon to be released as 1.0.0
+Currently this package version is 0.7.5.
 
 ### Public API Declaration [1.iii]
 All symbols in the installed headers are considered part of the public API.
@@ -54,11 +55,11 @@ All pull request will be peer-reviewed, check [ROS 2 Developer Guide](https://in
 
 ### Feature Documentation [3.i]
 
-`rcutils` does not have a documented feature list. Soon to be added.
+`rcutils` does not have a documented feature list.
 
 ### Public API Documentation [3.ii]
 
-`rcutils` does not cover a public API documentation. Soon to be added.
+`rcutils` does not cover a public API documentation.
 
 ### License [3.iii]
 
@@ -105,7 +106,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/ci_linu
 ### Performance [4.iv]
 
 `rcutils` follows the recommendations for performance testing of C code in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#performance), and opts to do performance analysis on each release rather than each change.
-Soon to be defined if this package requires performance testing and how addresses this topic.
+It is not yet defined if this package requires performance testing and how addresses this topic.
 
 ### Linters and Static Analysis [4.v]
 
@@ -179,20 +180,3 @@ Missing to quality level 3:
 1.ii, Stable version
 7.i, Vulnerability Disclosure Policy (To be defined in Developer Guide for ROS2 Core packages)
 
-## To-Do
-### Section [1.ii]
-(Missing part, bumping to version 1.0.0)
-
-### Section [3.i]
-TODO add feature list (Missing part)
-
-### Section [3.ii]
-TODO fix link (Missing part)
-
-### Section [4.iv]
-TODO fix link (Missing part)
-TODO how to run perf tests, where do they live, etc.
-TODO exclusions of parts of the code from perf testing listed here? or linked to?
-
-### Section [7.i]
-TODO add Vulnerability Disclosure Policy section

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 `rcutils` is a C API consisting of macros, functions, and data structures used through out the ROS 2 code base.
 
+## Quality Declaration
+
+This package claims to be in the **Quality Level 1** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.
+
+## API
+
 The API is a combination of parts:
 
 - Allocator concept, used to inject the allocating and deallocating methods into a function or type.


### PR DESCRIPTION
This PR extends #202 changing some links, wording and adding a Current State section where is a table similar to the one presented in [REP-2004](https://github.com/ros-infrastructure/rep/blob/d1074e43f25f957d75f50dbfda94ab10d86bcbfd/rep-2004.rst#quality-level-comparison-chart) that can be useful to categorize the missing parts to move packages to Q1 as we make progress.

The current state is Quality level 4, as the package version is not yet 1.0.0 and the ROS2 developer guide will need to have a section addressing a Vulnerability Disclosure Policy.