### PR TITLE
Fix format of code description on document

### DIFF
--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -79,11 +79,12 @@ extern "C"
  * https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
  *
  * For the following function:
+ * ```
  * int snprintf(char *str, size_t size, const char *format, ...);
  *              ^^^^^^^^^  ^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^  ^^^
  *              ARG 1      ARG 2        ARG 3               ARG 4
  *                                      format string       first optional argument
- *
+ * ```
  * format_string_index value would be 3, first_to_check_index value would be 4.
  *
  * IMPORTANT: the first argument has an index of ONE (not zero!).


### PR DESCRIPTION
From 
![image](https://user-images.githubusercontent.com/64191023/98899622-e0f48300-24ea-11eb-96c2-fcfcd68e7995.png)
to
![image](https://user-images.githubusercontent.com/64191023/98899659-f49fe980-24ea-11eb-845d-d59287e14616.png)


Signed-off-by: Chen Lihui <lihui.chen@sony.com>