### PR TITLE
use a better way to check whether string is empty

### DIFF
--- a/src/split.c
+++ b/src/split.c
@@ -38,7 +38,7 @@ rcutils_split(
     RCUTILS_SET_ERROR_MSG("string_array is null");
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
-  if (NULL == str || strlen(str) == 0) {
+  if (NULL == str || '\0' == *str) {
     *string_array = rcutils_get_zero_initialized_string_array();
     return RCUTILS_RET_OK;
   }


### PR DESCRIPTION
call `strlen` twice at https://github.com/ros2/rcutils/blob/4c534768869bdec1bf380832729e1eb2f2bed896/src/split.c#L41-L47, I believe L41 can be updated from `strlen` to `'\0' == *str`

Signed-off-by: Chen Lihui <lihui.chen@sony.com>