### PR TITLE
Add mock test for rcutils/strerror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,8 @@ if(BUILD_TESTING)
       "${CMAKE_CURRENT_BINARY_DIR}/include/rcutils/logging_macros.h")
   endif()
 
+  find_package(mimick_vendor REQUIRED)
+
   find_package(osrf_testing_tools_cpp REQUIRED)
   get_target_property(memory_tools_test_env_vars
     osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_VARIABLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ if(BUILD_TESTING)
     test/test_strerror.cpp
   )
   if(TARGET test_strerror)
-    target_link_libraries(test_strerror ${PROJECT_NAME})
+    target_link_libraries(test_strerror ${PROJECT_NAME} mimick)
   endif()
 
   rcutils_custom_add_gtest(test_string_array

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,8 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>mimick</test_depend>
+  <test_depend>mimick_vendor</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>mimick</test_depend>
   <test_depend>mimick_vendor</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -76,12 +76,12 @@ errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
   return errnum;
 }
 
-/* Mocking test example */
+// Mocking test example
 TEST(test_strerror, test_mock) {
-  /* Mock the strerror_s function in the current module using
-     the `strerror_s_mock` blueprint. */
+  // Mock the strerror_s function in the current module using
+  // the `strerror_s_mock` blueprint.
   mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
-  /* Tell the mock to call mocked_windows_strerror instead*/
+  // Tell the mock to call mocked_windows_strerror instead
   mmk_when(
     strerror_s(mmk_any(errno_t), mmk_any(char *), mmk_any(rsize_t), mmk_any(errno_t)),
     .then_call = (mmk_fn) mocked_windows_strerror);
@@ -104,12 +104,12 @@ char * mocked_gnu_strerror(int errnum, char * buf, size_t buflen)
   return buf;
 }
 
-/* Mocking test example */
+// Mocking test example
 TEST(test_strerror, test_mock) {
-  /* Mock the strerror_r function in the current module using
-     the `strerror_r_mock` blueprint. */
+  // Mock the strerror_r function in the current module using
+  // the `strerror_r_mock` blueprint.
   mmk_mock(RCUTILS_STRINGIFY(strerror_r) "@lib:rcutils", strerror_r_mock);
-  /* Tell the mock to call mocked_gnu_strerror instead */
+  // Tell the mock to call mocked_gnu_strerror instead
   mmk_when(
     strerror_r(mmk_any(int), mmk_any(char *), mmk_any(size_t) ),
     .then_call = (mmk_fn) mocked_gnu_strerror);
@@ -124,13 +124,14 @@ TEST(test_strerror, test_mock) {
 
 #else
 mmk_mock_define(strerror_r_mock, int, int, char *, size_t);
-/* Mocking test example */
+
+// Mocking test example
 TEST(test_strerror, test_mock) {
-  /* Mock the strerror_r function in the current module using
-     the `strerror_r_mock` blueprint. */
+  // Mock the strerror_r function in the current module using
+  // the `strerror_r_mock` blueprint.
   mmk_mock(RCUTILS_STRINGIFY(strerror_r) "@lib:rcutils", strerror_r_mock);
-  /* Tell the mock to return NULL and set errno to EINVAL
-     whatever the given parameter is. */
+  // Tell the mock to return NULL and set errno to EINVAL
+  // whatever the given parameter is.
   mmk_when(
     strerror_r(mmk_any(int), mmk_any(char *), mmk_any(size_t) ),
     .then_return = mmk_val(int, EINVAL));
@@ -142,5 +143,4 @@ TEST(test_strerror, test_mock) {
   ASSERT_STREQ(error_string, "Failed to get error");
   mmk_reset(strerror_r);
 }
-
 #endif

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -91,7 +91,7 @@ TEST(test_strerror, test_mock) {
   char error_string[1024];
   rcutils_strerror(error_string, sizeof(error_string));
   ASSERT_STREQ(error_string, "Failed to get error");
-  mmk_reset(strerror_s);
+  mmk_reset(reinterpret_cast<mmk_fn>strerror_s);
 }
 
 #elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -91,7 +91,7 @@ TEST(test_strerror, test_mock) {
   char error_string[1024];
   rcutils_strerror(error_string, sizeof(error_string));
   ASSERT_STREQ(error_string, "Failed to get error");
-  mmk_reset(reinterpret_cast<mmk_fn>(strerror_s));
+  mmk_reset(strerror_s_mock);
 }
 
 #elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -80,7 +80,7 @@ errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
 TEST(test_strerror, test_mock) {
   // Mock the strerror_s function in the current module using
   // the `strerror_s_mock` blueprint.
-  mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
+  malloc_mock mock = mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
   // Tell the mock to call mocked_windows_strerror instead
   mmk_when(
     strerror_s(mmk_any(char *), mmk_any(rsize_t), mmk_any(errno_t)),
@@ -91,7 +91,7 @@ TEST(test_strerror, test_mock) {
   char error_string[1024];
   rcutils_strerror(error_string, sizeof(error_string));
   ASSERT_STREQ(error_string, "Failed to get error");
-  mmk_reset(strerror_s_mock);
+  mmk_reset(mock);
 }
 
 #elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -105,10 +105,9 @@ mmk_mock_define(strerror_r_mock, char *, int, char *, size_t);
 char * mocked_gnu_strerror(int errnum, char * buf, size_t buflen)
 {
   (void) errnum;
-  const char error_msg[] = "Failed to get error";
   unsigned char index_err = 0;
   while (buf && buflen--) {
-    buf[index_err] = error_msg[index_err];
+    buf[index_err] = expected_error_msg[index_err];
     index_err++;
   }
   return buf;

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -80,7 +80,7 @@ errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
 TEST(test_strerror, test_mock) {
   // Mock the strerror_s function in the current module using
   // the `strerror_s_mock` blueprint.
-  malloc_mock mock = mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
+  strerror_s_mock mock = mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
   // Tell the mock to call mocked_windows_strerror instead
   mmk_when(
     strerror_s(mmk_any(char *), mmk_any(rsize_t), mmk_any(errno_t)),

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -24,7 +24,7 @@
 #include <string>
 
 #include "rcutils/strerror.h"
-#include "mimick_vendor/mimic.h"
+#include "mimick_vendor/mimick.h"
 
 TEST(test_strerror, get_error) {
   // cleaning possible errors

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -72,7 +72,7 @@ mmk_mock_define(strerror_s_mock, errno_t, char *, rsize_t, errno_t);
 errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
 {
   (void) errnum;
-  strncpy_s(buf, expected_error_msg, (size_t) bufsz);
+  strncpy_s(buf, (size_t) bufsz, expected_error_msg, (size_t) bufsz);
   return errnum;
 }
 

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -72,12 +72,7 @@ mmk_mock_define(strerror_s_mock, errno_t, char *, rsize_t, errno_t);
 errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
 {
   (void) errnum;
-  unsigned char index_err = 0;
-
-  while (buf && bufsz--) {
-    buf[index_err] = expected_error_msg[index_err];
-    index_err++;
-  }
+  strncpy(buf, expected_error_msg, (size_t) bufsz);
   return errnum;
 }
 
@@ -105,11 +100,7 @@ mmk_mock_define(strerror_r_mock, char *, int, char *, size_t);
 char * mocked_gnu_strerror(int errnum, char * buf, size_t buflen)
 {
   (void) errnum;
-  unsigned char index_err = 0;
-  while (buf && buflen--) {
-    buf[index_err] = expected_error_msg[index_err];
-    index_err++;
-  }
+  strncpy(buf, expected_error_msg, buflen);
   return buf;
 }
 

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -73,9 +73,6 @@ mmk_mock_define(strerror_r_mock, int, char *, size_t);
 TEST(test_strerror, test_mock) {
   /* Mock the strerror_r function in the current module using
      the `strerror_r_mock` blueprint. */
-  // mmk_mock("strerror_r@rcutils", strerror_r_mock);
-  // mmk_mock("__xpg_strerror_r@self", strerror_r_mock);
-  // mmk_mock("strerror_r@self", strerror_r_mock);
   mmk_mock("__xpg_strerror_r@lib:rcutils", strerror_r_mock);
 
   /* Tell the mock to return NULL and set errno to ENOMEM

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -91,7 +91,7 @@ TEST(test_strerror, test_mock) {
   char error_string[1024];
   rcutils_strerror(error_string, sizeof(error_string));
   ASSERT_STREQ(error_string, "Failed to get error");
-  mmk_reset(reinterpret_cast<mmk_fn>strerror_s);
+  mmk_reset(reinterpret_cast<mmk_fn>(strerror_s));
 }
 
 #elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -83,7 +83,7 @@ TEST(test_strerror, test_mock) {
   mmk_mock(RCUTILS_STRINGIFY(strerror_s) "@lib:rcutils", strerror_s_mock);
   // Tell the mock to call mocked_windows_strerror instead
   mmk_when(
-    strerror_s(mmk_any(errno_t), mmk_any(char *), mmk_any(rsize_t), mmk_any(errno_t)),
+    strerror_s(mmk_any(char *), mmk_any(rsize_t), mmk_any(errno_t)),
     .then_call = (mmk_fn) mocked_windows_strerror);
 
   // Set the error (not used by the mock)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -24,7 +24,10 @@
 #include <string>
 
 #include "rcutils/strerror.h"
-#include "mimick_vendor/mimick.h"
+
+extern "C" {
+#include "mimick.h"
+}
 
 TEST(test_strerror, get_error) {
   // cleaning possible errors
@@ -71,7 +74,7 @@ TEST(test_strerror, get_error) {
 
   /* Tell the mock to return NULL and set errno to ENOMEM
      whatever the given parameter is. */
-  mmk_when(strerror_r(mmk_any(int, char *, size_t)),
+  mmk_when(strerror_r(mmk_any(int), mmk_any(char *), mmk_any(size_t) ),
 	   .then_return = EINVAL);
 
   // Now normal usage of the function returning unexpected EINVAL

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -56,7 +56,6 @@ TEST(test_strerror, get_error) {
 #endif
 }
 
-const char expected_error_msg[] = "Failed to get error";
 /*
    Define the blueprint of a mock identified by `strerror_r_proto`
    strerror_r possible signatures:
@@ -67,6 +66,7 @@ const char expected_error_msg[] = "Failed to get error";
 */
 
 #if defined(_WIN32)
+const char expected_error_msg[] = "Failed to get error";
 mmk_mock_define(strerror_s_mock, errno_t, char *, rsize_t, errno_t);
 
 errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
@@ -95,6 +95,7 @@ TEST(test_strerror, test_mock) {
 }
 
 #elif defined(_GNU_SOURCE) && (!defined(ANDROID) || __ANDROID_API__ >= 23)
+const char expected_error_msg[] = "Failed to get error";
 mmk_mock_define(strerror_r_mock, char *, int, char *, size_t);
 
 char * mocked_gnu_strerror(int errnum, char * buf, size_t buflen)

--- a/test/test_strerror.cpp
+++ b/test/test_strerror.cpp
@@ -72,7 +72,7 @@ mmk_mock_define(strerror_s_mock, errno_t, char *, rsize_t, errno_t);
 errno_t mocked_windows_strerror(char * buf, rsize_t bufsz, errno_t errnum)
 {
   (void) errnum;
-  strncpy(buf, expected_error_msg, (size_t) bufsz);
+  strncpy_s(buf, expected_error_msg, (size_t) bufsz);
   return errnum;
 }
 


### PR DESCRIPTION
This PR includes a test for the `rcutils_strerror` function that required making a mock of the `strerror_r / strerror_s`.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>