### PR TITLE
Fault injection macros and functionality (plus example)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(rcutils_sources
   src/strerror.c
   src/string_array.c
   src/string_map.c
+  src/testing/fault_injection.c
   src/time.c
   ${time_impl_c}
   src/uint8_array.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCUTILS_BUILDING_DLL")
 
+if(BUILD_TESTING AND NOT RCUTILS_DISABLE_FAULT_INJECTION)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
+endif()
+
 target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
 
 # Needed if pthread is used for thread local storage.

--- a/Doxyfile
+++ b/Doxyfile
@@ -24,6 +24,7 @@ EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCUTILS_PUBLIC=
 PREDEFINED             += RCUTILS_PUBLIC_TYPE=
 PREDEFINED             += RCUTILS_WARN_UNUSED=
+PREDEFINED             += RCUTILS_ENABLE_FAULT_INJECTION=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -36,6 +36,7 @@ extern "C"
 #include "rcutils/allocator.h"
 #include "rcutils/macros.h"
 #include "rcutils/snprintf.h"
+#include "rcutils/testing/fault_injection.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -162,11 +162,12 @@ extern "C"
  * should go on a separate line.
  *
  * If in your function, there are expected effects on output parameters that occur during
- * the failure case, then it will introduce a discrepency between fault injection testing and
+ * the failure case, then it will introduce a discrepancy between fault injection testing and
  * production operation. This is because the fault injection will cause the function to return
  * where this macro is used, not at the location the error values are typically returned. To help
- * protect against this scenario you may consider adding unit tests that checks your function does
- * not modify output parameters when it actually returns a failing error code.
+ * protect against this scenario you may consider adding unit tests that check your function does
+ * not modify output parameters when it actually returns a failing error code if it's possible for
+ * your code.
  *
  * If your function is void, this macro can be used without parameters. However, for the above
  * reasoning, there should be no side effects on output parameters for all possible early returns.
@@ -177,8 +178,26 @@ extern "C"
 # define RCUTILS_CAN_RETURN_WITH_ERROR_OF(error_return_value) \
   RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(error_return_value);
 
+/**
+ * \def RCUTILS_CAN_FAIL_WITH
+ * Indicating macro similar to RCUTILS_CAN_RETURN_WITH_ERROR_OF but for use with more complicated
+ * statements.
+ *
+ * The `failure_code` will be executed inside a scoped if block, so any variables declared within
+ * will not be available outside of the macro.
+ *
+ * One example where you might need this version, is if a side-effect may occur within a function.
+ * For example, in snprintf, rcutils_snprintf needs to set both errno and return -1 on failure.
+ * This macro is used to capture both effects.
+ *
+ * \param failure_code Code that is representative of the failure case in this function.
+ */
+# define RCUTILS_CAN_FAIL_WITH(failure_code) \
+  RCUTILS_FAULT_INJECTION_MAYBE_FAIL(failure_code);
+
 #else
 # define RCUTILS_CAN_RETURN_WITH_ERROR_OF(error_return_value)
+# define RCUTILS_CAN_FAIL_WITH(failure_code)
 #endif  // defined RCUTILS_ENABLE_FAULT_INJECTION
 
 #ifdef __cplusplus

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -145,9 +145,10 @@ extern "C"
  *   ...  // rest of function
  * }
  *
- * For now, this macro just simply calls `RCUTILS_MAYBE_RETURN_ERROR` if fault injection is
- * enabled. However, for source code, the macro annotation `RCUTILS_CAN_RETURN_WITH_ERROR_OF` helps
- * clarify that a function may return a value signifying an error and what those are.
+ * For now, this macro just simply calls `RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR` if fault
+ * injection is enabled. However, for source code, the macro annotation
+ * `RCUTILS_CAN_RETURN_WITH_ERROR_OF` helps clarify that a function may return a value signifying
+ * an error and what those are.
  *
  * In general, you should only include a return value that originates in the function you're
  * annotating instead of one that is merely passed on from a called function already annotated with
@@ -174,7 +175,7 @@ extern "C"
  * a rcutils_ret_t type. It could also be NULL, -1, a string error message, etc
  */
 # define RCUTILS_CAN_RETURN_WITH_ERROR_OF(error_return_value) \
-  RCUTILS_MAYBE_RETURN_ERROR(error_return_value);
+  RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(error_return_value);
 
 #else
 # define RCUTILS_CAN_RETURN_WITH_ERROR_OF(error_return_value)

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -104,12 +104,6 @@ int _rcutils_fault_injection_maybe_fail();
 #define RCUTILS_FAULT_INJECTION_GET_COUNT() \
   _rcutils_fault_injection_get_count();
 
-#define RCUTILS_FAULT_INJECTION_INIT() \
-  RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL)
-
-#define RCUTILS_FAULT_INJECTION_FINI() \
-  RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL)
-
 #define RCUTILS_FAULT_INJECTION_TEST(code) \
   do { \
     int fault_injection_count = 0; \
@@ -117,6 +111,7 @@ int _rcutils_fault_injection_maybe_fail();
       RCUTILS_FAULT_INJECTION_SET_COUNT(fault_injection_count++); \
       code; \
     } while (!rcutils_fault_injection_is_test_complete()); \
+    RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL); \
   } while(0)
 
 #else  // RCUTILS_ENABLE_FAULT_INJECTION
@@ -128,11 +123,7 @@ int _rcutils_fault_injection_maybe_fail();
 
 #define RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(msg, error_statement)
 
-#define RCUTILS_FAULT_INJECTION_INIT() \
-  printf("Fault injection is disabled, skipping\n"); \
-  return;
-
-#define RCUTILS_FAULT_INJECTION_FINI()
+#define RCUTILS_FAULT_INJECTION_TEST(code) return;
 
 #endif  // defined RCUTILS_ENABLE_FAULT_INJECTION
 

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -1,0 +1,90 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__TESTING_MACROS_H_
+#define RCUTILS__TESTING_MACROS_H_
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+void _rcutils_set_fault_injection_count(int count);
+
+int _rcutils_maybe_fail();
+
+#if defined RCUTILS_ENABLE_FAULT_INJECTION
+
+/**
+ * \def RCUTILS_MAYBE_RETURN_ERROR
+ * \brief This macro checks and decrements a static global variable atomic counter and returns
+ * `return_value_on_error` if 0.
+ *
+ * This macro is not a function itself, so when this macro returns it will cause the calling
+ * function to return with the return value.
+ *
+ * Set the counter with `RCUTILS_SET_FAULT_INJECTION_COUNT`. If the count is less than 0, then
+ * `RCUTILS_MAYBE_RETURN_ERROR` will not cause an early return.
+ *
+ * This macro is thread-safe, and ensures that at most one invocation results in a failure for each
+ * time the fault injection counter is set with `RCUTILS_SET_FAULT_INJECTION_COUNT`
+ *
+ * \param return_value_on_error the value to return in the case of fault injected failure.
+ */
+#define RCUTILS_MAYBE_RETURN_ERROR(return_value_on_error) \
+  if (0 == _rcutils_maybe_fail()) { \
+    return return_value_on_error; \
+  }
+
+/**
+ * \def RCUTILS_SET_FAULT_INJECTION_COUNT
+ * \brief Atomically set the fault injection counter.
+ *
+ * There will be at most one fault injected failure per call to RCUTILS_SET_FAULT_INJECTION_COUNT.
+ * To test all reachable fault injection locations, call this macro inside a for loop with
+ * sufficient iterations setting count to the loop iteration variable. For example:
+ *
+ *  for (int i = 0; i < SUFFICIENTLY_LARGE_ITERATION_COUNT; ++i) {
+ *    RCUTILS_SET_FAULT_INJECTION_COUNT(i);
+ *    ... // Call function under test
+ *  }
+ *
+ * Where SUFFICIENTLY_LARGE_ITERATION_COUNT is a value larger than the maximum expected calls to
+ * `RCUTILS_MAYBE_RETURN_ERROR`. In your fault injection unit test, it is recommended to run one
+ * last iteration with the fault injection counter set to this maximum value and validate that the
+ * results of the call to the function under test would result in the same thing as if no fault
+ * injection was used. This will help ensure that this maximum value is suitable and will call
+ * attention to maintainers if it needs to be increased because more instances of
+ * RCUTILS_MAYBE_RETURN_ERROR were introduced.
+ *
+ * \param count The count to set the fault injection counter to. If count is negative, then fault
+ * injection errors will be disabled. The counter is globally initialized to -1.
+ */
+#define RCUTILS_SET_FAULT_INJECTION_COUNT(count) \
+  _rcutils_set_fault_injection_count(count);
+
+#else  // RCUTILS_ENABLE_FAULT_INJECTION
+
+#define RCUTILS_SET_FAULT_INJECTION_COUNT(count)
+
+#define RCUTILS_MAYBE_RETURN_ERROR(msg, error_statement)
+
+#endif  // defined RCUTILS_ENABLE_FAULT_INJECTION
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__TESTING_MACROS_H_

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -18,6 +18,9 @@
 #include <stdio.h>
 #include <stdint.h>
 
+#include "rcutils/macros.h"
+#include "rcutils/visibility_control.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -27,36 +30,10 @@ extern "C"
 
 #define RCUTILS_FAULT_INJECTION_FAIL_NOW 0
 
-bool rcutils_fault_injection_is_test_complete();
-
-void _rcutils_fault_injection_set_count(int count);
-
-int_least64_t _rcutils_fault_injection_get_count();
-
-int_least64_t _rcutils_fault_injection_maybe_fail();
-
-/**
- * \def RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR
- * \brief This macro checks and decrements a static global variable atomic counter and returns
- * `return_value_on_error` if 0.
- *
- * This macro is not a function itself, so when this macro returns it will cause the calling
- * function to return with the return value.
- *
- * Set the counter with `RCUTILS_FAULT_INJECTION_SET_COUNT`. If the count is less than 0, then
- * `RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR` will not cause an early return.
- *
- * This macro is thread-safe, and ensures that at most one invocation results in a failure for each
- * time the fault injection counter is set with `RCUTILS_FAULT_INJECTION_SET_COUNT`
- *
- * \param return_value_on_error the value to return in the case of fault injected failure.
- */
-#define RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(return_value_on_error) \
-  if (RCUTILS_FAULT_INJECTION_FAIL_NOW == _rcutils_fault_injection_maybe_fail()) { \
-    printf( \
-      "%s:%d Injecting fault and returning " #return_value_on_error "\n", __FILE__, __LINE__); \
-    return return_value_on_error; \
-  }
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+bool
+rcutils_fault_injection_is_test_complete(void);
 
 /**
  * \def RCUTILS_FAULT_INJECTION_SET_COUNT
@@ -87,8 +64,9 @@ int_least64_t _rcutils_fault_injection_maybe_fail();
  * injection errors will be disabled. The counter is globally initialized to
  * RCUTILS_FAULT_INJECTION_NEVER_FAIL.
  */
-#define RCUTILS_FAULT_INJECTION_SET_COUNT(count) \
-  _rcutils_fault_injection_set_count(count);
+RCUTILS_PUBLIC
+void
+rcutils_fault_injection_set_count(int count);
 
 /**
  * \def RCUTILS_FAULT_INJECTION_GET_COUNT
@@ -100,17 +78,47 @@ int_least64_t _rcutils_fault_injection_maybe_fail();
  * count value was greater or equal to 0, then the failure was not caused by the fault injection
  * counter.
  */
-#define RCUTILS_FAULT_INJECTION_GET_COUNT() \
-  _rcutils_fault_injection_get_count();
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+int_least64_t
+rcutils_fault_injection_get_count(void);
+
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+int_least64_t
+_rcutils_fault_injection_maybe_fail(void);
+
+/**
+ * \def RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR
+ * \brief This macro checks and decrements a static global variable atomic counter and returns
+ * `return_value_on_error` if 0.
+ *
+ * This macro is not a function itself, so when this macro returns it will cause the calling
+ * function to return with the return value.
+ *
+ * Set the counter with `RCUTILS_FAULT_INJECTION_SET_COUNT`. If the count is less than 0, then
+ * `RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR` will not cause an early return.
+ *
+ * This macro is thread-safe, and ensures that at most one invocation results in a failure for each
+ * time the fault injection counter is set with `RCUTILS_FAULT_INJECTION_SET_COUNT`
+ *
+ * \param return_value_on_error the value to return in the case of fault injected failure.
+ */
+#define RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(return_value_on_error) \
+  if (RCUTILS_FAULT_INJECTION_FAIL_NOW == _rcutils_fault_injection_maybe_fail()) { \
+    printf( \
+      "%s:%d Injecting fault and returning " #return_value_on_error "\n", __FILE__, __LINE__); \
+    return return_value_on_error; \
+  }
 
 #define RCUTILS_FAULT_INJECTION_TEST(code) \
   do { \
     int fault_injection_count = 0; \
     do { \
-      RCUTILS_FAULT_INJECTION_SET_COUNT(fault_injection_count++); \
+      rcutils_fault_injection_set_count(fault_injection_count++); \
       code; \
     } while (!rcutils_fault_injection_is_test_complete()); \
-    RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL); \
+    rcutils_fault_injection_set_count(RCUTILS_FAULT_INJECTION_NEVER_FAIL); \
   } while (0)
 
 #ifdef __cplusplus

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -33,8 +34,6 @@ void _rcutils_fault_injection_set_count(int count);
 int_least64_t _rcutils_fault_injection_get_count();
 
 int _rcutils_fault_injection_maybe_fail();
-
-#if defined RCUTILS_ENABLE_FAULT_INJECTION
 
 /**
  * \def RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR
@@ -113,19 +112,6 @@ int _rcutils_fault_injection_maybe_fail();
     } while (!rcutils_fault_injection_is_test_complete()); \
     RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL); \
   } while (0)
-
-#else  // RCUTILS_ENABLE_FAULT_INJECTION
-
-#define RCUTILS_FAULT_INJECTION_SET_COUNT(count)
-
-// This needs to be set to an int for compatibility
-#define RCUTILS_FAULT_INJECTION_GET_COUNT() RCUTILS_FAULT_INJECTION_NEVER_FAIL
-
-#define RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR(msg, error_statement)
-
-#define RCUTILS_FAULT_INJECTION_TEST(code) return;
-
-#endif  // defined RCUTILS_ENABLE_FAULT_INJECTION
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -33,7 +33,7 @@ void _rcutils_fault_injection_set_count(int count);
 
 int_least64_t _rcutils_fault_injection_get_count();
 
-int _rcutils_fault_injection_maybe_fail();
+int_least64_t _rcutils_fault_injection_maybe_fail();
 
 /**
  * \def RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -50,7 +50,7 @@ rcutils_fault_injection_is_test_complete(void);
  * ASSERT_LT(RCUTILS_FAULT_INJECTION_NEVER_FAIL, RCUTILS_FAULT_INJECTION_GET_COUNT());
  *
  * Where SUFFICIENTLY_LARGE_ITERATION_COUNT is a value larger than the maximum expected calls to
- * `RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR`. This last assertion just insures that your choice for
+ * `RCUTILS_FAULT_INJECTION_MAYBE_RETURN_ERROR`. This last assertion just ensures that your choice for
  * SUFFICIENTLY_LARGE_ITERATION_COUNT was large enough. To avoid having to choose this count
  * yourself, you can use a do-while loop.
  *
@@ -109,6 +109,30 @@ _rcutils_fault_injection_maybe_fail(void);
     printf( \
       "%s:%d Injecting fault and returning " #return_value_on_error "\n", __FILE__, __LINE__); \
     return return_value_on_error; \
+  }
+
+/**
+ * \def RCUTILS_FAULT_INJECTION_MAYBE_FAIL
+ * \brief This macro checks and decrements a static global variable atomic counter and executes
+ * `failure_code` if the counter is 0 inside a scoped block (any variables declared in failure_code)
+ * will not be avaliable outside of this scoped block.
+ *
+ * This macro is not a function itself, so it will cause the calling function to execute the code
+ * from within an if loop.
+ *
+ * Set the counter with `RCUTILS_FAULT_INJECTION_SET_COUNT`. If the count is less than 0, then
+ * `RCUTILS_FAULT_INJECTION_MAYBE_FAIL` will not execute the failure code.
+ *
+ * This macro is thread-safe, and ensures that at most one invocation results in a failure for each
+ * time the fault injection counter is set with `RCUTILS_FAULT_INJECTION_SET_COUNT`
+ *
+ * \param failure_code the code to execute in the case of fault injected failure.
+ */
+#define RCUTILS_FAULT_INJECTION_MAYBE_FAIL(failure_code) \
+  if (RCUTILS_FAULT_INJECTION_FAIL_NOW == _rcutils_fault_injection_maybe_fail()) { \
+    printf( \
+      "%s:%d Injecting fault and executing " #failure_code "\n", __FILE__, __LINE__); \
+    failure_code; \
   }
 
 #define RCUTILS_FAULT_INJECTION_TEST(code) \

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCUTILS__TESTING_MACROS_H_
-#define RCUTILS__TESTING_MACROS_H_
+#ifndef RCUTILS__TESTING__FAULT_INJECTION_H_
+#define RCUTILS__TESTING__FAULT_INJECTION_H_
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 #ifdef __cplusplus
@@ -24,6 +25,8 @@ extern "C"
 #define RCUTILS_FAULT_INJECTION_NEVER_FAIL -1
 
 #define RCUTILS_FAULT_INJECTION_FAIL_NOW 0
+
+bool rcutils_fault_injection_is_test_complete();
 
 void _rcutils_set_fault_injection_count(int count);
 
@@ -51,6 +54,8 @@ int _rcutils_maybe_fail();
  */
 #define RCUTILS_MAYBE_RETURN_ERROR(return_value_on_error) \
   if (RCUTILS_FAULT_INJECTION_FAIL_NOW == _rcutils_maybe_fail()) { \
+    printf( \
+      "%s:%d Injecting fault and returning " #return_value_on_error "\n", __FILE__, __LINE__); \
     return return_value_on_error; \
   }
 
@@ -114,4 +119,4 @@ int _rcutils_maybe_fail();
 }
 #endif
 
-#endif  // RCUTILS__TESTING_MACROS_H_
+#endif  // RCUTILS__TESTING__FAULT_INJECTION_H_

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -15,9 +15,7 @@
 #ifndef RCUTILS__TESTING_MACROS_H_
 #define RCUTILS__TESTING_MACROS_H_
 #include <stdio.h>
-
-#include "rcutils/stdatomic_helper.h"
-
+#include <stdint.h>
 #ifdef __cplusplus
 extern "C"
 {
@@ -94,7 +92,7 @@ int _rcutils_maybe_fail();
  *
  * Use this macro after running the code under test to check whether the counter reached a negative
  * value. This is helpful so you can verify that you ran the fault injection test in a loop a
- * sufficient number of times. Likewise, if the code under test returned with an error, but the 
+ * sufficient number of times. Likewise, if the code under test returned with an error, but the
  * count value was greater or equal to 0, then the failure was not caused by the fault injection
  * counter.
  */

--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -112,7 +112,7 @@ int _rcutils_fault_injection_maybe_fail();
       code; \
     } while (!rcutils_fault_injection_is_test_complete()); \
     RCUTILS_FAULT_INJECTION_SET_COUNT(RCUTILS_FAULT_INJECTION_NEVER_FAIL); \
-  } while(0)
+  } while (0)
 
 #else  // RCUTILS_ENABLE_FAULT_INJECTION
 

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -27,6 +27,7 @@ C_ASSERT(sizeof(void *) == sizeof(HINSTANCE));
 #endif  // _WIN32
 
 #include "rcutils/error_handling.h"
+#include "rcutils/macros.h"
 #include "rcutils/shared_library.h"
 #include "rcutils/strdup.h"
 
@@ -46,6 +47,10 @@ rcutils_load_shared_library(
   const char * library_path,
   rcutils_allocator_t allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_BAD_ALLOC);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_ERROR);
+
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(lib, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(library_path, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -39,7 +39,7 @@ rcutils_snprintf(char * buffer, size_t buffer_size, const char * format, ...)
 int
 rcutils_vsnprintf(char * buffer, size_t buffer_size, const char * format, va_list args)
 {
-  RCUTILS_CAN_RETURN_WITH_ERROR_OF(-1);
+  RCUTILS_CAN_FAIL_WITH({errno = EINVAL; return -1;});
 
   if (NULL == format) {
     errno = EINVAL;

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -39,6 +39,8 @@ rcutils_snprintf(char * buffer, size_t buffer_size, const char * format, ...)
 int
 rcutils_vsnprintf(char * buffer, size_t buffer_size, const char * format, va_list args)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(-1);
+
   if (NULL == format) {
     errno = EINVAL;
     return -1;

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -17,12 +17,13 @@ extern "C"
 {
 #endif
 
+#include "rcutils/strdup.h"
+
 #include <stddef.h>
 #include <string.h>
 
 #include "./common.h"
 #include "rcutils/macros.h"
-#include "rcutils/strdup.h"
 
 
 char *

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -17,16 +17,19 @@ extern "C"
 {
 #endif
 
-#include "rcutils/strdup.h"
-
 #include <stddef.h>
 #include <string.h>
 
 #include "./common.h"
+#include "rcutils/macros.h"
+#include "rcutils/strdup.h"
+
 
 char *
 rcutils_strdup(const char * str, rcutils_allocator_t allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
   if (NULL == str) {
     return NULL;
   }
@@ -36,6 +39,8 @@ rcutils_strdup(const char * str, rcutils_allocator_t allocator)
 char *
 rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
   if (NULL == str) {
     return NULL;
   }

--- a/src/string_array.c
+++ b/src/string_array.c
@@ -42,6 +42,9 @@ rcutils_string_array_init(
   size_t size,
   const rcutils_allocator_t * allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_BAD_ALLOC);
+
   if (NULL == allocator) {
     RCUTILS_SET_ERROR_MSG("allocator is null");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -63,6 +66,8 @@ rcutils_string_array_init(
 rcutils_ret_t
 rcutils_string_array_fini(rcutils_string_array_t * string_array)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCUTILS_RET_INVALID_ARGUMENT);
+
   if (NULL == string_array) {
     RCUTILS_SET_ERROR_MSG("string_array is null");
     return RCUTILS_RET_INVALID_ARGUMENT;

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -18,6 +18,15 @@
 
 static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
 
+bool rcutils_fault_injection_is_test_complete()
+{
+#ifndef RCUTILS_ENABLE_FAULT_INJECTION
+  return true;
+#endif  // RCUTILS_ENABLE_FAULT_INJECTION
+
+  return _rcutils_get_fault_injection_count() > RCUTILS_FAULT_INJECTION_NEVER_FAIL;
+}
+
 int _rcutils_maybe_fail()
 {
   bool set_atomic_success = false;

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -1,0 +1,44 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcutils/testing/fault_injection.h"
+
+#include "rcutils/stdatomic_helper.h"
+
+static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
+
+int _rcutils_maybe_fail()
+{
+  bool set_atomic_success = false;
+  int_least64_t current_count = -1;
+  rcutils_atomic_load(&g_rcutils_fault_injection_count, current_count);
+  do {
+    // A fault_injection_count less than 0 means that maybe_fail doesn't fail, so just return.
+    if (current_count < 0) {
+      return current_count;
+    }
+
+    // Otherwise decrement by one, but do so in a thread-safe manner so that exactly one calling
+    // thread gets the 0 case.
+    int_least64_t desired_count = current_count - 1;
+    rcutils_atomic_compare_exchange_strong(
+      &g_rcutils_fault_injection_count, set_atomic_success, &current_count, desired_count);
+  } while (!set_atomic_success);
+  return current_count;
+}
+
+void _rcutils_set_fault_injection_count(int count)
+{
+  rcutils_atomic_store(&g_rcutils_fault_injection_count, count);
+}

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -27,7 +27,7 @@ bool rcutils_fault_injection_is_test_complete()
 #endif  // RCUTILS_ENABLE_FAULT_INJECTION
 }
 
-int _rcutils_fault_injection_maybe_fail()
+int_least64_t _rcutils_fault_injection_maybe_fail()
 {
   bool set_atomic_success = false;
   int_least64_t current_count = RCUTILS_FAULT_INJECTION_NEVER_FAIL;

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -14,18 +14,16 @@
 
 #include "rcutils/testing/fault_injection.h"
 
-#include "rcutils/stdatomic_helper.h"
-
 static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
 
 int _rcutils_maybe_fail()
 {
   bool set_atomic_success = false;
-  int_least64_t current_count = -1;
+  int_least64_t current_count = RCUTILS_FAULT_INJECTION_NEVER_FAIL;
   rcutils_atomic_load(&g_rcutils_fault_injection_count, current_count);
   do {
     // A fault_injection_count less than 0 means that maybe_fail doesn't fail, so just return.
-    if (current_count < 0) {
+    if (current_count <= RCUTILS_FAULT_INJECTION_NEVER_FAIL) {
       return current_count;
     }
 
@@ -41,4 +39,11 @@ int _rcutils_maybe_fail()
 void _rcutils_set_fault_injection_count(int count)
 {
   rcutils_atomic_store(&g_rcutils_fault_injection_count, count);
+}
+
+int_least64_t _rcutils_get_fault_injection_count()
+{
+  int_least64_t count = 0;
+  rcutils_atomic_load(&g_rcutils_fault_injection_count, count);
+  return count;
 }

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -14,6 +14,8 @@
 
 #include "rcutils/testing/fault_injection.h"
 
+#include "rcutils/stdatomic_helper.h"
+
 static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
 
 int _rcutils_maybe_fail()

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -24,10 +24,10 @@ bool rcutils_fault_injection_is_test_complete()
   return true;
 #endif  // RCUTILS_ENABLE_FAULT_INJECTION
 
-  return _rcutils_get_fault_injection_count() > RCUTILS_FAULT_INJECTION_NEVER_FAIL;
+  return _rcutils_fault_injection_get_count() > RCUTILS_FAULT_INJECTION_NEVER_FAIL;
 }
 
-int _rcutils_maybe_fail()
+int _rcutils_fault_injection_maybe_fail()
 {
   bool set_atomic_success = false;
   int_least64_t current_count = RCUTILS_FAULT_INJECTION_NEVER_FAIL;
@@ -47,12 +47,12 @@ int _rcutils_maybe_fail()
   return current_count;
 }
 
-void _rcutils_set_fault_injection_count(int count)
+void _rcutils_fault_injection_set_count(int count)
 {
   rcutils_atomic_store(&g_rcutils_fault_injection_count, count);
 }
 
-int_least64_t _rcutils_get_fault_injection_count()
+int_least64_t _rcutils_fault_injection_get_count()
 {
   int_least64_t count = 0;
   rcutils_atomic_load(&g_rcutils_fault_injection_count, count);

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,7 @@
 
 #include "rcutils/stdatomic_helper.h"
 
-static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
+static atomic_int_least64_t g_rcutils_fault_injection_count = ATOMIC_VAR_INIT(-1);
 
 bool rcutils_fault_injection_is_test_complete()
 {

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -22,9 +22,9 @@ bool rcutils_fault_injection_is_test_complete()
 {
 #ifndef RCUTILS_ENABLE_FAULT_INJECTION
   return true;
-#endif  // RCUTILS_ENABLE_FAULT_INJECTION
-
+#else  // RCUTILS_ENABLE_FAULT_INJECTION
   return _rcutils_fault_injection_get_count() > RCUTILS_FAULT_INJECTION_NEVER_FAIL;
+#endif  // RCUTILS_ENABLE_FAULT_INJECTION
 }
 
 int _rcutils_fault_injection_maybe_fail()


### PR DESCRIPTION
This introduces a set of fault injection macros that enable selective functions to return failing error codes to help test upstream code. 

The macro `RCUTILS_MAYBE_RETURN_ERROR` is a compile flag enabled macro that selectively returns the error value that is passed to it. It allows for simple unit tests of upstream code that helps ensure the code under test is robust to all possible return failures regardless of how difficult they are to trigger. In order to enable `RCUTILS_MAYBE_RETURN_ERROR`, you must set the global counter.

The counter is set with `RCUTILS_SET_FAULT_INJECTION_COUNT`. The counter counts down for every invocation of `RCUTILS_MAYBE_RETURN_ERROR` and when it reaches 0 will cause `RCUTILS_MAYBE_RETURN_ERROR` to return the designated error. As this macro may be widely placed in the code base, it is necessary to run this in a for loop in the unit tests. For example

```c++
TEST(TestMyFunction, test_function) {
  constexpr int maximum_calls_to_maybe_return = 100;
  for (int i = 0; i < maximum_calls_to_maybe_return; ++i) {
    RCUTILS_SET_FAULT_INJECTION_COUNT(i);
    auto result = function_under_test();
    // unless cleanup needs to occur, result is likely to be ignored
  }
}
```

This sort of test doesn't help you assert that the behavior of the function is correct in face of downstream code failing, but it does let you ensure that your code returns safely and that resources are adequately cleaned up in all possible return paths (with the appropriate analysis tools). 

The high level macro `RCUTILS_CAN_RETURN_WITH_ERROR_OF` is a descriptive macro that includes a call to `RCUTILS_MAYBE_RETURN_ERROR`, with the `RCUTILS_ENABLE_FAULT_INJECTION` compiler flag enabled. It has the extra benefit of providing a quick glance at the expected failure return codes in the function.

Currently, the intention is to use `RCUTILS_CAN_RETURN_WITH_ERROR_OF` once for each error return value, but more fully featured macros could also be included. For example, variadic versions can be introduced like `RCUTILS_CAN_RETURN_WITH_ERRORS_OF`, `RCUTILS_CAN_RETURN_WITH_STRING_ERRORS_OF`, etc.

### Possible Extensions
**RCUTILS_CHECK_RETURN_OK**
If labeling the upstream code is troublesome, an alternative macro like `RCUTILS_CHECK_RETURN_OK` could be created that would replace simple if statements. This would be placed in the downstream code that checks the called functions for error values. That macro would include the call to `RCUTILS_MAYBE_FAIL`, which executes a statement on error (not just return an error value).

```c++
#define RCUTILS_CHECK_RETURN_OK(ret, error_message, error_statement) \
  RCUTILS_MAYBE_FAIL(error_statement); \
  if (ret != RCUTILS_RET_OK) { \
    RCUTILS_SET_ERROR_MESSAGE(error_message); \
    error_statement; \
  }
```

**Targeted fault injection macros**
While `RCUTILS_MAYBE_RETURN_ERROR` allows for robust coverage of numerous possible return paths with very easy unit tests, it doesn't allow for targeted failures. Another extension of this feature would be to give string names to each `RCUTILS_CAN_RETURN_WITH_ERROR_OF` macro that are registered with a global lookup. In the unit test, these macros could then be set to specifically fail and the expected failure behavior can then be asserted.