### PR TITLE
Fix rcutils_shared_library_t path on Windows.

### DIFF
--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -177,7 +177,7 @@ fail:
       continue;
     }
     lib->library_path = lib->allocator.reallocate(
-      buffer, buffer_size, lib->allocator.state);
+      buffer, buffer_size + 1, lib->allocator.state);
     if (NULL == lib->library_path) {
       lib->library_path = buffer;
     }


### PR DESCRIPTION
Precisely what the title says. `GetModuleFileName()` returns the size of the filename *minus* the null-terminating character...

CI up to `rcutils` and `rcpputils`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13370)](http://ci.ros2.org/job/ci_linux/13370/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8297)](http://ci.ros2.org/job/ci_linux-aarch64/8297/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11099)](http://ci.ros2.org/job/ci_osx/11099/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13423)](http://ci.ros2.org/job/ci_windows/13423/)
* Windows Debug [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13424)](http://ci.ros2.org/job/ci_windows/13424/)
