### PR TITLE
Add token join macros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_logging_console_output_handler ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
+  rcutils_custom_add_gtest(test_macros
+    test/test_macros.cpp
+  )
+  if(TARGET test_macros)
+    target_link_libraries(test_macros ${PROJECT_NAME})
+  endif()
 endif()
 
 ament_export_dependencies(ament_cmake)

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -64,6 +64,9 @@ extern "C"
 #define RCUTILS_STRINGIFY(x) RCUTILS_STRINGIFY_IMPL(x)
 #define RCUTILS_UNUSED(x) (void)(x)
 
+#define RCUTILS_JOIN_IMPL(arg1, arg2) arg1 ## arg2
+#define RCUTILS_JOIN(arg1, arg2) RCUTILS_JOIN_IMPL(arg1, arg2)
+
 #if defined _WIN32 || defined __CYGWIN__
 /// Macro to annotate printf-like functions on Linux. Disabled on Windows.
 #define RCUTILS_ATTRIBUTE_PRINTF_FORMAT(format_string_index, first_to_check_index)

--- a/test/test_macros.cpp
+++ b/test/test_macros.cpp
@@ -1,0 +1,30 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcutils/macros.h"
+
+TEST(TestMacros, stringify) {
+#define NUMBER 23
+  EXPECT_STREQ(RCUTILS_STRINGIFY(foo), "foo");
+  EXPECT_STREQ(RCUTILS_STRINGIFY(42), "42");
+  EXPECT_STREQ(RCUTILS_STRINGIFY(NUMBER), "23");
+#undef NUMBER
+}
+
+TEST(TestMacros, join) {
+  EXPECT_STREQ(RCUTILS_STRINGIFY(RCUTILS_JOIN(foo, bar)), "foobar");
+  EXPECT_STREQ(RCUTILS_STRINGIFY(RCUTILS_JOIN(RCUTILS_JOIN(fizz, buzz), 42)), "fizzbuzz42");
+}


### PR DESCRIPTION
Precisely what the title says.

CI up to `rcutils`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11296)](http://ci.ros2.org/job/ci_linux/11296/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6543)](http://ci.ros2.org/job/ci_linux-aarch64/6543/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9248)](http://ci.ros2.org/job/ci_osx/9248/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11200)](http://ci.ros2.org/job/ci_windows/11200/)