### PR TITLE
Address unused return values found in scan-build

### DIFF
--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -237,6 +237,7 @@ TEST_F(ArrayListPreInitTest, remove_success_removes_from_list) {
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)1);
 
   ret = rcutils_array_list_remove(&list, index);
@@ -310,12 +311,14 @@ TEST_F(ArrayListPreInitTest, get_size_increases_with_add) {
   rcutils_ret_t ret;
 
   ret = rcutils_array_list_get_size(&list, &size);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)0);
 
   ret = rcutils_array_list_add(&list, &data);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)1);
 }
 

--- a/test/test_array_list.cpp
+++ b/test/test_array_list.cpp
@@ -234,14 +234,14 @@ TEST_F(ArrayListPreInitTest, remove_success_removes_from_list) {
 
   // Add something first so we know the index isn't out of bounds
   rcutils_ret_t ret = rcutils_array_list_add(&list, &data);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)1);
 
   ret = rcutils_array_list_remove(&list, index);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
   ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
@@ -311,14 +311,14 @@ TEST_F(ArrayListPreInitTest, get_size_increases_with_add) {
   rcutils_ret_t ret;
 
   ret = rcutils_array_list_get_size(&list, &size);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)0);
 
   ret = rcutils_array_list_add(&list, &data);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_array_list_get_size(&list, &size);
-  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  ASSERT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(size, (size_t)1);
 }
 

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -154,6 +154,7 @@ TEST_F(HashMapBaseTest, init_map_success) {
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 
   ret = rcutils_hash_map_fini(&map);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 }
 
 TEST_F(HashMapBaseTest, fini_map_success) {

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -139,7 +139,7 @@ TEST_F(TestTimeFixture, test_rcutils_system_time_now) {
   // Compare to std::chrono::system_clock time (within a second).
   now = 0;
   ret = rcutils_system_time_now(&now);
-  EXPECT_EQ(ret, RCUTILS_RET_OK) << rcutils_get_error_string().str;
+  ASSERT_EQ(ret, RCUTILS_RET_OK) << rcutils_get_error_string().str;
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
     auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now_sc.time_since_epoch());

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -139,6 +139,7 @@ TEST_F(TestTimeFixture, test_rcutils_system_time_now) {
   // Compare to std::chrono::system_clock time (within a second).
   now = 0;
   ret = rcutils_system_time_now(&now);
+  EXPECT_EQ(ret, RCUTILS_RET_OK) << rcutils_get_error_string().str;
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
     auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now_sc.time_since_epoch());


### PR DESCRIPTION
These return values were not being checked. After addressing these scan-build passes for `rcutils`.

Signed-off-by: Stephen Brawner <brawner@gmail.com>