### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,7 +503,8 @@ if(BUILD_TESTING)
 
   rcutils_custom_add_gtest(test_logging_custom_env test/test_logging_custom_env.cpp
     ENV
-      RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
+      RCUTILS_CONSOLE_OUTPUT_FORMAT=
+        "[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=1
       RCUTILS_LOGGING_BUFFERED_STREAM=1
       RCUTILS_LOGGING_USE_STDOUT=1
@@ -515,7 +516,8 @@ if(BUILD_TESTING)
 
   # RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN is defined as 2048, truncation should occur
   foreach(i RANGE 0 100)
-    set(_output_format "${_output_format} [{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}")
+    set(_output_format
+      "${_output_format} [{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}")
   endforeach(i)
   rcutils_custom_add_gtest(test_logging_custom_env2 test/test_logging_custom_env.cpp
     ENV


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)