### PR TITLE
Add rcutils_string_array_resize function

### DIFF
--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -135,10 +135,11 @@ rcutils_string_array_cmp(
 
 /// Resize a string array, reclaiming removed resources.
 /**
- * This function changes the size of an existing string array. If the new size
- * is larger, new entries are added to the end of the array and are zero-
- * initialized. If the new size is smaller, entries are removed from the end of
- * the array and their resources reclaimed.
+ * This function changes the size of an existing string array.
+ * If the new size is larger, new entries are added to the end of the array and
+ * are zero- initialized.
+ * If the new size is smaller, entries are removed from the end of the array
+ * and their resources reclaimed.
  *
  * \par Note:
  * Resizing to 0 is not a substitute for calling ::rcutils_string_array_fini.

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -133,6 +133,27 @@ rcutils_string_array_cmp(
   const rcutils_string_array_t * rhs,
   int * res);
 
+/// Resize a string array, reclaiming removed resources.
+/**
+ * This function changes the size of an existing string array. If the new size
+ * is larger, new entries are added to the end of the array and are zero-
+ * initialized. If the new size is smaller, entries are removed from the end of
+ * the array and their resources reclaimed.
+ *
+ * \param[inout] string_array object to be resized.
+ * \param[in] new_size the size the array should be changed to.
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs.
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_string_array_resize(
+  rcutils_string_array_t * string_array,
+  size_t new_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -140,6 +140,9 @@ rcutils_string_array_cmp(
  * initialized. If the new size is smaller, entries are removed from the end of
  * the array and their resources reclaimed.
  *
+ * \note
+ * Resizing to 0 is not a substitute for calling ::rcutils_string_array_fini.
+ *
  * \param[inout] string_array object to be resized.
  * \param[in] new_size the size the array should be changed to.
  * \return `RCUTILS_RET_OK` if successful, or

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -140,8 +140,12 @@ rcutils_string_array_cmp(
  * initialized. If the new size is smaller, entries are removed from the end of
  * the array and their resources reclaimed.
  *
- * \note
+ * \par Note:
  * Resizing to 0 is not a substitute for calling ::rcutils_string_array_fini.
+ *
+ * \par Note:
+ * If this function fails, \p string_array remains unchanged and should still
+ * be reclaimed with ::rcutils_string_array_fini.
  *
  * \param[inout] string_array object to be resized.
  * \param[in] new_size the size the array should be changed to.

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -147,10 +147,8 @@ rcutils_string_array_resize(
   }
 
   rcutils_allocator_t * allocator = &string_array->allocator;
-  if (!rcutils_allocator_is_valid(allocator)) {
-    RCUTILS_SET_ERROR_MSG("allocator is invalid");
-    return RCUTILS_RET_INVALID_ARGUMENT;
-  }
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "allocator is invalid", return RCUTILS_RET_INVALID_ARGUMENT);
 
   // Stash entries being removed
   rcutils_string_array_t to_reclaim = rcutils_get_zero_initialized_string_array();

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -53,7 +53,7 @@ rcutils_string_array_init(
   string_array->size = size;
   string_array->data = allocator->zero_allocate(size, sizeof(char *), allocator->state);
   if (NULL == string_array->data) {
-    RCUTILS_SET_ERROR_MSG("failed to allocator string array");
+    RCUTILS_SET_ERROR_MSG("failed to allocate string array");
     return RCUTILS_RET_BAD_ALLOC;
   }
   string_array->allocator = *allocator;
@@ -146,10 +146,6 @@ rcutils_string_array_resize(
     return RCUTILS_RET_OK;
   }
 
-  if (0 == new_size) {
-    return rcutils_string_array_fini(string_array);
-  }
-
   // Reclaim entries being removed
   rcutils_allocator_t * allocator = &string_array->allocator;
   if (!rcutils_allocator_is_valid(allocator)) {
@@ -163,8 +159,8 @@ rcutils_string_array_resize(
 
   char ** new_data = allocator->reallocate(
     string_array->data, new_size * sizeof(char *), allocator->state);
-  if (NULL == new_data) {
-    RCUTILS_SET_ERROR_MSG("failed to allocator string array");
+  if (NULL == new_data && new_size != 0) {
+    RCUTILS_SET_ERROR_MSG("failed to allocate string array");
     return RCUTILS_RET_BAD_ALLOC;
   }
   string_array->data = new_data;

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -159,7 +159,7 @@ rcutils_string_array_resize(
 
   char ** new_data = allocator->reallocate(
     string_array->data, new_size * sizeof(char *), allocator->state);
-  if (NULL == new_data && new_size != 0) {
+  if (NULL == new_data && 0 != new_size) {
     RCUTILS_SET_ERROR_MSG("failed to allocate string array");
     return RCUTILS_RET_BAD_ALLOC;
   }

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -180,13 +180,6 @@ rcutils_string_array_resize(
   }
   string_array->data = new_data;
 
-  // Reclaim removed entries
-  rcutils_ret_t ret = rcutils_string_array_fini(&to_reclaim);
-  if (RCUTILS_RET_OK != ret) {
-    // rcutils_string_array_fini should have already set an error message
-    return ret;
-  }
-
   // Zero-initialize new entries
   for (size_t i = string_array->size; i < new_size; ++i) {
     string_array->data[i] = NULL;
@@ -194,7 +187,8 @@ rcutils_string_array_resize(
 
   string_array->size = new_size;
 
-  return RCUTILS_RET_OK;
+  // Lastly, reclaim removed entries
+  return rcutils_string_array_fini(&to_reclaim);
 }
 
 #ifdef __cplusplus

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -162,7 +162,9 @@ rcutils_string_array_resize(
       // rcutils_string_array_init should have already set an error message
       return ret;
     }
-    memcpy(to_reclaim.data, &string_array->data[new_size], to_reclaim.size);
+    memcpy(
+      to_reclaim.data, &string_array->data[new_size],
+      to_reclaim.size * sizeof(char *));
   }
 
   char ** new_data = allocator->reallocate(

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -159,9 +159,7 @@ rcutils_string_array_resize(
       // rcutils_string_array_init should have already set an error message
       return ret;
     }
-    for (size_t i = 0; i < to_reclaim.size; ++i) {
-      to_reclaim.data[i] = string_array->data[new_size + i];
-    }
+    memcpy(to_reclaim.data, string_array->data[new_size], to_reclaim.size);
   }
 
   char ** new_data = allocator->reallocate(

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -152,6 +152,10 @@ rcutils_string_array_resize(
 
   // Reclaim entries being removed
   rcutils_allocator_t * allocator = &string_array->allocator;
+  if (!rcutils_allocator_is_valid(allocator)) {
+    RCUTILS_SET_ERROR_MSG("allocator is invalid");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
   for (size_t i = new_size; i < string_array->size; ++i) {
     allocator->deallocate(string_array->data[i], allocator->state);
     string_array->data[i] = NULL;

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -162,7 +162,7 @@ rcutils_string_array_resize(
       // rcutils_string_array_init should have already set an error message
       return ret;
     }
-    memcpy(to_reclaim.data, string_array->data[new_size], to_reclaim.size);
+    memcpy(to_reclaim.data, &string_array->data[new_size], to_reclaim.size);
   }
 
   char ** new_data = allocator->reallocate(

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -252,20 +252,6 @@ TEST(test_string_array, string_array_resize) {
   EXPECT_EQ(RCUTILS_RET_OK, ret);
   EXPECT_EQ(0u, sa0.size);
 
-  // Allocation failure
-  sa0.allocator = failing_allocator;
-  ret = rcutils_string_array_resize(&sa0, 8);
-  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
-  EXPECT_EQ(0u, sa0.size);
-  rcutils_reset_error();
-
-  // Invalid allocator
-  sa0.allocator = invalid_allocator;
-  ret = rcutils_string_array_resize(&sa0, 8);
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
-  EXPECT_EQ(0u, sa0.size);
-  rcutils_reset_error();
-
   sa0.allocator = allocator;
   ret = rcutils_string_array_fini(&sa0);
   ASSERT_EQ(RCUTILS_RET_OK, ret);

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -134,6 +134,7 @@ TEST(test_string_array, string_array_cmp) {
 TEST(test_string_array, string_array_resize) {
   auto allocator = rcutils_get_default_allocator();
   auto failing_allocator = get_failing_allocator();
+  auto invalid_allocator = rcutils_get_zero_initialized_allocator();
   rcutils_ret_t ret;
 
   ret = rcutils_string_array_resize(nullptr, 8);
@@ -187,8 +188,15 @@ TEST(test_string_array, string_array_resize) {
   EXPECT_EQ(RCUTILS_RET_OK, ret);
   EXPECT_EQ(0u, sa0.size);
 
+  // Allocation failure
   sa0.allocator = failing_allocator;
   ret = rcutils_string_array_resize(&sa0, 8);
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
+  EXPECT_EQ(0u, sa0.size);
+
+  // Invalid allocator
+  sa0.allocator = invalid_allocator;
+  ret = rcutils_string_array_resize(&sa0, 8);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
   EXPECT_EQ(0u, sa0.size);
 }

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -173,7 +173,22 @@ TEST(test_string_array, string_array_resize) {
   ret = rcutils_string_array_resize(&sa0, sa0.size);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
+  // Grow to 16 (with allocation failure)
+  sa0.allocator = failing_allocator;
+  ret = rcutils_string_array_resize(&sa0, 16);
+  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
+  EXPECT_EQ(8u, sa0.size);
+  rcutils_reset_error();
+
+  // Grow to 16 (witn invalid allocator)
+  sa0.allocator = invalid_allocator;
+  ret = rcutils_string_array_resize(&sa0, 16);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+  EXPECT_EQ(8u, sa0.size);
+  rcutils_reset_error();
+
   // Grow to 16
+  sa0.allocator = allocator;
   ret = rcutils_string_array_resize(&sa0, 16);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
   ASSERT_EQ(16u, sa0.size);
@@ -191,7 +206,22 @@ TEST(test_string_array, string_array_resize) {
     sa0.data[i] = strdup(val);
   }
 
+  // Shrink to 4 (with allocation failure)
+  sa0.allocator = failing_allocator;
+  ret = rcutils_string_array_resize(&sa0, 4);
+  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
+  EXPECT_EQ(16u, sa0.size);
+  rcutils_reset_error();
+
+  // Shrink to 4 (witn invalid allocator)
+  sa0.allocator = invalid_allocator;
+  ret = rcutils_string_array_resize(&sa0, 4);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+  EXPECT_EQ(16u, sa0.size);
+  rcutils_reset_error();
+
   // Shrink to 4
+  sa0.allocator = allocator;
   ret = rcutils_string_array_resize(&sa0, 4);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
   ASSERT_EQ(4u, sa0.size);

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -15,8 +15,8 @@
 #include "gtest/gtest.h"
 
 #include "./allocator_testing_utils.h"
-#include "rcutils/types/string_array.h"
 #include "rcutils/error_handling.h"
+#include "rcutils/types/string_array.h"
 
 #ifdef _WIN32
   #define strdup _strdup

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -16,6 +16,7 @@
 
 #include "./allocator_testing_utils.h"
 #include "rcutils/types/string_array.h"
+#include "rcutils/error_handling.h"
 
 #ifdef _WIN32
   #define strdup _strdup
@@ -139,6 +140,7 @@ TEST(test_string_array, string_array_resize) {
 
   ret = rcutils_string_array_resize(nullptr, 8);
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
+  rcutils_reset_error();
 
   // Start with 8 elements
   rcutils_string_array_t sa0;
@@ -193,10 +195,16 @@ TEST(test_string_array, string_array_resize) {
   ret = rcutils_string_array_resize(&sa0, 8);
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
   EXPECT_EQ(0u, sa0.size);
+  rcutils_reset_error();
 
   // Invalid allocator
   sa0.allocator = invalid_allocator;
   ret = rcutils_string_array_resize(&sa0, 8);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret);
   EXPECT_EQ(0u, sa0.size);
+  rcutils_reset_error();
+
+  sa0.allocator = allocator;
+  ret = rcutils_string_array_fini(&sa0);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }


### PR DESCRIPTION
This change adds a new function to safely modify the size of an array which is already allocated, preserving existing entries where possible. It combines the existing behaviors in `rcutils_string_array_init` and `rcutils_string_array_fini`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10745)](http://ci.ros2.org/job/ci_linux/10745/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6141)](http://ci.ros2.org/job/ci_linux-aarch64/6141/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8747)](http://ci.ros2.org/job/ci_osx/8747/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10631)](http://ci.ros2.org/job/ci_windows/10631/)