### PR TITLE
Set appropriate size for buffered logging on Windows (logging.c)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,10 +414,22 @@ if(BUILD_TESTING)
     ENV
       RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=1
+      RCUTILS_LOGGING_BUFFERED_STREAM=1
       RCUTILS_COLORIZED_OUTPUT=1
   )
   if(TARGET test_logging_custom_env)
     target_link_libraries(test_logging_custom_env ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
+  endif()
+
+  rcutils_custom_add_gtest(test_logging_custom_env2 test/test_logging_custom_env.cpp
+    ENV
+      RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
+      RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=0
+      RCUTILS_LOGGING_BUFFERED_STREAM=0
+      RCUTILS_COLORIZED_OUTPUT=0
+  )
+  if(TARGET test_logging_custom_env2)
+    target_link_libraries(test_logging_custom_env2 ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
   rcutils_custom_add_gtest(test_logging_enable_for

--- a/src/logging.c
+++ b/src/logging.c
@@ -45,6 +45,17 @@ extern "C"
 
 #define RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN (2048)
 
+#if defined(_WIN32)
+// Used with setvbuf, and size must be 2 <= size <= INT_MAX. For more info, see:
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf
+#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (BUFSIZ)
+#else
+// Let the system choose the appropriate size
+// glibc reference: https://sourceware.org/git/?p=glibc.git;a=blob;f=libio/iosetvbuf.c;hb=HEAD
+// OSX reference: https://opensource.apple.com/source/Libc/Libc-166/stdio.subproj/setvbuf.c.auto.html
+#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (0)
+#endif
+
 const char * const g_rcutils_log_severity_names[] = {
   [RCUTILS_LOG_SEVERITY_UNSET] = "UNSET",
   [RCUTILS_LOG_SEVERITY_DEBUG] = "DEBUG",
@@ -195,7 +206,10 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     }
     if (RCUTILS_GET_ENV_ZERO == retval || RCUTILS_GET_ENV_ONE == retval) {
       int mode = retval == RCUTILS_GET_ENV_ZERO ? _IONBF : _IOLBF;
-      if (setvbuf(g_output_stream, NULL, mode, BUFSIZ) != 0) {
+      size_t buffer_size = (mode == _IOLBF) ? RCUTILS_LOGGING_STREAM_BUFFER_SIZE : 0;
+
+      // buffer_size cannot be 0 on Windows with IOLBF, see comments above where it's #define'd
+      if (setvbuf(g_output_stream, NULL, mode, buffer_size) != 0) {
         char error_string[1024];
         rcutils_strerror(error_string, sizeof(error_string));
         RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(

--- a/src/logging.c
+++ b/src/logging.c
@@ -45,14 +45,6 @@ extern "C"
 
 #define RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN (2048)
 
-#if defined(_WIN32)
-// Used with setvbuf, and size must be 2 <= size <= INT_MAX. For more info, see:
-// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf
-#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (4096)
-#else
-#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (0)
-#endif
-
 const char * const g_rcutils_log_severity_names[] = {
   [RCUTILS_LOG_SEVERITY_UNSET] = "UNSET",
   [RCUTILS_LOG_SEVERITY_DEBUG] = "DEBUG",
@@ -203,7 +195,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     }
     if (RCUTILS_GET_ENV_ZERO == retval || RCUTILS_GET_ENV_ONE == retval) {
       int mode = retval == RCUTILS_GET_ENV_ZERO ? _IONBF : _IOLBF;
-      if (setvbuf(g_output_stream, NULL, mode, RCUTILS_LOGGING_STREAM_BUFFER_SIZE) != 0) {
+      if (setvbuf(g_output_stream, NULL, mode, BUFSIZ) != 0) {
         char error_string[1024];
         rcutils_strerror(error_string, sizeof(error_string));
         RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(

--- a/src/logging.c
+++ b/src/logging.c
@@ -45,6 +45,14 @@ extern "C"
 
 #define RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN (2048)
 
+#if defined(_WIN32)
+// Used with setvbuf, and size must be 2 <= size <= INT_MAX. For more info, see:
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf
+#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (4096)
+#else
+#define RCUTILS_LOGGING_STREAM_BUFFER_SIZE (0)
+#endif
+
 const char * const g_rcutils_log_severity_names[] = {
   [RCUTILS_LOG_SEVERITY_UNSET] = "UNSET",
   [RCUTILS_LOG_SEVERITY_DEBUG] = "DEBUG",
@@ -195,7 +203,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     }
     if (RCUTILS_GET_ENV_ZERO == retval || RCUTILS_GET_ENV_ONE == retval) {
       int mode = retval == RCUTILS_GET_ENV_ZERO ? _IONBF : _IOLBF;
-      if (setvbuf(g_output_stream, NULL, mode, 0) != 0) {
+      if (setvbuf(g_output_stream, NULL, mode, RCUTILS_LOGGING_STREAM_BUFFER_SIZE) != 0) {
         char error_string[1024];
         rcutils_strerror(error_string, sizeof(error_string));
         RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(


### PR DESCRIPTION
When using _IOFBF or _IOLBF with `setvbuf` on Windows, size must be at least 2 otherwise it will segfault. This PR adds a new constant to logging.c and sets it to 4096 in order to be twice the size of `RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN`, but I'm happy to set it to whatever anyone thinks is an appropriate default. It is set to 0 for non-windows systems to retain the same behavior as before.

Example failure:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10875)](https://ci.ros2.org/job/ci_windows/10875/)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10988)](http://ci.ros2.org/job/ci_linux/10988/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6324)](http://ci.ros2.org/job/ci_linux-aarch64/6324/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8947)](http://ci.ros2.org/job/ci_osx/8947/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10896)](http://ci.ros2.org/job/ci_windows/10896/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>