### PR TITLE
Fixed a link to REP-2004 in QUALITY_DECLARATION.md

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -2,7 +2,7 @@
 
 
 
-This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/rep-2004/rep-2004.rst).
+This document is a declaration of software quality for the `rcutils` package, based on the guidelines in [REP-2004](https://github.com/ros-infrastructure/rep/blob/master/rep-2004.rst).
 
 # `rcutils` Quality Declaration
 


### PR DESCRIPTION
The `rep-2004` branch merged at https://github.com/ros-infrastructure/rep/pull/218 .

This PR fixed a link to the REP-2004 page.