### PR TITLE
Fix vsnprintf mocks for Release builds.

### DIFF
--- a/test/mocking_utils/stdio.hpp
+++ b/test/mocking_utils/stdio.hpp
@@ -52,7 +52,26 @@ using _vsnprintf_s_type =
 /// Patch _vscprintf with the given `replacement` in the given `scope`.
 #define patch__vscprintf(scope, replacement) patch(scope, _vscprintf, replacement)
 
-#endif  // defined(_WIN32)
+#else  // defined(_WIN32)
+
+// Deal with binary API nuances
+#ifndef NDEBUG
+
+/// Patch vsnprintf with the given `replacement` in the given `scope`.
+#define patch_vsnprintf(scope, replacement) patch(scope, vsnprintf, replacement)
+
+#else
+
+/// Patch vsnprintf with the given `replacement` in the given `scope`.
+#define patch_vsnprintf(scope, replacement) patch( \
+    scope, __vsnprintf_chk, [&](char * __str, size_t, int, size_t __size, \
+    const char * __fmt, va_list __ap) { \
+      auto f = replacement; \
+      return f(__str, __size, __fmt, __ap); \
+    })
+
+#endif
+#endif
 
 }  // namespace mocking_utils
 

--- a/test/test_char_array.cpp
+++ b/test/test_char_array.cpp
@@ -144,8 +144,8 @@ TEST_F(ArrayCharTest, vsprintf_fail) {
       return -1;
     });
 #else
-  auto mock = mocking_utils::patch(
-    "lib:rcutils", vsnprintf, [&](char * buffer, size_t buffer_size, auto...) {
+  auto mock = mocking_utils::patch_vsnprintf(
+    "lib:rcutils", [&](char * buffer, size_t buffer_size, auto...) {
       if (nullptr == buffer || buffer_size < buffer_threshold) {
         return static_cast<int>(buffer_threshold);
       }

--- a/test/test_format_string.cpp
+++ b/test/test_format_string.cpp
@@ -75,8 +75,8 @@ TEST(test_format_string_limit, on_internal_error) {
       return -1;
     });
 #else
-  auto mock = mocking_utils::patch(
-    "lib:rcutils", vsnprintf, [](char * buffer, auto && ...) {
+  auto mock = mocking_utils::patch_vsnprintf(
+    "lib:rcutils", [](char * buffer, auto && ...) {
       if (nullptr == buffer) {
         return 1;  // provide a dummy value if buffer required size is queried
       }

--- a/test/test_shared_library.cpp
+++ b/test/test_shared_library.cpp
@@ -61,8 +61,8 @@ TEST_F(TestSharedLibrary, basic_load) {
         return -1;
       });
 #else
-    auto mock = mocking_utils::patch(
-      "lib:rcutils", vsnprintf, [](char * buffer, auto && ...) {
+    auto mock = mocking_utils::patch_vsnprintf(
+      "lib:rcutils", [](char * buffer, auto && ...) {
         if (nullptr == buffer) {
           return 1;  // provide a dummy value if buffer required size is queried
         }

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -311,8 +311,8 @@ TEST_F(TestTimeFixture, test_rcutils_time_point_value_as_nanoseconds_string) {
       return -1;
     });
 #else
-  auto mock = mocking_utils::patch(
-    "lib:rcutils", vsnprintf, [](char * buffer, auto && ...) {
+  auto mock = mocking_utils::patch_vsnprintf(
+    "lib:rcutils", [](char * buffer, auto && ...) {
       if (nullptr == buffer) {
         return 1;    // provide a dummy value if buffer required size is queried
       }
@@ -391,8 +391,8 @@ TEST_F(TestTimeFixture, test_rcutils_time_point_value_as_seconds_string) {
       return -1;
     });
 #else
-  auto mock = mocking_utils::patch(
-    "lib:rcutils", vsnprintf, [](char * buffer, auto && ...) {
+  auto mock = mocking_utils::patch_vsnprintf(
+    "lib:rcutils", [](char * buffer, auto && ...) {
       if (nullptr == buffer) {
         return 1;    // provide a dummy value if buffer required size is queried
       }


### PR DESCRIPTION
This pull request deals with binary API nuances. Fixes regressions introduced by #272.

CI up to `rcutils`:
* Linux (default) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11847)](http://ci.ros2.org/job/ci_linux/11847/)
* Linux (release) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11848)](http://ci.ros2.org/job/ci_linux/11848/)

