### PR TITLE
Add rcutils_get_temp_name function

### DIFF
--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -187,6 +187,19 @@ RCUTILS_PUBLIC
 size_t
 rcutils_get_file_size(const char * file_path);
 
+/// Return a unique temporary filename.
+/**
+ * \param[in] buffer Allocated string to store the filename.
+ * \param[in] max_length maximum length to be stored in buffer
+ * \return `True` if success
+ * \return `False` if buffer is NULL
+ * \return `False` on failure
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+bool
+rcutils_get_temp_name(char * buffer, size_t max_length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -275,6 +275,24 @@ rcutils_get_file_size(const char * file_path)
   return rc == 0 ? (size_t)(stat_buffer.st_size) : 0;
 }
 
+bool
+rcutils_get_temp_name(char * buffer, size_t max_length)
+{
+  if (NULL == buffer || max_length == 0) {
+    return false;
+  }
+#ifdef _WIN32
+  if (0 != tmpnam_s(buffer, max_length)) {
+    return false;
+  }
+#else
+  if (max_length < L_tmpnam || NULL == tmpnam_r(buffer)) {
+    return false;
+  }
+#endif  // _WIN32
+  return true;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -360,3 +360,14 @@ TEST_F(TestFilesystemFixture, calculate_file_size) {
     g_allocator.deallocate(non_existing_path, g_allocator.state);
   });
 }
+
+TEST_F(TestFilesystemFixture, get_temp_name) {
+  char temp_name[L_tmpnam];
+
+  EXPECT_FALSE(rcutils_get_temp_name(NULL, sizeof(temp_name)));
+  EXPECT_FALSE(rcutils_get_temp_name(temp_name, 0));
+  EXPECT_FALSE(rcutils_get_temp_name(temp_name, 1));
+
+  EXPECT_TRUE(rcutils_get_temp_name(temp_name, sizeof(temp_name)));
+  EXPECT_FALSE(rcutils_exists(temp_name));
+}


### PR DESCRIPTION
This change adds a method for obtaining a unique temp path. The interface is modeled after `rcutils_get_cwd`, which aligns well with the Win32 API, but not perfectly with the posix API.