### PR TITLE
adds QNX support for rcutils_get_executable_name

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -48,7 +48,7 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
 
 #if defined __APPLE__ || defined __FreeBSD__ || (defined __ANDROID__ && __ANDROID_API__ >= 21)
   const char * appname = getprogname();
-#elif defined __GNUC__
+#elif defined __GNUC__ && !defined(__QNXNTO__)
   const char * appname = program_invocation_name;
 #elif defined _WIN32 || defined __CYGWIN__
   char appname[MAX_PATH];
@@ -56,6 +56,9 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
   if (size == 0) {
     return NULL;
   }
+#elif defined __QNXNTO__
+  extern char * __progname;
+  const char * appname = __progname;
 #else
 #error "Unsupported OS"
 #endif


### PR DESCRIPTION
Fixes #281 

adds the global variable "__progname", which holds the basename of the program being executed, in function rcutils_get_executable_name(rcutils_allocator_t allocator)

reference:
http://www.qnx.com/developers/docs/6.5.0/index.jsp?topic=%2Fcom.qnx.doc.neutrino_lib_ref%2Fp%2F__progname.html