### PR TITLE
Inject faults on rcutils_get_env() and rcutils_set_env() call.

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -28,6 +28,8 @@ extern "C"
 bool
 rcutils_set_env(const char * env_name, const char * env_value)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(false);
+
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     env_name, "env_name is null", return false);
 

--- a/src/get_env.c
+++ b/src/get_env.c
@@ -29,6 +29,8 @@ extern "C"
 const char *
 rcutils_get_env(const char * env_name, const char ** env_value)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF("some string error");
+
   if (NULL == env_name) {
     return "argument env_name is null";
   }


### PR DESCRIPTION
Precisely what the title says. To force a few more internal errors across the board.

Full CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12389)](http://ci.ros2.org/job/ci_linux/12389/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7357)](http://ci.ros2.org/job/ci_linux-aarch64/7357/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10100)](http://ci.ros2.org/job/ci_osx/10100/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12301)](http://ci.ros2.org/job/ci_windows/12301/)
