### PR TITLE
Increase testing coverage of rcutils to 95%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,30 +415,66 @@ if(BUILD_TESTING)
       RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=1
       RCUTILS_LOGGING_BUFFERED_STREAM=1
+      RCUTILS_LOGGING_USE_STDOUT=1
       RCUTILS_COLORIZED_OUTPUT=1
   )
   if(TARGET test_logging_custom_env)
     target_link_libraries(test_logging_custom_env ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
+  # RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN is defined as 2048, truncation should occur
+  foreach(i RANGE 0 100)
+    set(_output_format "${_output_format} [{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}")
+  endforeach(i)
   rcutils_custom_add_gtest(test_logging_custom_env2 test/test_logging_custom_env.cpp
     ENV
-      RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
+      RCUTILS_CONSOLE_OUTPUT_FORMAT="${_output_format}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=0
-      RCUTILS_LOGGING_BUFFERED_STREAM=0
+      RCUTILS_LOGGING_USE_STDOUT=0
       RCUTILS_COLORIZED_OUTPUT=0
+      RCUTILS_LOGGING_BUFFERED_STREAM=0
   )
   if(TARGET test_logging_custom_env2)
     target_link_libraries(test_logging_custom_env2 ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
+  endif()
+
+  rcutils_custom_add_gtest(test_logging_bad_env test/test_logging_bad_env.cpp
+    ENV
+      RCUTILS_LOGGING_USE_STDOUT=42
+  )
+  if(TARGET test_logging_bad_env)
+    target_link_libraries(test_logging_bad_env ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_logging_bad_env2 test/test_logging_bad_env.cpp
+    ENV
+      RCUTILS_COLORIZED_OUTPUT=42
+  )
+  if(TARGET test_logging_bad_env2)
+    target_link_libraries(test_logging_bad_env2 ${PROJECT_NAME})
+  endif()
+
+  rcutils_custom_add_gtest(test_logging_bad_env3 test/test_logging_bad_env.cpp
+    ENV
+      RCUTILS_LOGGING_BUFFERED_STREAM=42
+  )
+  if(TARGET test_logging_bad_env3)
+    target_link_libraries(test_logging_bad_env3 ${PROJECT_NAME})
   endif()
 
   rcutils_custom_add_gtest(test_logging_enable_for
     test/test_logging_enable_for.cpp
   )
   if(TARGET test_logging_enable_for)
-    target_link_libraries(test_logging_enable_for ${PROJECT_NAME})
+    target_link_libraries(test_logging_enable_for ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
+  rcutils_custom_add_gtest(test_logging_console_output_handler
+    test/test_logging_console_output_handler.cpp
+  )
+  if(TARGET test_logging_console_output_handler)
+    target_link_libraries(test_logging_console_output_handler ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
+  endif()
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,9 +430,9 @@ if(BUILD_TESTING)
     ENV
       RCUTILS_CONSOLE_OUTPUT_FORMAT="${_output_format}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=0
+      RCUTILS_LOGGING_BUFFERED_STREAM=0
       RCUTILS_LOGGING_USE_STDOUT=0
       RCUTILS_COLORIZED_OUTPUT=0
-      RCUTILS_LOGGING_BUFFERED_STREAM=0
   )
   if(TARGET test_logging_custom_env2)
     target_link_libraries(test_logging_custom_env2 ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)

--- a/include/rcutils/testing_utils/time_bomb_allocator_testing_utils.h
+++ b/include/rcutils/testing_utils/time_bomb_allocator_testing_utils.h
@@ -1,0 +1,146 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
+#define RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>
+
+#include "rcutils/allocator.h"
+
+typedef struct __time_bomb_allocator_state
+{
+  // Set these to negative if you want to disable time bomb for the associated function call.
+  int malloc_count_until_failure;
+  int realloc_count_until_failure;
+  int free_count_until_failure;
+  int calloc_count_until_failure;
+} __time_bomb_allocator_state;
+
+static void *
+time_bomb_malloc(size_t size, void * state)
+{
+  if (((__time_bomb_allocator_state *)state)->malloc_count_until_failure >= 0 &&
+    ((__time_bomb_allocator_state *)state)->malloc_count_until_failure-- == 0)
+  {
+    printf("Malloc time bomb countdown reached 0, returning nullptr\n");
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().allocate(size, rcutils_get_default_allocator().state);
+}
+
+static void *
+time_bomb_realloc(void * pointer, size_t size, void * state)
+{
+  if (((__time_bomb_allocator_state *)state)->realloc_count_until_failure >= 0 &&
+    ((__time_bomb_allocator_state *)state)->realloc_count_until_failure-- == 0)
+  {
+    printf("Realloc time bomb countdown reached 0, returning nullptr\n");
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().reallocate(
+    pointer, size, rcutils_get_default_allocator().state);
+}
+
+static void
+time_bomb_free(void * pointer, void * state)
+{
+  if (((__time_bomb_allocator_state *)state)->free_count_until_failure >= 0 &&
+    ((__time_bomb_allocator_state *)state)->free_count_until_failure-- == 0)
+  {
+    printf("Free time bomb countdown reached 0, not freeing memory\n");
+    return;
+  }
+  rcutils_get_default_allocator().deallocate(pointer, rcutils_get_default_allocator().state);
+}
+
+static void *
+time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state)
+{
+  if (((__time_bomb_allocator_state *)state)->calloc_count_until_failure >= 0 &&
+    ((__time_bomb_allocator_state *)state)->calloc_count_until_failure-- == 0)
+  {
+    printf("Calloc time bomb countdown reached 0, returning nullptr\n");
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().zero_allocate(
+    number_of_elements, size_of_element, rcutils_get_default_allocator().state);
+}
+
+/**
+ * This allocator uses the rcutils default allocator functions, but decrements a time bomb counter
+ * for each function call. When the counter reaches 0, that call will fail.
+ * In the case of the allocating functions, it will return a nullptr. In the case of free,
+ * it will fail to free the memory.
+ *
+ * Use this allocator when you need a fixed amount of calls to succeed before it fails.
+ *
+ * Set the count to negative for the time bomb effect to be disabled for that function.
+ */
+static inline rcutils_allocator_t
+get_time_bomb_allocator(void)
+{
+  static __time_bomb_allocator_state state;
+  state.malloc_count_until_failure = -1;
+  state.realloc_count_until_failure = -1;
+  state.free_count_until_failure = -1;
+  state.calloc_count_until_failure = -1;
+  auto time_bomb_allocator = rcutils_get_default_allocator();
+  time_bomb_allocator.allocate = time_bomb_malloc;
+  time_bomb_allocator.deallocate = time_bomb_free;
+  time_bomb_allocator.reallocate = time_bomb_realloc;
+  time_bomb_allocator.zero_allocate = time_bomb_calloc;
+  time_bomb_allocator.state = &state;
+  return time_bomb_allocator;
+}
+
+/**
+ * Set count to the number of times you want the call to succeed before it fails.
+ * After it fails once, it will succeed until this count is reset.
+ * Set it to a negative value to disable the time bomb effect for that function.
+ */
+static inline void
+set_time_bomb_allocator_malloc_count(rcutils_allocator_t & time_bomb_allocator, int count)
+{
+  ((__time_bomb_allocator_state *)time_bomb_allocator.state)->malloc_count_until_failure = count;
+}
+
+static inline void
+set_time_bomb_allocator_realloc_count(rcutils_allocator_t & time_bomb_allocator, int count)
+{
+  ((__time_bomb_allocator_state *)time_bomb_allocator.state)->realloc_count_until_failure = count;
+}
+
+static inline void
+set_time_bomb_allocator_free_count(rcutils_allocator_t & time_bomb_allocator, int count)
+{
+  ((__time_bomb_allocator_state *)time_bomb_allocator.state)->free_count_until_failure = count;
+}
+
+static inline void
+set_time_bomb_allocator_calloc_count(rcutils_allocator_t & time_bomb_allocator, int count)
+{
+  ((__time_bomb_allocator_state *)time_bomb_allocator.state)->calloc_count_until_failure = count;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_

--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -379,18 +379,6 @@ TEST_F(ArrayListPreInitTest, init_list_twice_fails) {
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
 }
 
-TEST_F(ArrayListTest, init_list_bad_allocator_fail) {
-  // Allocating array-list->impl fails
-  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
-  rcutils_ret_t ret = rcutils_array_list_init(&list, 2, sizeof(uint32_t), &failing_allocator);
-  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
-
-  // Allocating array-list->impl->list fails
-  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
-  ret = rcutils_array_list_init(&list, 2, sizeof(uint32_t), &failing_allocator);
-  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
-}
-
 typedef struct allocator_state
 {
   bool is_failing;

--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -17,7 +17,7 @@
 #include <string>
 
 #include "./allocator_testing_utils.h"
-#include "rcutils/testing_utils/time_bomb_allocator_testing_utils.h"
+#include "./time_bomb_allocator_testing_utils.h"
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/types/array_list.h"

--- a/test/test_char_array.cpp
+++ b/test/test_char_array.cpp
@@ -125,6 +125,7 @@ TEST_F(ArrayCharTest, vsprintf_fail) {
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret);
   rcutils_reset_error();
 
+  char_array.allocator = allocator;
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_fini(&char_array));
 }
 

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -44,6 +44,9 @@ public:
 TEST_F(TestFilesystemFixture, get_cwd_nullptr) {
   EXPECT_FALSE(rcutils_get_cwd(NULL, sizeof(this->cwd)));
   EXPECT_FALSE(rcutils_get_cwd(this->cwd, 0));
+
+  // ERANGE, including a null terminating character, cwd should always be longer than 1 char
+  EXPECT_FALSE(rcutils_get_cwd(this->cwd, 1));
 }
 
 TEST_F(TestFilesystemFixture, join_path) {
@@ -234,6 +237,16 @@ TEST_F(TestFilesystemFixture, is_writable) {
 TEST_F(TestFilesystemFixture, is_readable_and_writable) {
   {
     char * path = rcutils_join_path(this->test_path, "dummy_folder", g_allocator);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      g_allocator.deallocate(path, g_allocator.state);
+    });
+    ASSERT_FALSE(nullptr == path);
+    EXPECT_TRUE(rcutils_is_readable_and_writable(path));
+  }
+  {
+    char * path =
+      rcutils_join_path(this->test_path, "dummy_readable_file.txt", g_allocator);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
     {
       g_allocator.deallocate(path, g_allocator.state);

--- a/test/test_format_string.cpp
+++ b/test/test_format_string.cpp
@@ -38,6 +38,15 @@ TEST(test_format_string_limit, nominal) {
       allocator.deallocate(formatted, allocator.state);
     }
   }
+
+  {
+    auto allocator = rcutils_get_default_allocator();
+    char * formatted = rcutils_format_string_limit(allocator, 3, "string is too long %s", "test");
+    EXPECT_STREQ("st", formatted);
+    if (formatted) {
+      allocator.deallocate(formatted, allocator.state);
+    }
+  }
 }
 
 TEST(test_format_string_limit, invalid_arguments) {

--- a/test/test_get_env.cpp
+++ b/test/test_get_env.cpp
@@ -50,15 +50,22 @@ TEST(TestGetEnv, test_get_env) {
 
 TEST(TestGetEnv, test_get_home) {
   EXPECT_STRNE(NULL, rcutils_get_home_dir());
-
   const char * home = NULL;
-  const char * ret = rcutils_get_env("HOME", &home);
-  EXPECT_EQ(NULL, ret);
 
 #ifdef _WIN32
+  // Assert pre-condition that USERPROFILE is defined
+  const char * ret = rcutils_get_env("USERPROFILE", &home);
+  ASSERT_EQ(NULL, ret);
+
+  // Check USERPROFILE is not defined
   EXPECT_TRUE(rcutils_set_env("USERPROFILE", NULL));
   EXPECT_EQ(NULL, rcutils_get_home_dir());
 #else
+  // Assert pre-condition that HOME is defined
+  const char * ret = rcutils_get_env("HOME", &home);
+  ASSERT_EQ(NULL, ret);
+
+  // Check HOME is not defined
   EXPECT_TRUE(rcutils_set_env("HOME", NULL));
   EXPECT_EQ(NULL, rcutils_get_home_dir());
 #endif

--- a/test/test_get_env.cpp
+++ b/test/test_get_env.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 
+#include "rcutils/env.h"
 #include "rcutils/get_env.h"
 
 /* Tests rcutils_get_env.
@@ -49,4 +50,16 @@ TEST(TestGetEnv, test_get_env) {
 
 TEST(TestGetEnv, test_get_home) {
   EXPECT_STRNE(NULL, rcutils_get_home_dir());
+
+  const char * home = NULL;
+  const char * ret = rcutils_get_env("HOME", &home);
+  EXPECT_EQ(NULL, ret);
+
+#ifdef _WIN32
+  EXPECT_TRUE(rcutils_set_env("USERPROFILE", NULL));
+  EXPECT_EQ(NULL, rcutils_get_home_dir());
+#else
+  EXPECT_TRUE(rcutils_set_env("HOME", NULL));
+  EXPECT_EQ(NULL, rcutils_get_home_dir());
+#endif
 }

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "rcutils/testing_utils/time_bomb_allocator_testing_utils.h"
+#include "./time_bomb_allocator_testing_utils.h"
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/types/hash_map.h"

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -139,7 +139,7 @@ TEST_F(HashMapBaseTest, init_map_failing_allocator) {
     test_hash_map_uint32_hash_func, test_uint32_cmp, &failing_allocator);
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
 
-  // Check allocate hash_map->impl fails
+  // Check allocate hash_map->impl->map fails
   set_time_bomb_allocator_malloc_count(failing_allocator, 1);
   ret = rcutils_hash_map_init(
     &map, 2, sizeof(uint32_t), sizeof(uint32_t),

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -34,6 +34,9 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging_initialization) {
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+
+    // Ok to shutdown after it's already been shutdown
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
   });
   EXPECT_TRUE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
@@ -237,6 +240,10 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
   ASSERT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
     rcutils_logging_set_logger_level("rcutils_test_loggers", -1));
+  rcutils_reset_error();
+  ASSERT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    rcutils_logging_set_logger_level("rcutils_test_loggers", 21));
   rcutils_reset_error();
   ASSERT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,

--- a/test/test_logging_bad_env.cpp
+++ b/test/test_logging_bad_env.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcutils/logging.h"
+
+TEST(TestBadCustomEnv, test_initialize) {
+  EXPECT_FALSE(g_rcutils_logging_initialized);
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_logging_initialize());
+}

--- a/test/test_logging_console_output_handler.cpp
+++ b/test/test_logging_console_output_handler.cpp
@@ -31,6 +31,8 @@ static void call_handler(
   va_end(args);
 }
 
+// There are no outputs of the handler function, and the only result are fprintf() calls.
+// This is just a smoke test to check that the code can handle simple inputs cleanly.
 TEST(TestLoggingConsoleOutputHandler, typical_inputs) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -58,7 +60,8 @@ TEST(TestLoggingConsoleOutputHandler, typical_inputs) {
     &log_location, RCUTILS_LOG_SEVERITY_FATAL, log_name, timestamp, format, "part1", "part2");
 }
 
-// This handler function uses fprintf to print to stdout/stderr so there are no outputs to check
+// There are no outputs of the handler function, and the only result are fprintf() calls.
+// This is just a smoke test to check that the code can handle bad inputs cleanly.
 TEST(TestLoggingConsoleOutputHandler, bad_inputs) {
   rcutils_log_location_t log_location = {
     "test_function",

--- a/test/test_logging_console_output_handler.cpp
+++ b/test/test_logging_console_output_handler.cpp
@@ -1,0 +1,94 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcutils/logging.h"
+
+static void call_handler(
+  const rcutils_log_location_t * location,
+  int severity, const char * name, rcutils_time_point_value_t timestamp,
+  const char * format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  rcutils_logging_console_output_handler(location, severity, name, timestamp, format, &args);
+  va_end(args);
+}
+
+TEST(TestLoggingConsoleOutputHandler, typical_inputs) {
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
+
+  rcutils_log_location_t log_location = {
+    "test_function",
+    "test_file",
+    1,
+  };
+  const char * log_name = "test_name";
+  rcutils_time_point_value_t timestamp = 1;
+  const char * format = "%s - %s";
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_DEBUG, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_INFO, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_WARN, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_ERROR, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_FATAL, log_name, timestamp, format, "part1", "part2");
+}
+
+// This handler function uses fprintf to print to stdout/stderr so there are no outputs to check
+TEST(TestLoggingConsoleOutputHandler, bad_inputs) {
+  rcutils_log_location_t log_location = {
+    "test_function",
+    "test_file",
+    1,
+  };
+  const char * log_name = "test_name";
+  rcutils_time_point_value_t timestamp = 1;
+  const char * format = "%s - %s";
+
+  // Check !g_rcutils_logging_initialized
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_DEBUG, log_name, timestamp, format, "part1", "part2");
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
+
+  call_handler(
+    nullptr, RCUTILS_LOG_SEVERITY_INFO, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_UNSET, log_name, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_INFO, nullptr, timestamp, format, "part1", "part2");
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_INFO, log_name, 0, format, "part1", "part2");
+
+  // If format is NULL, this call will segfault on some (but not all) systems
+  call_handler(
+    &log_location, RCUTILS_LOG_SEVERITY_INFO, log_name, timestamp, "bad format", "part1", "part2");
+}

--- a/test/test_logging_enable_for.cpp
+++ b/test/test_logging_enable_for.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging.h"
 
 TEST(test_logging_logger_is_enabled_for, test_logging_logger_is_enabled_for) {
@@ -59,4 +60,48 @@ TEST(test_logging_logger_is_enabled_for, test_logging_logger_is_enabled_for) {
   ret = rcutils_logging_logger_is_enabled_for(
     "rmw_fastrtps_cpp", RCUTILS_LOG_SEVERITY_FATAL);
   ASSERT_TRUE(ret);
+}
+
+TEST(test_logging_logger_is_enabled_for, test_logger_is_enabled_for) {
+  EXPECT_FALSE(
+    rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", RCUTILS_LOG_SEVERITY_DEBUG));
+  EXPECT_TRUE(
+    rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", RCUTILS_LOG_SEVERITY_FATAL));
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
+
+  EXPECT_TRUE(
+    rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", RCUTILS_LOG_SEVERITY_INFO));
+
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_level(
+      "rcutils_test_loggers", RCUTILS_LOG_SEVERITY_WARN));
+
+  EXPECT_FALSE(
+    rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", RCUTILS_LOG_SEVERITY_INFO));
+
+  EXPECT_FALSE(rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", -1));
+  EXPECT_TRUE(rcutils_logging_logger_is_enabled_for("rcutils_test_loggers", 1000));
+
+  // These should all resort to default logging severity
+  EXPECT_FALSE(rcutils_logging_logger_is_enabled_for("", RCUTILS_LOG_SEVERITY_DEBUG));
+  EXPECT_TRUE(rcutils_logging_logger_is_enabled_for("", RCUTILS_LOG_SEVERITY_FATAL));
+
+  EXPECT_FALSE(rcutils_logging_logger_is_enabled_for(NULL, RCUTILS_LOG_SEVERITY_DEBUG));
+  EXPECT_TRUE(rcutils_logging_logger_is_enabled_for(NULL, RCUTILS_LOG_SEVERITY_FATAL));
+
+  EXPECT_TRUE(
+    rcutils_logging_logger_is_enabled_for("name_that_doesn't_exist", RCUTILS_LOG_SEVERITY_FATAL));
+  EXPECT_FALSE(
+    rcutils_logging_logger_is_enabled_for("name_that_doesn't_exist", RCUTILS_LOG_SEVERITY_DEBUG));
+
+  EXPECT_TRUE(
+    rcutils_logging_logger_is_enabled_for("name.that.doesn't.exist", RCUTILS_LOG_SEVERITY_FATAL));
+  EXPECT_FALSE(
+    rcutils_logging_logger_is_enabled_for("name.that.doesn't.exist", RCUTILS_LOG_SEVERITY_DEBUG));
 }

--- a/test/test_process.cpp
+++ b/test/test_process.cpp
@@ -15,10 +15,10 @@
 #include <gtest/gtest.h>
 
 #include "./allocator_testing_utils.h"
+#include "./time_bomb_allocator_testing_utils.h"
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/process.h"
-#include "rcutils/testing_utils/time_bomb_allocator_testing_utils.h"
 
 TEST(TestProcess, test_get_pid) {
   EXPECT_NE(rcutils_get_pid(), 0);
@@ -32,12 +32,10 @@ TEST(TestProcess, test_get_executable_name) {
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
   EXPECT_STREQ(NULL, rcutils_get_executable_name(time_bomb_allocator));
 
-  // Allocating intermediate fails
+  // Allocating intermediate fails. This allocation doesn't happen on windows
 #if defined __APPLE__ || defined __FreeBSD__ || defined __GNUC__
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
   EXPECT_STREQ(NULL, rcutils_get_executable_name(time_bomb_allocator));
-#elif defined _WIN32 || defined __CYGWIN__
-  // This allocation doesn't happen on windows
 #endif
 
   char * exec_name = rcutils_get_executable_name(allocator);

--- a/test/test_repl_str.cpp
+++ b/test/test_repl_str.cpp
@@ -85,7 +85,7 @@ TEST(test_repl_str, nominal) {
     for (size_t i = 0; i < 1048576; ++i) {
       ss << "f";
     }
-    char * out = rcutils_repl_str(ss.str().c_str(), "f", "longer replacementment", &allocator);
+    char * out = rcutils_repl_str(ss.str().c_str(), "f", "longer replacement", &allocator);
     EXPECT_NE(nullptr, out);
     allocator.deallocate(out, allocator.state);
   }

--- a/test/test_repl_str.cpp
+++ b/test/test_repl_str.cpp
@@ -62,4 +62,31 @@ TEST(test_repl_str, nominal) {
     char * out = rcutils_repl_str(typical.c_str(), "{bar}", "", &failing_allocator);
     EXPECT_EQ(NULL, out);
   }
+
+  // no matches
+  {
+    std::string typical = "foo/{bar}/baz";
+    char * out = rcutils_repl_str(typical.c_str(), "no match", "n/a", &allocator);
+    EXPECT_STREQ(typical.c_str(), out);
+    allocator.deallocate(out, allocator.state);
+  }
+
+  // no matches and bad allocator
+  {
+    std::string typical = "foo/{bar}/baz";
+    rcutils_allocator_t failing_allocator = get_failing_allocator();
+    char * out = rcutils_repl_str(typical.c_str(), "no match", "n/a", &failing_allocator);
+    EXPECT_EQ(NULL, out);
+  }
+
+  // Force cache_sz_inc to exceed cache_sz_inc_max
+  {
+    std::stringstream ss;
+    for (size_t i = 0; i < 1048576; ++i) {
+      ss << "f";
+    }
+    char * out = rcutils_repl_str(ss.str().c_str(), "f", "longer replacementment", &allocator);
+    EXPECT_NE(nullptr, out);
+    allocator.deallocate(out, allocator.state);
+  }
 }

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -46,6 +46,8 @@ TEST_F(TestSharedLibrary, basic_load) {
   EXPECT_TRUE(lib.lib_pointer == NULL);
   EXPECT_FALSE(rcutils_is_shared_library_loaded(&lib));
 
+  // Check debug name works first because rcutils_load_shared_library should be called on
+  // non-debug symbol name
   ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, true);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -46,6 +46,9 @@ TEST_F(TestSharedLibrary, basic_load) {
   EXPECT_TRUE(lib.lib_pointer == NULL);
   EXPECT_FALSE(rcutils_is_shared_library_loaded(&lib));
 
+  ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, true);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
   ret = rcutils_get_platform_library_name("dummy_shared_library", library_path, 1024, false);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -158,6 +158,10 @@ TEST_F(TestSharedLibrary, error_symbol) {
   ASSERT_EQ(RCUTILS_RET_OK, ret);
   is_symbol = rcutils_has_symbol(&lib, "symbol");
   EXPECT_FALSE(is_symbol);
+
+  // unload shared_library
+  ret = rcutils_unload_shared_library(&lib);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
 }
 
 TEST_F(TestSharedLibrary, basic_symbol) {

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -18,6 +18,7 @@
 #include "rcutils/error_handling.h"
 #include "rcutils/split.h"
 #include "rcutils/types/string_array.h"
+#include "rcutils/testing_utils/time_bomb_allocator_testing_utils.h"
 
 #define ENABLE_LOGGING 1
 
@@ -63,9 +64,19 @@ TEST(test_split, split) {
     RCUTILS_RET_INVALID_ARGUMENT,
     rcutils_split("Test", '/', rcutils_get_default_allocator(), NULL));
 
+  // Allocating string_array->data fails
+  rcutils_allocator_t time_bomb_allocator = get_time_bomb_allocator();
+  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
   EXPECT_EQ(
     RCUTILS_RET_ERROR,
-    rcutils_split("Test", '/', get_failing_allocator(), &tokens_fail));
+    rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array->data[0] fails
+  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    rcutils_split("hello/world", '/', time_bomb_allocator, &tokens_fail));
+
 
   rcutils_string_array_t tokens0 = test_split("", '/', 0);
   ret = rcutils_string_array_fini(&tokens0);
@@ -149,9 +160,37 @@ TEST(test_split, split) {
 TEST(test_split, split_last) {
   rcutils_ret_t ret = RCUTILS_RET_OK;
   rcutils_string_array_t tokens_fail;
+
+  // Allocating string_array fails
+  rcutils_allocator_t time_bomb_allocator = get_time_bomb_allocator();
+  set_time_bomb_allocator_calloc_count(time_bomb_allocator, 0);
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,
-    rcutils_split_last("Test", '/', get_failing_allocator(), &tokens_fail));
+    rcutils_split_last("Test", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array->data[0] fails
+  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    rcutils_split_last("Test", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array fails, found_last != string_size
+  set_time_bomb_allocator_calloc_count(time_bomb_allocator, 0);
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    rcutils_split_last("hello/world", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array->data[0] fails, found_last != string_size
+  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    rcutils_split_last("hello/world", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array->data[1] fails, found_last != string_size
+  set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    rcutils_split_last("hello/world", '/', time_bomb_allocator, &tokens_fail));
 
   rcutils_string_array_t tokens0 = test_split_last("", '/', 0);
   ret = rcutils_string_array_fini(&tokens0);

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -15,10 +15,10 @@
 #include "gtest/gtest.h"
 
 #include "./allocator_testing_utils.h"
+#include "./time_bomb_allocator_testing_utils.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/split.h"
 #include "rcutils/types/string_array.h"
-#include "rcutils/testing_utils/time_bomb_allocator_testing_utils.h"
 
 #define ENABLE_LOGGING 1
 

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -49,6 +49,8 @@ TEST(test_strerror, get_error) {
   // Hopefully this does not become a valid errno.
   errno = 12345;
   rcutils_strerror(error_string, sizeof(error_string));
-  ASSERT_STREQ(error_string, "Failed to get error");
+  ASSERT_STREQ(error_string, "Failed to get error") <<
+    "Calling rcutils_strerror with an errno of '" << errno <<
+    "' did not cause the expected error message.";
 #endif
 }

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -43,4 +43,12 @@ TEST(test_strerror, get_error) {
 
   rcutils_strerror(error_string, sizeof(error_string));
   ASSERT_STREQ(error_string, "No such file or directory");
+
+#if (!defined(_WIN32)) && (!( \
+    defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)))
+  // Hopefully this does not become a valid errno.
+  errno = 12345;
+  rcutils_strerror(error_string, sizeof(error_string));
+  ASSERT_STREQ(error_string, "Failed to get error");
+#endif
 }

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -35,6 +35,8 @@ TEST(test_string_array, boot_string_array) {
   ret = rcutils_string_array_fini(&sa0);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_init(NULL, 2, &allocator));
+  rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_init(&sa0, 2, NULL));
   rcutils_reset_error();
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, rcutils_string_array_init(&sa0, 2, &failing_allocator));
@@ -57,6 +59,8 @@ TEST(test_string_array, boot_string_array) {
   rcutils_string_array_t sa3 = rcutils_get_zero_initialized_string_array();
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_init(&sa3, 3, &allocator));
   sa3.allocator.allocate = NULL;
+  ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_fini(NULL));
+  rcutils_reset_error();
   ASSERT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_string_array_fini(&sa3));
   rcutils_reset_error();
   sa3.allocator = allocator;

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -69,6 +69,7 @@ TEST(test_string_array, boot_string_array) {
   rcutils_string_array_t sa4 = rcutils_get_zero_initialized_string_array();
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_init(&sa4, 0, &allocator));
   ASSERT_EQ(0u, sa4.size);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_fini(&sa4));
 }
 
 TEST(test_string_array, string_array_cmp) {

--- a/test/test_string_map.cpp
+++ b/test/test_string_map.cpp
@@ -1091,8 +1091,11 @@ TEST(test_string_map, set) {
       rcutils_reset_error();
     });
 
-    set_failing_allocator_is_failing(failing_allocator, true);
     ret = rcutils_string_map_set(&string_map, "key1", "value1");
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+
+    set_failing_allocator_is_failing(failing_allocator, true);
+    ret = rcutils_string_map_set(&string_map, "key1", "value2");
     EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
     rcutils_reset_error();
   }

--- a/test/time_bomb_allocator_testing_utils.h
+++ b/test/time_bomb_allocator_testing_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
-#define RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
+#ifndef TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
+#define TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
 
 #ifdef __cplusplus
 extern "C"
@@ -143,4 +143,4 @@ set_time_bomb_allocator_calloc_count(rcutils_allocator_t & time_bomb_allocator, 
 }
 #endif
 
-#endif  // RCUTILS__TESTING_UTILS__TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_
+#endif  // TIME_BOMB_ALLOCATOR_TESTING_UTILS_H_


### PR DESCRIPTION
I've added a bit more test cases to the unit tests in rcutils to boost the coverage to 95% (just barely).

The big question about this PR is the desired location of `time_bomb_allocator`. @hidmic had suggested putting it into a centralized location so it can be used in other packages. I'm thinking I might want to do that for the allocator_testing_utils.h as well. But I don't think rcutils/include is the desired end location.

The remaining 5% of untested logic pretty much consists of failure checks that won't fail, generally because bad parameters have already been sanitized by the time the function under test calls a function that is checked for failure. In a few cases it might be because the system call cannot be made to fail reliably or even at all in a simple unit test.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10965)](http://ci.ros2.org/job/ci_linux/10965/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6305)](http://ci.ros2.org/job/ci_linux-aarch64/6305/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8927)](http://ci.ros2.org/job/ci_osx/8927/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10875)](http://ci.ros2.org/job/ci_windows/10875/)
Signed-off-by: Stephen Brawner <brawner@gmail.com>