### PR TITLE
Add rcutils_list_directory function

### DIFF
--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -25,6 +25,7 @@ extern "C"
 
 #include "rcutils/allocator.h"
 #include "rcutils/macros.h"
+#include "rcutils/types.h"
 #include "rcutils/visibility_control.h"
 
 /// Return current working directory.
@@ -186,6 +187,27 @@ rcutils_calculate_directory_size(const char * directory_path, rcutils_allocator_
 RCUTILS_PUBLIC
 size_t
 rcutils_get_file_size(const char * file_path);
+
+/// List the entries present in a directory.
+/**
+ * This function lists the name of each file or directory present in the given
+ * directory in an implementation-specific order.
+ *
+ * \param[in] directory_path The directory path to list the contents of.
+ * \param[in] allocator Allocator being used for resources in the string_array.
+ * \param[out] string_array The object to store the entries into.
+ * \return `RCUTILS_RET_OK` if successful, or
+ * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
+ * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_list_directory(
+  const char * directory_path,
+  rcutils_allocator_t allocator,
+  rcutils_string_array_t * string_array);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This change adds a simple function for listing the contents of a directory, and returning the names of those files as a string_array object. The iteration method is largely based on the one used in `rcutils_calculate_directory_size`.

The signature for this new function is modeled after the existing `rcutils_split` function: https://github.com/ros2/rcutils/blob/6acf8d88906a9b304c7785c7b2ce1174a5ce4ecd/include/rcutils/split.h#L27-L44

Requires #247 and #248

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10748)](http://ci.ros2.org/job/ci_linux/10748/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6143)](http://ci.ros2.org/job/ci_linux-aarch64/6143/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8749)](http://ci.ros2.org/job/ci_osx/8749/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10635)](http://ci.ros2.org/job/ci_windows/10635/)