### PR TITLE
Change rcutils_fault_injection_set_count to use int64_t

### DIFF
--- a/include/rcutils/testing/fault_injection.h
+++ b/include/rcutils/testing/fault_injection.h
@@ -59,7 +59,7 @@ rcutils_fault_injection_is_test_complete(void);
  */
 RCUTILS_PUBLIC
 void
-rcutils_fault_injection_set_count(int count);
+rcutils_fault_injection_set_count(int_least64_t count);
 
 /**
  * \brief Atomically get the fault injection counter value

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -18,7 +18,7 @@
 
 static atomic_int_least64_t g_rcutils_fault_injection_count = ATOMIC_VAR_INIT(-1);
 
-void rcutils_fault_injection_set_count(int count)
+void rcutils_fault_injection_set_count(int_least64_t count)
 {
   rcutils_atomic_store(&g_rcutils_fault_injection_count, count);
 }


### PR DESCRIPTION
Discovered this warning during a ci_windows build for https://github.com/ros2/rmw_dds_common/pull/27. The integer type for set count doesn't match the one for get count.

Example warning:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12010)](https://ci.ros2.org/job/ci_windows/12010/) 

Signed-off-by: Stephen Brawner <brawner@gmail.com>