### PR TITLE
Disable a Windows platform warning.

### DIFF
--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -63,7 +63,19 @@
 #ifndef RCUTILS__STDATOMIC_HELPER__WIN32__STDATOMIC_H_
 #define RCUTILS__STDATOMIC_HELPER__WIN32__STDATOMIC_H_
 
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+
+#pragma warning(push)
+#pragma warning(disable : 5105)
 #include <Windows.h>
+#pragma warning(pop)
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -27,7 +27,18 @@ extern "C"
 #include <dirent.h>
 #include <unistd.h>
 #else
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+#pragma warning(push)
+#pragma warning(disable : 5105)
 #include <windows.h>
+#pragma warning(pop)
 #include <direct.h>
 #endif  // _WIN32
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -26,7 +26,18 @@ extern "C"
 
 #ifdef _WIN32
 # include <io.h>
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+# pragma warning(push)
+# pragma warning(disable : 5105)
 # include <windows.h>
+# pragma warning(pop)
 #else
 # include <unistd.h>
 #endif

--- a/src/process.c
+++ b/src/process.c
@@ -22,7 +22,18 @@ extern "C"
 #include <string.h>
 
 #if defined _WIN32 || defined __CYGWIN__
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+#pragma warning(push)
+#pragma warning(disable : 5105)
 #include <Windows.h>
+#pragma warning(pop)
 #else
 #include <libgen.h>
 #include <unistd.h>

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -22,7 +22,18 @@ extern "C"
 #ifndef _WIN32
 #include <dlfcn.h>
 #else
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+#pragma warning(push)
+#pragma warning(disable : 5105)
 #include <windows.h>
+#pragma warning(pop)
 C_ASSERT(sizeof(void *) == sizeof(HINSTANCE));
 #endif  // _WIN32
 

--- a/src/time_win32.c
+++ b/src/time_win32.c
@@ -23,7 +23,18 @@ extern "C"
 
 #include "rcutils/time.h"
 
+// When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
+// there appears to be a problem with winbase.h (which is included by
+// Windows.h).  In particular, warnings of the form:
+//
+// warning C5105: macro expansion producing 'defined' has undefined behavior
+//
+// See https://developercommunity.visualstudio.com/content/problem/695656/wdk-and-sdk-are-not-compatible-with-experimentalpr.html
+// for more information.  For now disable that warning when including windows.h
+#pragma warning(push)
+#pragma warning(disable : 5105)
 #include <windows.h>
+#pragma warning(pop)
 
 #include "./common.h"
 #include "rcutils/allocator.h"


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should get rid of most of the warnings we are currently getting from the Windows CI jobs, as seen in https://ci.ros2.org/view/nightly/job/nightly_win_deb/1804/msbuild .  See the diff for a better explanation of why we have to do this.