### PR TITLE
Reset error state after testing expected errors

### DIFF
--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 
 #include "./allocator_testing_utils.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/types/string_array.h"
 
 #ifdef _WIN32
@@ -35,7 +36,9 @@ TEST(test_string_array, boot_string_array) {
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_init(&sa0, 2, NULL));
+  rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, rcutils_string_array_init(&sa0, 2, &failing_allocator));
+  rcutils_reset_error();
 
   rcutils_string_array_t sa1 = rcutils_get_zero_initialized_string_array();
   ret = rcutils_string_array_init(&sa1, 3, &allocator);
@@ -55,6 +58,7 @@ TEST(test_string_array, boot_string_array) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_init(&sa3, 3, &allocator));
   sa3.allocator.allocate = NULL;
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_fini(&sa3));
+  rcutils_reset_error();
   sa3.allocator = allocator;
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_fini(&sa3));
 }
@@ -98,9 +102,13 @@ TEST(test_string_array, string_array_cmp) {
 
   // Test failure cases
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_cmp(NULL, &sa0, &res));
+  rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_cmp(&sa0, NULL, &res));
+  rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_cmp(&sa0, &sa1, NULL));
+  rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_string_array_cmp(&sa0, &incomplete_string_array, &res));
+  rcutils_reset_error();
 
   // Test success cases
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_string_array_cmp(&sa0, &sa1, &res));


### PR DESCRIPTION
This change eliminates unnecessary output from the `string_array` tests when running operations that are expected to set error information. It does not change the intended behavior of the tests, but suppresses the extra output when the tests are functioning as expected.

The idea is to make it easier to use the output to debug an actual failure, which is easier to do when you don't need to wade through the output from the expected failures overwriting each other.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10790)](http://ci.ros2.org/job/ci_linux/10790/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6175)](http://ci.ros2.org/job/ci_linux-aarch64/6175/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8782)](http://ci.ros2.org/job/ci_osx/8782/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10678)](http://ci.ros2.org/job/ci_windows/10678/)