### PR TITLE
Take const rcutils_allocator_t in filesystem/process

### DIFF
--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -124,7 +124,7 @@ char *
 rcutils_join_path(
   const char * left_hand_path,
   const char * right_hand_path,
-  rcutils_allocator_t allocator);
+  const rcutils_allocator_t allocator);
 
 /// Return newly allocated string with all argument's "/" replaced by platform specific separator.
 /**
@@ -142,7 +142,7 @@ RCUTILS_PUBLIC
 char *
 rcutils_to_native_path(
   const char * path,
-  rcutils_allocator_t allocator);
+  const rcutils_allocator_t allocator);
 
 /// Create the specified directory.
 /**
@@ -176,7 +176,9 @@ rcutils_mkdir(const char * abs_path);
  */
 RCUTILS_PUBLIC
 size_t
-rcutils_calculate_directory_size(const char * directory_path, rcutils_allocator_t allocator);
+rcutils_calculate_directory_size(
+  const char * directory_path,
+  const rcutils_allocator_t allocator);
 
 /// Calculate the size of the specifed file.
 /*

--- a/include/rcutils/process.h
+++ b/include/rcutils/process.h
@@ -49,7 +49,7 @@ int rcutils_get_pid(void);
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
-char * rcutils_get_executable_name(rcutils_allocator_t allocator);
+char * rcutils_get_executable_name(const rcutils_allocator_t allocator);
 
 #ifdef __cplusplus
 }

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -153,7 +153,7 @@ char *
 rcutils_join_path(
   const char * left_hand_path,
   const char * right_hand_path,
-  rcutils_allocator_t allocator)
+  const rcutils_allocator_t allocator)
 {
   if (NULL == left_hand_path) {
     return NULL;
@@ -171,7 +171,7 @@ rcutils_join_path(
 char *
 rcutils_to_native_path(
   const char * path,
-  rcutils_allocator_t allocator)
+  const rcutils_allocator_t allocator)
 {
   if (NULL == path) {
     return NULL;
@@ -213,7 +213,9 @@ rcutils_mkdir(const char * abs_path)
 }
 
 size_t
-rcutils_calculate_directory_size(const char * directory_path, rcutils_allocator_t allocator)
+rcutils_calculate_directory_size(
+  const char * directory_path,
+  const rcutils_allocator_t allocator)
 {
   size_t dir_size = 0;
 

--- a/src/process.c
+++ b/src/process.c
@@ -42,7 +42,7 @@ int rcutils_get_pid(void)
 #endif
 }
 
-char * rcutils_get_executable_name(rcutils_allocator_t allocator)
+char * rcutils_get_executable_name(const rcutils_allocator_t allocator)
 {
   RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
     &allocator, "invalid allocator", return NULL);


### PR DESCRIPTION
This change allows `const` instances of `rcutils_allocator_t` to be passed to the filesystem and process functions in rcutils.

This makes the API less restrictive and therefore does not break API. In C, symbols do not differ when const-ness changes and it therefore does not break ABI either.

From the C11 standard, 6.2.5/26:
> ...The qualified or unqualified versions of a type are distinct types that belong to the same type category and have the same representation and alignment requirements...

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10795)](http://ci.ros2.org/job/ci_linux/10795/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6180)](http://ci.ros2.org/job/ci_linux-aarch64/6180/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8788)](http://ci.ros2.org/job/ci_osx/8788/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10683)](http://ci.ros2.org/job/ci_windows/10683/)