### PR TITLE
[dashing] adds QNX support for rcutils_get_executable_name (#282)

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -49,7 +49,7 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
 
 #if defined __APPLE__ || (defined __ANDROID__ && __ANDROID_API__ >= 21)
   const char * appname = getprogname();
-#elif defined __GNUC__
+#elif defined __GNUC__ && !defined(__QNXNTO__)
   const char * appname = program_invocation_name;
 #elif defined _WIN32 || defined __CYGWIN__
   char appname[MAX_PATH];
@@ -57,6 +57,9 @@ char * rcutils_get_executable_name(rcutils_allocator_t allocator)
   if (size == 0) {
     return NULL;
   }
+#elif defined __QNXNTO__
+  extern char * __progname;
+  const char * appname = __progname;
 #else
 #error "Unsupported OS"
 #endif


### PR DESCRIPTION
Backport #282 to Dashing.