### PR TITLE
Make sure to check the return values of rcutils APIs.

### DIFF
--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -243,6 +243,7 @@ TEST_F(ArrayListPreInitTest, remove_success_removes_from_list) {
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)0);
 }
 
@@ -333,6 +334,7 @@ TEST_F(ArrayListTest, add_grow_capacity) {
   for (uint32_t i = 0; i < 17; ++i) {
     uint32_t ret_data = 0;
     ret = rcutils_array_list_get(&list, i, &ret_data);
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
     EXPECT_EQ((i * 2), ret_data) << rcutils_get_error_string().str;
   }
 

--- a/test/test_logging_custom_env.cpp
+++ b/test/test_logging_custom_env.cpp
@@ -43,7 +43,9 @@ TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcutils_char_array_t msg_buf, output_buf;
   ret = rcutils_char_array_init(&msg_buf, 1024, &allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
   ret = rcutils_char_array_init(&output_buf, 1024, &allocator);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
   rcutils_time_point_value_t now = 0;
 
   ret = rcutils_logging_format_message(


### PR DESCRIPTION
This is just a further check to ensure the test is correct,
and also gets rid of a slew of dead store warnings from
clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>