### PR TITLE
Add fault injection hooks to default allocator

### DIFF
--- a/src/allocator.c
+++ b/src/allocator.c
@@ -31,6 +31,8 @@
 static void *
 __default_allocate(size_t size, void * state)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
   RCUTILS_UNUSED(state);
   return malloc(size);
 }
@@ -45,6 +47,8 @@ __default_deallocate(void * pointer, void * state)
 static void *
 __default_reallocate(void * pointer, size_t size, void * state)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
   RCUTILS_UNUSED(state);
   return realloc(pointer, size);
 }
@@ -52,6 +56,8 @@ __default_reallocate(void * pointer, size_t size, void * state)
 static void *
 __default_zero_allocate(size_t number_of_elements, size_t size_of_element, void * state)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
+
   RCUTILS_UNUSED(state);
   return calloc(number_of_elements, size_of_element);
 }

--- a/test/test_allocator.cpp
+++ b/test/test_allocator.cpp
@@ -117,7 +117,7 @@ TEST(test_allocator, default_allocator_maybe_fail) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
   // Check allocate
-  rcutils_fault_injection_set_count(0);
+  rcutils_fault_injection_set_count(RCUTILS_FAULT_INJECTION_FAIL_NOW);
   EXPECT_EQ(nullptr, allocator.allocate(1u, allocator.state));
   EXPECT_EQ(RCUTILS_FAULT_INJECTION_NEVER_FAIL, rcutils_fault_injection_get_count());
 
@@ -129,12 +129,12 @@ TEST(test_allocator, default_allocator_maybe_fail) {
   });
 
   // Check reallocate
-  rcutils_fault_injection_set_count(0);
+  rcutils_fault_injection_set_count(RCUTILS_FAULT_INJECTION_FAIL_NOW);
   EXPECT_EQ(nullptr, allocator.reallocate(pointer, 1u, allocator.state));
   EXPECT_EQ(RCUTILS_FAULT_INJECTION_NEVER_FAIL, rcutils_fault_injection_get_count());
 
   // Check zero_allocate
-  rcutils_fault_injection_set_count(0);
+  rcutils_fault_injection_set_count(RCUTILS_FAULT_INJECTION_FAIL_NOW);
   EXPECT_EQ(nullptr, allocator.zero_allocate(1u, 1u, allocator.state));
   EXPECT_EQ(RCUTILS_FAULT_INJECTION_NEVER_FAIL, rcutils_fault_injection_get_count());
 }


### PR DESCRIPTION
This adds the fault injection hooks to the default allocator. This will enable similar tests to the `time_bomb_allocator` but will inject failures into the three allocating functions (not deallocate) whereas the `time_bomb_allocator` allows for testing each one individually (as well as deallocate).

I'm leaving it out of deallocate so that memory can be freed as well as possible during fault_injection tests. Likewise, unless there is a bug in the program, I don't think `free()` can really fail.

Signed-off-by: Stephen Brawner <brawner@gmail.com>