### PR TITLE
Add rcutils_expand_user() to expand user directory in path

### DIFF
--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -144,6 +144,24 @@ rcutils_to_native_path(
   const char * path,
   rcutils_allocator_t allocator);
 
+/// Expand user directory in path.
+/**
+ * This function expands an initial '~' to the current user's home directory.
+ * The home directory is fetched using `rcutils_get_home_dir()`.
+ * This function returns a newly allocated string on success.
+ * It is up to the caller to release the memory once it is done with it by
+ * calling `deallocate` on the same allocator passed here.
+ *
+ * \param[in] path A null-terminated C string representing a path.
+ * \param[in] allocator
+ * \return path with expanded home directory on success, or
+ * \return `NULL` on invalid arguments, or
+ * \return `NULL` on failure.
+ */
+RCUTILS_PUBLIC
+char *
+rcutils_expand_user(const char * path, rcutils_allocator_t allocator);
+
 /// Create the specified directory.
 /**
  * This function creates an absolutely-specified directory.

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -33,7 +33,9 @@ extern "C"
 
 #include "rcutils/error_handling.h"
 #include "rcutils/format_string.h"
+#include "rcutils/get_env.h"
 #include "rcutils/repl_str.h"
+#include "rcutils/strdup.h"
 
 #ifdef _WIN32
 # define RCUTILS_PATH_DELIMITER "\\"
@@ -179,6 +181,29 @@ rcutils_to_native_path(
   }
 
   return rcutils_repl_str(path, "/", RCUTILS_PATH_DELIMITER, &allocator);
+}
+
+char *
+rcutils_expand_user(const char * path, rcutils_allocator_t allocator)
+{
+  if (NULL == path) {
+    return NULL;
+  }
+
+  if ('~' != path[0]) {
+    return rcutils_strdup(path, allocator);
+  }
+
+  const char * homedir = rcutils_get_home_dir();
+  if (NULL == homedir) {
+    return NULL;
+  }
+  return rcutils_format_string_limit(
+    allocator,
+    strlen(homedir) + strlen(path),
+    "%s%s",
+    homedir,
+    path + 1);
 }
 
 bool


### PR DESCRIPTION
Similar to Python's [`os.path.expanduser`](https://docs.python.org/3/library/os.path.html#os.path.expanduser).

Closes #293

Implementation originally from https://github.com/ros2/rcl_logging/pull/53 (but modified)