### PR TITLE
Fix a leak during error handling in dir size calculation

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -365,8 +365,8 @@ rcutils_calculate_directory_size_with_recursion(
   dir_list->path = rcutils_strdup(directory_path, allocator);
   if (NULL == dir_list->path) {
     RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to duplicate directory path !\n");
-    ret = RCUTILS_RET_BAD_ALLOC;
-    goto fail;
+    allocator.deallocate(dir_list, allocator.state);
+    return RCUTILS_RET_BAD_ALLOC;
   }
 
   *size = 0;

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -365,7 +365,8 @@ rcutils_calculate_directory_size_with_recursion(
   dir_list->path = rcutils_strdup(directory_path, allocator);
   if (NULL == dir_list->path) {
     RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to duplicate directory path !\n");
-    return RCUTILS_RET_BAD_ALLOC;
+    ret = RCUTILS_RET_BAD_ALLOC;
+    goto fail;
   }
 
   *size = 0;


### PR DESCRIPTION
Have to free the memory allocated on line 357.

FYI @Barry-Xu-2018

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13407)](http://ci.ros2.org/job/ci_linux/13407/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8327)](http://ci.ros2.org/job/ci_linux-aarch64/8327/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11132)](http://ci.ros2.org/job/ci_osx/11132/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13466)](http://ci.ros2.org/job/ci_windows/13466/)