### PR TITLE
Remove failure check of RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED

### DIFF
--- a/src/format_string.c
+++ b/src/format_string.c
@@ -39,7 +39,7 @@ rcutils_format_string_limit(
     return NULL;
   }
   RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
-  // extract the variadic arguments twice, once for length calculatio and once for formatting.
+  // extract the variadic arguments twice, once for length calculation and once for formatting.
   va_list args1;
   va_start(args1, format_string);
   va_list args2;

--- a/src/logging.c
+++ b/src/logging.c
@@ -147,18 +147,12 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
 
     const char * line_buffered = NULL;
     const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
-    if (NULL == ret_str) {
-      if (strcmp(line_buffered, "") != 0) {
-        fprintf(
-          stderr,
-          "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored.  "
-          "Please set RCUTILS_LOGGING_USE_STDOUT and RCUTILS_LOGGING_BUFFERED_STREAM "
-          "to control the stream and the buffering of log messages.\n");
-      }
-    } else {
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "Error getting environment variable RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s", ret_str);
-      return RCUTILS_RET_ERROR;
+    if (NULL == ret_str && strcmp(line_buffered, "") != 0) {
+      fprintf(
+        stderr,
+        "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored.  "
+        "Please set RCUTILS_LOGGING_USE_STDOUT and RCUTILS_LOGGING_BUFFERED_STREAM "
+        "to control the stream and the buffering of log messages.\n");
     }
 
     // Set the default output stream for all severities to stderr so that errors


### PR DESCRIPTION
While looking for places to increase testing coverage, I noticed that logic in logging.c required the `rcutils_get_env` call for RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED to at least succeed. As currently implemented, it will always succeed and return NULL thus the else statement is dead code. But even if it could result in an error, the else clause doesn't seem useful since the environment variable use has been deprecated.

Importantly for foxy considerations, this will not change the API of the function, since the environment variable was unused and the rcutils_get_env call will always succeed.

`colcon build --packages-up-to rcutils && colcon test --packages-select rcutils`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10962)](http://ci.ros2.org/job/ci_linux/10962/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6302)](http://ci.ros2.org/job/ci_linux-aarch64/6302/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8924)](http://ci.ros2.org/job/ci_osx/8924/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10865)](http://ci.ros2.org/job/ci_windows/10865/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>