### PR TITLE
Better support and testing for empty string_array

### DIFF
--- a/src/string_array.c
+++ b/src/string_array.c
@@ -52,7 +52,7 @@ rcutils_string_array_init(
   }
   string_array->size = size;
   string_array->data = allocator->zero_allocate(size, sizeof(char *), allocator->state);
-  if (NULL == string_array->data) {
+  if (NULL == string_array->data && 0 != size) {
     RCUTILS_SET_ERROR_MSG("failed to allocator string array");
     return RCUTILS_RET_BAD_ALLOC;
   }

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -99,15 +99,18 @@ rcutils_string_array_cmp(
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     rhs, "rhs string array is null", return RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    lhs->data, "lhs->data is null", return RCUTILS_RET_INVALID_ARGUMENT);
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-    rhs->data, "rhs->data is null", return RCUTILS_RET_INVALID_ARGUMENT);
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     res, "res argument is null", return RCUTILS_RET_INVALID_ARGUMENT);
 
   size_t smallest_size = lhs->size;
   if (rhs->size < smallest_size) {
     smallest_size = rhs->size;
+  }
+
+  if (smallest_size > 0) {
+    RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+      lhs->data, "lhs->data is null", return RCUTILS_RET_INVALID_ARGUMENT);
+    RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+      rhs->data, "rhs->data is null", return RCUTILS_RET_INVALID_ARGUMENT);
   }
 
   for (size_t i = 0; i < smallest_size; ++i) {

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -57,6 +57,10 @@ TEST(test_string_array, boot_string_array) {
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_fini(&sa3));
   sa3.allocator = allocator;
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_fini(&sa3));
+
+  rcutils_string_array_t sa4 = rcutils_get_zero_initialized_string_array();
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_init(&sa4, 0, &allocator));
+  ASSERT_EQ(0u, sa4.size);
 }
 
 TEST(test_string_array, string_array_cmp) {
@@ -92,6 +96,7 @@ TEST(test_string_array, string_array_cmp) {
   sa3.data[0] = strdup("foo");
   sa3.data[1] = strdup("bar");
 
+  rcutils_string_array_t empty_string_array = rcutils_get_zero_initialized_string_array();
   rcutils_string_array_t incomplete_string_array = rcutils_get_zero_initialized_string_array();
   ret = rcutils_string_array_init(&incomplete_string_array, 3, &allocator);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
@@ -117,6 +122,11 @@ TEST(test_string_array, string_array_cmp) {
   EXPECT_LT(res, 0);
   // Test transitivity
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_string_array_cmp(&sa3, &sa2, &res));
+  EXPECT_LT(res, 0);
+  // Test empty
+  EXPECT_EQ(RCUTILS_RET_OK, rcutils_string_array_cmp(&sa0, &empty_string_array, &res));
+  EXPECT_GT(res, 0);
+  EXPECT_EQ(RCUTILS_RET_OK, rcutils_string_array_cmp(&empty_string_array, &sa0, &res));
   EXPECT_LT(res, 0);
 
   ret = rcutils_string_array_fini(&sa0);


### PR DESCRIPTION
Specifically test for `string_array`s of size 0, and relax the null check in `rcutils_string_array_cmp` when it won't be used.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10737)](http://ci.ros2.org/job/ci_linux/10737/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6137)](http://ci.ros2.org/job/ci_linux-aarch64/6137/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8743)](http://ci.ros2.org/job/ci_osx/8743/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10627)](http://ci.ros2.org/job/ci_windows/10627/)