### PR TITLE
Update the documentation to be more consistent.

### DIFF
--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__ALLOCATOR_H_
 #define RCUTILS__ALLOCATOR_H_
 
@@ -108,20 +110,21 @@ rcutils_get_default_allocator(void);
 
 /// Return true if the given allocator has non-null function pointers.
 /**
- * Will also return false if the allocator pointer is null.
- *
  * \param[in] allocator to be checked by the function
+ * \return `true` if the allocator is valid, `false` otherwise.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 bool
 rcutils_allocator_is_valid(const rcutils_allocator_t * allocator);
 
+/// Check the given allocator and run fail_statement if it is not valid.
 #define RCUTILS_CHECK_ALLOCATOR(allocator, fail_statement) \
   if (!rcutils_allocator_is_valid(allocator)) { \
     fail_statement; \
   }
 
+/// Check the given allocator, and set the message in msg and run fail_statement if it is not valid.
 #define RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, msg, fail_statement) \
   if (!rcutils_allocator_is_valid(allocator)) { \
     RCUTILS_SET_ERROR_MSG(msg); \

--- a/include/rcutils/cmdline_parser.h
+++ b/include/rcutils/cmdline_parser.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__CMDLINE_PARSER_H_
 #define RCUTILS__CMDLINE_PARSER_H_
 
@@ -26,10 +28,11 @@ extern "C"
 
 /// Return `true` if the option is defined in the command line arguments or `false` otherwise.
 /**
-* \param[in] begin first element to check in the array
-* \param[in] end last element to check in the array
-* \param[in] option string to find in the array of arguments
-* \return if the option exists returns true, otherwise returns false.
+ * \param[in] begin first element to check in the array
+ * \param[in] end last element to check in the array
+ * \param[in] option string to find in the array of arguments
+ * \return `true` if the option exists, or
+ * \return `false` otherwise.
  */
 RCUTILS_PUBLIC
 bool
@@ -37,11 +40,11 @@ rcutils_cli_option_exist(char ** begin, char ** end, const char * option);
 
 /// Return the value for a specific option of the command line arguments.
 /**
-* \param[in] begin first element to check in the array
-* \param[in] end last element to check in the array
-* \param[in] option string to find in the array of arguments
-* \return the value for a specific option of the command line arguments or `NULL` if the option
-* doesn't exist
+ * \param[in] begin first element to check in the array
+ * \param[in] end last element to check in the array
+ * \param[in] option string to find in the array of arguments
+ * \return the value for a specific option of the command line arguments, or
+ * \return `NULL` if the option doesn't exist.
  */
 RCUTILS_PUBLIC
 char *

--- a/include/rcutils/env.h
+++ b/include/rcutils/env.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__ENV_H_
 #define RCUTILS__ENV_H_
 
@@ -47,9 +49,9 @@ extern "C"
  * \param[in] env_name Name of the environment variable to modify.
  * \param[in] env_value Value to set the environment variable to, or `NULL` to
  *   un-set.
- * \return `True` if success
- * \return `False` if env_name is invalid or NULL
- * \return `False` on failure
+ * \return `true` if success, or
+ * \return `false` if env_name is invalid or NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Note: migrated from rmw/error_handling.h in 2017-04
+/// @file
 
 #ifndef RCUTILS__ERROR_HANDLING_H_
 #define RCUTILS__ERROR_HANDLING_H_
@@ -41,11 +41,15 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 #ifdef __STDC_LIB_EXT1__
-// Limit the buffer size in the `fwrite` call to give an upper bound to buffer overrun in the case
-// of non-null terminated `msg`.
+/// Write the given msg out to stderr, limiting the buffer size in the `fwrite`.
+/**
+ * This ensures that there is an upper bound to a buffer overrun if `msg` is
+ * non-null terminated.
+ */
 #define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) \
   do {fwrite(msg, sizeof(char), strnlen_s(msg, 4096), stderr);} while (0)
 #else
+/// Write the given msg out to stderr.
 #define RCUTILS_SAFE_FWRITE_TO_STDERR(msg) \
   do {fwrite(msg, sizeof(char), strlen(msg), stderr);} while (0)
 #endif
@@ -70,18 +74,26 @@ extern "C"
     } \
   } while (0)
 
-// fixed constraints
+/// The maximum length a formatted number is allowed to have.
 #define RCUTILS_ERROR_STATE_LINE_NUMBER_STR_MAX_LENGTH 20  // "18446744073709551615"
+
+/// The maximum number of formatting characters allowed.
 #define RCUTILS_ERROR_FORMATTING_CHARACTERS 6  // ', at ' + ':'
 
-// max formatted string length
+/// The maximum formatted string length.
 #define RCUTILS_ERROR_MESSAGE_MAX_LENGTH 1024
 
-// adjustable max length for user defined error message
-// remember "chained" errors will include previously specified file paths
-// e.g. "some error, at /path/to/a.c:42, at /path/to/b.c:42"
+/// The maximum length for user defined error message
+/**
+ * Remember that "chained" errors will include previously specified file paths
+ * e.g. "some error, at /path/to/a.c:42, at /path/to/b.c:42"
+ */
 #define RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH 768
-// with RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH = 768, RCUTILS_ERROR_STATE_FILE_MAX_LENGTH == 229
+
+/// The calculated maximum length for the filename.
+/**
+ * With RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH = 768, RCUTILS_ERROR_STATE_FILE_MAX_LENGTH == 229
+ */
 #define RCUTILS_ERROR_STATE_FILE_MAX_LENGTH ( \
     RCUTILS_ERROR_MESSAGE_MAX_LENGTH - \
     RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH - \
@@ -92,6 +104,7 @@ extern "C"
 /// Struct wrapping a fixed-size c string used for returning the formatted error string.
 typedef struct rcutils_error_string_t
 {
+  /// The fixed-size C string used for returning the formatted error string.
   char str[RCUTILS_ERROR_MESSAGE_MAX_LENGTH];
 } rcutils_error_string_t;
 
@@ -152,10 +165,10 @@ static_assert(
  * match the allocator used originally to initialize the thread-local storage.
  *
  * \param[in] allocator to be used to allocate and deallocate memory
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if the allocator is invalid, or
- * \return `RCUTILS_RET_BAD_ALLOC` if allocating memory fails, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occurs.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if the allocator is invalid, or
+ * \return #RCUTILS_RET_BAD_ALLOC if allocating memory fails, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__FILESYSTEM_H_
 #define RCUTILS__FILESYSTEM_H_
 
@@ -32,9 +34,9 @@ extern "C"
 /**
  * \param[in] buffer Allocated string to store current directory path to
  * \param[in] max_length maximum length to be stored in buffer
- * \return `True` if success
- * \return `False` if buffer is NULL
- * \return `False` on failure
+ * \return `true` if success, or
+ * \return `false` if buffer is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -44,9 +46,9 @@ rcutils_get_cwd(char * buffer, size_t max_length);
 /// Check if the provided path points to a directory.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if directory
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if provided path is a directory, or
+ * \return `false` if abs_path is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -55,9 +57,9 @@ rcutils_is_directory(const char * abs_path);
 /// Check if the provided path points to a file.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if file
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if provided path is a file, or
+ * \return `false` if abs_path is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -66,9 +68,9 @@ rcutils_is_file(const char * abs_path);
 /// Check if the provided path points to an existing file/folder.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if the path exists
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if the path exists, or
+ * \return `false` if abs_path is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -77,9 +79,9 @@ rcutils_exists(const char * abs_path);
 /// Check if the provided path points to a file/folder readable by current user.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if the file is readable
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if the file is readable, or
+ * \return `false` if abs_path is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -88,9 +90,9 @@ rcutils_is_readable(const char * abs_path);
 /// Check if the provided path points to a file/folder writable by current user.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if the file is writable
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if the file is writable, or
+ * \return `false` if abs_path is NULL, or
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -99,9 +101,9 @@ rcutils_is_writable(const char * abs_path);
 /// Check if the provided path points to a file/folder both readable and writable by current user.
 /**
  * \param[in] abs_path Absolute path to check.
- * \return `True` if the file is redable and writable False otherwise
- * \return `False` if abs_path is NULL
- * \return `False` on failure
+ * \return `true` if the file is readable and writable, or
+ * \return `false` if abs_path is NULL
+ * \return `false` on failure.
  */
 RCUTILS_PUBLIC
 bool
@@ -169,17 +171,17 @@ rcutils_expand_user(const char * path, rcutils_allocator_t allocator);
  * If any of the intermediate directories do not exist, this function will
  * return False.
  * If the abs_path already exists, and is a directory, this function will
- * return True.
+ * return true.
  *
  * This function is not thread-safe due to mkdir races as described in the
  * openat(2) documentation.
  *
  * \param[in] abs_path
- * \return `True` if making the directory was successful, False otherwise
- * \return `False` if path is NULL
- * \return `False` if path is empty
- * \return `False` if path is not absolute
- * \return `False` if any intermediate directories don't exist
+ * \return `true` if making the directory was successful, or
+ * \return `false` if path is NULL, or
+ * \return `false` if path is empty, or
+ * \return `false` if path is not absolute, or
+ * \return `false` if any intermediate directories don't exist.
  */
 RCUTILS_PUBLIC
 bool
@@ -192,10 +194,10 @@ rcutils_mkdir(const char * abs_path);
  * \param[in] directory_path The directory path to calculate the size of.
  * \param[out] size The size of the directory in bytes on success.
  * \param[in] allocator Allocator being used for internal file path composition.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails
- * \return `RCUTILS_RET_ERROR` if other error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails
+ * \return #RCUTILS_RET_ERROR if other error occurs
  */
 RCUTILS_PUBLIC
 rcutils_ret_t
@@ -221,10 +223,10 @@ rcutils_calculate_directory_size(
  * \param[in] max_depth The maximum depth of subdirectory. 0 means no limitation.
  * \param[out] size The size of the directory in bytes on success.
  * \param[in] allocator Allocator being used for internal file path composition.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails
- * \return `RCUTILS_RET_ERROR` if other error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails
+ * \return #RCUTILS_RET_ERROR if other error occurs
  */
 RCUTILS_PUBLIC
 rcutils_ret_t
@@ -255,7 +257,7 @@ typedef struct rcutils_dir_iter_t
 } rcutils_dir_iter_t;
 
 /// Begin iterating over the contents of the specified directory.
-/*
+/**
  * This function is used to list the files and directories that are contained in
  * a specified directory. The structure returned by it must be deallocated using
  * ::rcutils_dir_iter_end when the iteration is completed. The name of the
@@ -274,17 +276,17 @@ rcutils_dir_iter_t *
 rcutils_dir_iter_start(const char * directory_path, const rcutils_allocator_t allocator);
 
 /// Continue iterating over the contents of a directory.
-/*
+/**
  * \param[in] iter An iterator created by ::rcutils_dir_iter_start.
- * \return `True` if another entry was found
- * \return `False` if there are no more entries in the directory
+ * \return `true` if another entry was found, or
+ * \return `false` if there are no more entries in the directory.
  */
 RCUTILS_PUBLIC
 bool
 rcutils_dir_iter_next(rcutils_dir_iter_t * iter);
 
 /// Finish iterating over the contents of a directory.
-/*
+/**
  * \param[in] iter An iterator created by ::rcutils_dir_iter_start.
  */
 RCUTILS_PUBLIC

--- a/include/rcutils/find.h
+++ b/include/rcutils/find.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__FIND_H_
 #define RCUTILS__FIND_H_
 
@@ -29,8 +31,9 @@ extern "C"
  *
  * \param[in] str null terminated c string to search
  * \param[in] delimiter the character to search for
- * \returns the index of the first occurence of the delimiter if found, or
- * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
+ * \return the index of the first occurence of the delimiter if found, or
+ * \return `SIZE_MAX` for invalid arguments, or
+ * \return `SIZE_MAX` if the delimiter is not found.
  */
 RCUTILS_PUBLIC
 size_t
@@ -44,8 +47,9 @@ rcutils_find(const char * str, char delimiter);
  * \param[in] str string to search
  * \param[in] delimiter the character to search for
  * \param[in] string_length length of the string to search
- * \returns the index of the first occurence of the delimiter if found, or
- * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
+ * \return the index of the first occurence of the delimiter if found, or
+ * \return `SIZE_MAX` for invalid arguments, or
+ * \return `SIZE_MAX` if the delimiter is not found.
  */
 RCUTILS_PUBLIC
 size_t
@@ -57,8 +61,9 @@ rcutils_findn(const char * str, char delimiter, size_t string_length);
  *
  * \param[in] str null terminated c string to search
  * \param[in] delimiter the character to search for
- * \returns the index of the last occurence of the delimiter if found, or
- * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
+ * \return the index of the last occurence of the delimiter if found, or
+ * \return `SIZE_MAX` for invalid arguments, or
+ * \return `SIZE_MAX` if the delimiter is not found.
  */
 RCUTILS_PUBLIC
 size_t
@@ -72,8 +77,9 @@ rcutils_find_last(const char * str, char delimiter);
  * \param[in] str string to search
  * \param[in] delimiter the character to search for
  * \param[in] string_length length of the string to search
- * \returns the index of the last occurence of the delimiter if found, or
- * \returns `SIZE_MAX` for invalid arguments or if the delimiter is not found
+ * \return the index of the last occurence of the delimiter if found, or
+ * \return `SIZE_MAX` for invalid arguments, or
+ * \return `SIZE_MAX` if the delimiter is not found.
  */
 RCUTILS_PUBLIC
 size_t

--- a/include/rcutils/format_string.h
+++ b/include/rcutils/format_string.h
@@ -60,7 +60,8 @@ extern "C"
  * \param[in] allocator the allocator to use for allocation
  * \param[in] limit maximum length of the output string
  * \param[in] format_string format of the output, must be null terminated
- * \returns output string or null if there was an error
+ * \return The newly allocated and format output string, or
+ * \return `NULL` if there was an error.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -70,7 +71,10 @@ rcutils_format_string_limit(
   size_t limit,
   const char * format_string,
   ...)
-RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4);
+/// @cond Doxygen_Suppress
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4)
+/// @endcond
+;
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/get_env.h
+++ b/include/rcutils/get_env.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__GET_ENV_H_
 #define RCUTILS__GET_ENV_H_
 
@@ -24,7 +26,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// Retrieve the value of the given environment variable if it exists, or "".
-/* The c-string which is returned in the env_value output parameter is only
+/** The c-string which is returned in the env_value output parameter is only
  * valid until the next time this function is called, because it is a direct
  * pointer to the static storage.
  * The variable env_value populated by this function should never have free()
@@ -52,8 +54,8 @@ extern "C"
  *
  * \param[in] env_name the name of the environment variable
  * \param[out] env_value pointer to the value cstring, or "" if unset
- * \return NULL on success (success can be returning an empty string)
- *         error string on failure
+ * \return NULL on success (success can be returning an empty string), or
+ * \return an error string on failure.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -76,7 +78,8 @@ rcutils_get_env(const char * env_name, const char ** env_value);
  * This function cannot be thread-safely called together with rcutils_set_env
  * (or any platform specific equivalent), but multiple calls to this function are thread safe.
  *
- * \return The home directory on success, NULL on failure.
+ * \return The home directory on success, or
+ * \return `NULL` on failure.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/isalnum_no_locale.h
+++ b/include/rcutils/isalnum_no_locale.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__ISALNUM_NO_LOCALE_H_
 #define RCUTILS__ISALNUM_NO_LOCALE_H_
 

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__LOGGING_H_
 #define RCUTILS__LOGGING_H_
 
@@ -90,13 +92,13 @@ extern bool g_rcutils_logging_initialized;
  * Lock-Free          | Yes
  *
  * \param[in] allocator rcutils_allocator_t to be used.
- * \return `RCUTILS_RET_OK` if successful.
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if the allocator is invalid, in which
- *   case initialization will fail.
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if an error occurs reading the output
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if the allocator is invalid, in which
+ *   case initialization will fail, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if an error occurs reading the output
  *   format from the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable, in
- *   which case the default format will be used.
- * \return `RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID` if the internal logger
+ *   which case the default format will be used, or
+ * \return #RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID if the internal logger
  *   severity level map cannot be initialized, in which case logger severity
  *   levels will not be configurable.
  */
@@ -117,11 +119,11 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
  * Uses Atomics       | No
  * Lock-Free          | Yes
  *
- * \return `RCUTILS_RET_OK` if successful.
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if an error occurs reading the output
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if an error occurs reading the output
  *   format from the `RCUTILS_CONSOLE_OUTPUT_FORMAT` environment variable, in
- *   which case the default format will be used.
- * \return `RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID` if the internal logger
+ *   which case the default format will be used, or
+ * \return #RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID if the internal logger
  *   severity level map cannot be initialized, in which case logger levels
  *   will not be configurable.
  */
@@ -142,8 +144,8 @@ rcutils_ret_t rcutils_logging_initialize(void);
  * Uses Atomics       | No
  * Lock-Free          | Yes
  *
- * \return `RCUTILS_RET_OK` if successful.
- * \return `RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID` if the internal logger
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID if the internal logger
  *   severity level map cannot be finalized.
  */
 RCUTILS_PUBLIC
@@ -187,11 +189,11 @@ extern const char * const g_rcutils_log_severity_names[RCUTILS_LOG_SEVERITY_FATA
  * \param[in] allocator rcutils_allocator_t to be used
  * \param[in,out] severity The severity level as a represented by the
  *   `RCUTILS_LOG_SEVERITY` enum
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` on invalid arguments, or
- * \return `RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID` if unable to match
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT on invalid arguments, or
+ * \return #RCUTILS_RET_LOGGING_SEVERITY_STRING_INVALID if unable to match
  *   string, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occured
+ * \return #RCUTILS_RET_ERROR if an unspecified error occured.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -265,14 +267,14 @@ void rcutils_logging_set_output_handler(rcutils_logging_output_handler_t functio
  * Uses Atomics       | No
  * Lock-Free          | Yes
  *
- * \return `RCUTILS_RET_OK` if successful.
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation error occured
  * \param[in] location The location information about where the log came from
  * \param[in] severity The severity of the log message expressed as an integer
  * \param[in] name The name of the logger that this message came from
  * \param[in] timestamp The time at which the log message was generated
  * \param[in] msg The message being logged
  * \param[out] logging_output An output buffer for the formatted message
+ * \return #RCUTILS_RET_OK if successful.
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation error occured
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -413,7 +415,8 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level);
  * \param[in] name The name of the logger, must be null terminated c string or NULL.
  * \param[in] severity The severity level.
  *
- * \return true if the logger is enabled for the level; false otherwise.
+ * \return `true` if the logger is enabled for the level, or
+ * \return `false` otherwise.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -475,7 +478,10 @@ void rcutils_log(
   const char * name,
   const char * format,
   ...)
-RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5);
+/// @cond Doxygen_Suppress
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5)
+/// @endcond
+;
 
 /// The default output handler outputs log messages to the standard streams.
 /**

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__MACROS_H_
 #define RCUTILS__MACROS_H_
 
@@ -21,12 +23,14 @@ extern "C"
 #endif
 
 #ifndef _WIN32
+/// A macro to make the compiler warn when the return value of a function is not used.
 #define RCUTILS_WARN_UNUSED __attribute__((warn_unused_result))
 #else
+/// A macro to make the compiler warn when the return value of a function is not used.
 #define RCUTILS_WARN_UNUSED _Check_return_
 #endif
 
-// Note: this block was migrated from rmw/macros.h
+/// @cond Doxygen_Suppress
 // This block either sets RCUTILS_THREAD_LOCAL or RCUTILS_THREAD_LOCAL_PTHREAD.
 #if defined _WIN32 || defined __CYGWIN__
 // Windows or Cygwin
@@ -62,10 +66,13 @@ extern "C"
 
 #define RCUTILS_STRINGIFY_IMPL(x) #x
 #define RCUTILS_STRINGIFY(x) RCUTILS_STRINGIFY_IMPL(x)
+
+/// A macro to mark an argument or variable as unused.
 #define RCUTILS_UNUSED(x) (void)(x)
 
 #define RCUTILS_JOIN_IMPL(arg1, arg2) arg1 ## arg2
 #define RCUTILS_JOIN(arg1, arg2) RCUTILS_JOIN_IMPL(arg1, arg2)
+/// @endcond
 
 #if defined _WIN32 || defined __CYGWIN__
 /// Macro to annotate printf-like functions on Linux. Disabled on Windows.

--- a/include/rcutils/process.h
+++ b/include/rcutils/process.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__PROCESS_H_
 #define RCUTILS__PROCESS_H_
 
@@ -45,7 +47,8 @@ int rcutils_get_pid(void);
  * This function is thread-safe.
  *
  * \param[in] allocator the allocator to use
- * \return The program name on success, NULL on failure.
+ * \return The program name on success, or
+ * \return NULL on failure.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/qsort.h
+++ b/include/rcutils/qsort.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__QSORT_H_
 #define RCUTILS__QSORT_H_
 
@@ -35,9 +37,9 @@ extern "C"
  * \param[in] count number of elements present in the object.
  * \param[in] size size of each element, in bytes.
  * \param[in] comp function used to compare two elements.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/repl_str.h
+++ b/include/rcutils/repl_str.h
@@ -23,6 +23,8 @@
 // It has been modified to take a custom allocator and to fit some of our
 // style standards.
 
+/// @file
+
 #ifndef RCUTILS__REPL_STR_H_
 #define RCUTILS__REPL_STR_H_
 
@@ -120,7 +122,7 @@ extern "C"
  * \param[in] from string to match for replacement
  * \param[in] to string to replace matched strings with
  * \param[in] allocator structure defining functions to be used for allocation
- * \return duplicated `str` with all matches of `from` replaced with `to`
+ * \return duplicated `str` with all matches of `from` replaced with `to`.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__SHARED_LIBRARY_H_
 #define RCUTILS__SHARED_LIBRARY_H_
 
@@ -39,7 +41,7 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
 } rcutils_shared_library_t;
 
 /// Return an empty shared library struct.
-/*
+/**
  * This function returns an empty and zero initialized shared library struct.
  *
  * Example:
@@ -75,10 +77,10 @@ rcutils_get_zero_initialized_shared_library(void);
  * \param[inout] lib struct with the shared library pointer and shared library path name
  * \param[in] library_path string with the path of the library
  * \param[in] allocator to be used to allocate and deallocate memory
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -92,7 +94,8 @@ rcutils_load_shared_library(
 /**
  * \param[in] lib struct with the shared library pointer and shared library path name
  * \param[in] symbol_name name of the symbol inside the shared library
- * \return shared library symbol pointer, if the symbol doesn't exist then returns NULL.
+ * \return shared library symbol pointer, or
+ * \return `NULL` if the symbol doesn't exist.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -103,7 +106,8 @@ rcutils_get_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 /**
  * \param[in] lib struct with the shared library pointer and shared library path name
  * \param[in] symbol_name name of the symbol inside the shared library
- * \return if symbols exists returns true, otherwise returns false.
+ * \return `true` if the symbol exists, or
+ * \return `false` otherwise.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -113,9 +117,9 @@ rcutils_has_symbol(const rcutils_shared_library_t * lib, const char * symbol_nam
 /// Unload the shared library.
 /**
  * \param[in] lib rcutils_shared_library_t to be finalized
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -128,7 +132,8 @@ rcutils_unload_shared_library(rcutils_shared_library_t * lib);
  * It could very well be that a second shared library handle is still open and therefore the library
  * being loaded.
  * \param[in] lib rcutils_shared_library_t  to check
- * \return true if library is loaded, false otherwise
+ * \return `true` if library is loaded, or
+ * \return `false` otherwise.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -142,8 +147,8 @@ rcutils_is_shared_library_loaded(rcutils_shared_library_t * lib);
  * \param[in] buffer_size size of library_name_platform buffer
  * \param[in] debug if true the library will return a debug library name, otherwise
  * it returns a normal library path
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/snprintf.h
+++ b/include/rcutils/snprintf.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__SNPRINTF_H_
 #define RCUTILS__SNPRINTF_H_
 
@@ -47,15 +49,18 @@ extern "C"
  *
  * \see snprintf()
  * \see _snprintf_s()
- * \returns the number of bytes that would have been written given enough space,
- *   or a negative number if there is an error, but unlike _snprintf_s(),
+ * \return the number of bytes that would have been written given enough space, or
+ * \return a negative number if there is an error, but unlike _snprintf_s(),
  *   -1 is not returned if there is truncation.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 int
 rcutils_snprintf(char * buffer, size_t buffer_size, const char * format, ...)
-RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4);
+/// @cond Doxygen_Suppress
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(3, 4)
+/// @endcond
+;
 
 /// Format a string with va_list for arguments, see rcutils_snprintf().
 RCUTILS_PUBLIC

--- a/include/rcutils/split.h
+++ b/include/rcutils/split.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__SPLIT_H_
 #define RCUTILS__SPLIT_H_
 
@@ -30,10 +32,10 @@ extern "C"
  * \param[in] delimiter on where to split
  * \param[in] allocator for allocating new memory for the output array
  * \param[out] string_array with the split tokens
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs
  */
 RCUTILS_PUBLIC
 rcutils_ret_t
@@ -49,7 +51,8 @@ rcutils_split(
  * \param[in] delimiter on where to split
  * \param[in] allocator for allocating new memory for the output array
  * \param[out] string_array with the split tokens
- * \returns array with split token, NULL in case of error
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs
  */
 RCUTILS_PUBLIC
 rcutils_ret_t

--- a/include/rcutils/strcasecmp.h
+++ b/include/rcutils/strcasecmp.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__STRCASECMP_H_
 #define RCUTILS__STRCASECMP_H_
 
@@ -35,7 +37,8 @@ extern "C"
  *   An integer less than, equal to, or greater than zero if s1 is, after
  *   ignoring case, found to be less than, to match, or be greater than s2,
  *   respectively.
- * \return 0 if method succeeded , -1 if failed.
+ * \return 0 if method succeeded, or
+ * \return -1 if failed.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -58,7 +61,8 @@ rcutils_strcasecmp(
  *   An integer less than, equal to, or greater than zero if s1 is, after
  *   ignoring case, found to be less than, to match, or be greater than s2,
  *   respectively.
- * \return 0 if method succeeded , -1 if failed.
+ * \return 0 if method succeeded, or
+ * \return -1 if failed.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/strdup.h
+++ b/include/rcutils/strdup.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__STRDUP_H_
 #define RCUTILS__STRDUP_H_
 
@@ -36,7 +38,8 @@ extern "C"
  *
  * \param[in] str null terminated c string to be duplicated
  * \param[in] allocator the allocator to use for allocation
- * \returns duplicated string or null if there is an error
+ * \return duplicated string, or
+ * \return `NULL` if there is an error.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -60,7 +63,8 @@ rcutils_strdup(const char * str, rcutils_allocator_t allocator);
  * \param[in] str null terminated c string to be duplicated
  * \param[in] string_length length of the string to duplicate
  * \param[in] allocator the allocator to use for allocation
- * \returns duplicated string or null if there is an error
+ * \return duplicated string, or
+ * \return `NULL` if there is an error.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__STRERROR_H_
 #define RCUTILS__STRERROR_H_
 

--- a/include/rcutils/time.h
+++ b/include/rcutils/time.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TIME_H_
 #define RCUTILS__TIME_H_
 
@@ -65,9 +67,9 @@ typedef int64_t rcutils_duration_value_t;
  * Lock-Free          | Yes
  *
  * \param[out] now a datafield in which the current time is stored
- * \return `RCUTILS_RET_OK` if the current time was successfully obtained, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occur.
+ * \return #RCUTILS_RET_OK if the current time was successfully obtained, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occur.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -93,9 +95,9 @@ rcutils_system_time_now(rcutils_time_point_value_t * now);
  * Lock-Free          | Yes
  *
  * \param[out] now a struct in which the current time is stored
- * \return `RCUTILS_RET_OK` if the current time was successfully obtained, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occur.
+ * \return #RCUTILS_RET_OK if the current time was successfully obtained, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occur.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -129,9 +131,9 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now);
  * \param[in] time_point the time to be made into a string
  * \param[out] str the output string in which it is stored
  * \param[in] str_size the size of the output string
- * \return `RCUTILS_RET_OK` if successful (even if truncated), or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occur.
+ * \return #RCUTILS_RET_OK if successful (even if truncated), or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occur.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -168,9 +170,9 @@ rcutils_time_point_value_as_nanoseconds_string(
  * \param[in] time_point the time to be made into a string
  * \param[out] str the output string in which it is stored
  * \param[in] str_size the size of the output string
- * \return `RCUTILS_RET_OK` if successful (even if truncated), or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCUTILS_RET_ERROR` if an unspecified error occur.
+ * \return #RCUTILS_RET_OK if successful (even if truncated), or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occur.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/types/array_list.h
+++ b/include/rcutils/types/array_list.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__ARRAY_LIST_H_
 #define RCUTILS__TYPES__ARRAY_LIST_H_
 
@@ -29,8 +31,10 @@ extern "C"
 
 struct rcutils_array_list_impl_t;
 
+/// The structure holding the metadata for an array list.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_array_list_t
 {
+  /// A pointer to the PIMPL implementation type.
   struct rcutils_array_list_impl_t * impl;
 } rcutils_array_list_t;
 
@@ -112,10 +116,10 @@ rcutils_get_zero_initialized_array_list(void);
  * \param[in] initial_capacity the initial capacity to allocate in the list
  * \param[in] data_size the size (in bytes) of the data object being stored in the list
  * \param[in] allocator to be used to allocate and deallocate memory
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 rcutils_ret_t
@@ -141,9 +145,9 @@ rcutils_array_list_init(
  * Lock-Free          | Yes
  *
  * \param[inout] array_list object to be finalized
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -166,10 +170,10 @@ rcutils_array_list_fini(rcutils_array_list_t * array_list);
  *
  * \param[in] array_list to add the data to
  * \param[in] data a pointer to the data to add to the list
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -193,10 +197,10 @@ rcutils_array_list_add(rcutils_array_list_t * array_list, const void * data);
  * \param[in] array_list to add the data to
  * \param[in] index the position in the list to set the data
  * \param[in] data a pointer to the data that will be set in the list
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if index out of bounds, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if index out of bounds, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -218,10 +222,10 @@ rcutils_array_list_set(rcutils_array_list_t * array_list, size_t index, const vo
  *
  * \param[in] array_list to add the data to
  * \param[in] index the index of the item to remove from the list
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if index out of bounds, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if index out of bounds, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -244,9 +248,9 @@ rcutils_array_list_remove(rcutils_array_list_t * array_list, size_t index);
  * \param[in] array_list to add the data to
  * \param[in] index the index at which to get the data
  * \param[out] data a copy of the data stored in the list
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -268,9 +272,9 @@ rcutils_array_list_get(const rcutils_array_list_t * array_list, size_t index, vo
  *
  * \param[in] array_list list to get the size of
  * \param[out] size The number of items currently stored in the list
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/types/char_array.h
+++ b/include/rcutils/types/char_array.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__CHAR_ARRAY_H_
 #define RCUTILS__TYPES__CHAR_ARRAY_H_
 
@@ -26,8 +28,10 @@ extern "C"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 
+/// The structure holding the metadata for a char array.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_char_array_t
 {
+  /// A pointer to the allocated memory for this char array.
   char * buffer;
 
   /**
@@ -37,8 +41,13 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_char_array_t
    */
   bool owns_buffer;
 
+  /// The length of the data stored in the buffer pointer.
   size_t buffer_length;
+
+  /// The maximum capacity of the buffer pointer.
   size_t buffer_capacity;
+
+  /// The allocator used to allocate and free the data in the pointer.
   rcutils_allocator_t allocator;
 } rcutils_char_array_t;
 
@@ -61,10 +70,10 @@ rcutils_get_zero_initialized_char_array(void);
  * \param[in] char_array a pointer to the to be initialized char array struct
  * \param[in] buffer_capacity the size of the memory to allocate for the byte stream
  * \param[in] allocator the allocator to use for the memory allocation
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENTS` if any arguments are invalid, or
- * \return 'RCUTILS_RET_BAD_ALLOC` if no memory could be allocated correctly
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_BAD_ALLOC if no memory could be allocated correctly
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -85,9 +94,9 @@ rcutils_char_array_init(
  * behavior.
  *
  * \param[in] char_array pointer to the rcutils_char_array_t to be cleaned up
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENTS` if the char_array argument is invalid
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if the char_array argument is invalid
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -109,10 +118,10 @@ rcutils_char_array_fini(rcutils_char_array_t * char_array);
  *
  * \param[in] char_array pointer to the instance of rcutils_char_array_t which is being resized
  * \param[in] new_size the new size of the internal buffer
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if new_size is set to zero
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if new_size is set to zero
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -128,9 +137,9 @@ rcutils_char_array_resize(rcutils_char_array_t * char_array, size_t new_size);
  *
  * \param[inout] char_array pointer to the instance of rcutils_char_array_t which is being resized
  * \param[in] new_size the new size of the internal buffer
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -149,9 +158,9 @@ rcutils_char_array_expand_as_needed(rcutils_char_array_t * char_array, size_t ne
  * written to
  * \param[in] format the format string used by the underlying `vsnprintf`
  * \param[in] args the `va_list` used by the underlying `vsnprintf`
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -168,9 +177,9 @@ rcutils_char_array_vsprintf(rcutils_char_array_t * char_array, const char * form
  * \param[inout] char_array pointer to the instance of rcutils_char_array_t which is being appended to
  * \param[in] src the string to be appended to the end of the string in buffer
  * \param[in] n it uses at most n bytes from the src string
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -187,9 +196,9 @@ rcutils_char_array_strncat(rcutils_char_array_t * char_array, const char * src, 
  * \param[inout] char_array pointer to the instance of rcutils_char_array_t which is being
  * appended to
  * \param[in] src the string to be appended to the end of the string in buffer
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -204,9 +213,9 @@ rcutils_char_array_strcat(rcutils_char_array_t * char_array, const char * src);
  * \param[inout] char_array pointer to the instance of rcutils_char_array_t which is being resized
  * \param[in] src the memory to be copied from
  * \param[in] n a total of n bytes will be copied
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -221,9 +230,9 @@ rcutils_char_array_memcpy(rcutils_char_array_t * char_array, const char * src, s
  * \param[inout] char_array pointer to the instance of rcutils_char_array_t which is being
  * copied to
  * \param[in] src the string to be copied from
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/types/hash_map.h
+++ b/include/rcutils/types/hash_map.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__HASH_MAP_H_
 #define RCUTILS__TYPES__HASH_MAP_H_
 
@@ -29,8 +31,10 @@ extern "C"
 
 struct rcutils_hash_map_impl_t;
 
+/// The structure holding the metadata for a hash map.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_hash_map_t
 {
+  /// A pointer to the PIMPL implementation type.
   struct rcutils_hash_map_impl_t * impl;
 } rcutils_hash_map_t;
 
@@ -49,7 +53,7 @@ typedef size_t (* rcutils_hash_map_key_hasher_t)(
  * \param[in] val2 The second value to compare
  * \return A negative number if val1 < val2, or
  * \return A positve number if val1 > val2, or
- * \return Zero if val1 == val2
+ * \return Zero if val1 == val2.
  */
 typedef int (* rcutils_hash_map_key_cmp_t)(
   const void *,  // val1
@@ -59,8 +63,8 @@ typedef int (* rcutils_hash_map_key_cmp_t)(
 /**
  * Validates that an rcutils_hash_map_t* points to a valid hash map.
  * \param[in] map A pointer to an rcutils_hash_map_t
- * \return RCUTILS_RET_INVALID_ARGUMENT if map is null
- * \return RCUTILS_RET_NOT_INITIALIZED if map is not initialized
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if map is null
+ * \return #RCUTILS_RET_NOT_INITIALIZED if map is not initialized.
  */
 #define HASH_MAP_VALIDATE_HASH_MAP(map) \
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(map, RCUTILS_RET_INVALID_ARGUMENT); \
@@ -88,7 +92,7 @@ int
 rcutils_hash_map_string_cmp_func(const void * val1, const void * val2);
 
 /// Return an empty hash_map struct.
-/*
+/**
  * This function returns an empty and zero initialized hash_map struct.
  * All hash maps should be initialized with this or manually initialized
  * before being used.
@@ -158,11 +162,11 @@ rcutils_get_zero_initialized_hash_map();
  * \param[in] key_hashing_func a function that returns a hashed value for a key
  * \param[in] key_cmp_func a function used to compare keys
  * \param[in] allocator the allocator to use through out the lifetime of the hash_map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_ALREADY_INIT` if already initialized, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_ALREADY_INIT if alread initialized, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -190,9 +194,9 @@ rcutils_hash_map_init(
  * Lock-Free          | Yes
  *
  * \param[inout] hash_map rcutils_hash_map_t to be finalized
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -218,10 +222,10 @@ rcutils_hash_map_fini(rcutils_hash_map_t * hash_map);
  *
  * \param[in] hash_map rcutils_hash_map_t to be queried
  * \param[out] capacity capacity of the hash_map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -244,10 +248,10 @@ rcutils_hash_map_get_capacity(const rcutils_hash_map_t * hash_map, size_t * capa
  *
  * \param[in] hash_map rcutils_hash_map_t to be queried
  * \param[out] size size of the hash_map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -271,11 +275,11 @@ rcutils_hash_map_get_size(const rcutils_hash_map_t * hash_map, size_t * size);
  * \param[inout] hash_map rcutils_hash_map_t to be updated
  * \param[in] key hash_map key
  * \param[in] value value for given hash_map key
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -298,11 +302,11 @@ rcutils_hash_map_set(rcutils_hash_map_t * hash_map, const void * key, const void
  *
  * \param[inout] hash_map rcutils_hash_map_t to be updated
  * \param[in] key hash_map key, must be null terminated c string
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_STRING_KEY_NOT_FOUND` if the key is not found in the map, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_STRING_KEY_NOT_FOUND if the key is not found in the map, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -328,7 +332,7 @@ rcutils_hash_map_unset(rcutils_hash_map_t * hash_map, const void * key);
  * \return `true` if key is in the hash_map, or
  * \return `false` if key is not in the hash_map, or
  * \return `false` for invalid arguments, or
- * \return `false` if the hash_map is invalid
+ * \return `false` if the hash_map is invalid.
  */
 RCUTILS_PUBLIC
 bool
@@ -351,11 +355,11 @@ rcutils_hash_map_key_exists(const rcutils_hash_map_t * hash_map, const void * ke
  * \param[in] hash_map rcutils_hash_map_t to be searched
  * \param[in] key hash_map key to look up the data for
  * \param[out] data A copy of the data stored in the map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_NOT_FOUND` if the key doesn't exist in the map, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_NOT_FOUND if the key doesn't exist in the map, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 rcutils_ret_t
@@ -399,12 +403,12 @@ rcutils_hash_map_get(const rcutils_hash_map_t * hash_map, const void * key, void
  * \param[in] previous_key NULL to get the first key or the previous key to get the next for
  * \param[out] key A copy of the next key in the sequence
  * \param[out] data A copy of the next data in the sequence
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_NOT_INITIALIZED` if the hash_map is invalid, or
- * \return `RCUTILS_RET_NOT_FOUND` if the previous_key doesn't exist in the map, or
- * \return `RCUTILS_RET_HASH_MAP_NO_MORE_ENTRIES` if there is no more data beyound the previous_key, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_NOT_INITIALIZED if the hash_map is invalid, or
+ * \return #RCUTILS_RET_NOT_FOUND if the previous_key doesn't exist in the map, or
+ * \return #RCUTILS_RET_HASH_MAP_NO_MORE_ENTRIES if there is no more data beyound the previous_key, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 rcutils_ret_t

--- a/include/rcutils/types/rcutils_ret.h
+++ b/include/rcutils/types/rcutils_ret.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__RCUTILS_RET_H_
 #define RCUTILS__TYPES__RCUTILS_RET_H_
 
@@ -20,9 +22,14 @@ extern "C"
 {
 #endif
 
+/// The type that holds a return value for an rcutils operation.
 typedef int rcutils_ret_t;
+
+/// Successful operation.
 #define RCUTILS_RET_OK 0
+/// Operation produced a warning.
 #define RCUTILS_RET_WARN 1
+/// Generic failure in operation.
 #define RCUTILS_RET_ERROR 2
 
 /// Failed to allocate memory return code.

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__STRING_ARRAY_H_
 #define RCUTILS__TYPES__STRING_ARRAY_H_
 
@@ -29,10 +31,16 @@ extern "C"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 
+/// The structure holding the metadata for a string array.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_array_t
 {
+  /// The number of strings that can be stored in the string array.
   size_t size;
+
+  /// The allocated memory for the string array.
   char ** data;
+
+  /// The allocator used to allocate and free memory for the string array.
   rcutils_allocator_t allocator;
 } rcutils_string_array_t;
 
@@ -77,15 +85,15 @@ rcutils_get_zero_initialized_string_array(void);
  * string_array.data[0] = rcutils_strdup("Hello", &allocator);
  * string_array.data[1] = rcutils_strdup("World", &allocator);
  * ret = rcutils_string_array_fini(&string_array);
+ * ```
  *
  * \param[inout] string_array object to be initialized
  * \param[in] size the size the array should be
  * \param[in] allocator to be used to allocate and deallocate memory
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
- * ```
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -104,9 +112,9 @@ rcutils_string_array_init(
  * string in the array and the array of strings itself.
  *
  * \param[inout] string_array object to be finalized
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -121,11 +129,11 @@ rcutils_string_array_fini(rcutils_string_array_t * string_array);
  * \param[in] rhs The second string array.
  * \param[out] res Negative value if `lhs` appears before `rhs` in lexicographical order.
  *   Zero if `lhs` and `rhs` are equal.
- *   Positive value if `lhs` appears after `rhs in lexographical order.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if any argument is `NULL`, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if `lhs->data` or `rhs->data` is `NULL`, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs.
+ *   Positive value if `lhs` appears after `rhs` in lexographical order.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any argument is `NULL, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if `lhs->data` or `rhs->data` is `NULL, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -152,10 +160,10 @@ rcutils_string_array_cmp(
  *
  * \param[inout] string_array object to be resized.
  * \param[in] new_size the size the array should be changed to.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -187,9 +195,9 @@ rcutils_string_array_sort_compare(const void * lhs, const void * rhs);
  * Empty entries are placed at the end of the array.
  *
  * \param[inout] string_array object whose elements should be sorted.
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs.
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 inline
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__STRING_MAP_H_
 #define RCUTILS__TYPES__STRING_MAP_H_
 
@@ -29,13 +31,15 @@ extern "C"
 
 struct rcutils_string_map_impl_t;
 
+/// The structure holding the metadata for a string map.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_map_t
 {
+  /// A pointer to the PIMPL implementation type.
   struct rcutils_string_map_impl_t * impl;
 } rcutils_string_map_t;
 
 /// Return an empty string map struct.
-/*
+/**
  * This function returns an empty and zero initialized string map struct.
  *
  * Example:
@@ -84,11 +88,11 @@ rcutils_get_zero_initialized_string_map();
  * \param[inout] string_map rcutils_string_map_t to be initialized
  * \param[in] initial_capacity the amount of initial capacity for the string map
  * \param[in] allocator the allocator to use through out the lifetime of the map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_ALREADY_INIT` if already initialized, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_ALREADY_INIT if already initialized, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -104,9 +108,9 @@ rcutils_string_map_init(
  * or when calling rcutils_string_map_set().
  *
  * \param[inout] string_map rcutils_string_map_t to be finalized
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -124,10 +128,10 @@ rcutils_string_map_fini(rcutils_string_map_t * string_map);
  *
  * \param[in] string_map rcutils_string_map_t to be queried
  * \param[out] capacity capacity of the string map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -143,10 +147,10 @@ rcutils_string_map_get_capacity(const rcutils_string_map_t * string_map, size_t 
  *
  * \param[in] string_map rcutils_string_map_t to be queried
  * \param[out] size size of the string map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -170,11 +174,11 @@ rcutils_string_map_get_size(const rcutils_string_map_t * string_map, size_t * si
  *
  * \param[inout] string_map rcutils_string_map_t to have space reserved in
  * \param[in] capacity requested size to reserve in the map
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -188,10 +192,10 @@ rcutils_string_map_reserve(rcutils_string_map_t * string_map, size_t capacity);
  * rcutils_string_map_fini() should still be called after this.
  *
  * \param[inout] string_map rcutils_string_map_t to be cleared
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -208,11 +212,11 @@ rcutils_string_map_clear(rcutils_string_map_t * string_map);
  * \param[inout] string_map rcutils_string_map_t to be updated
  * \param[in] key map key, must be null terminated c string
  * \param[in] value value for given map key, must be null terminated c string
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -240,12 +244,12 @@ rcutils_string_map_set(rcutils_string_map_t * string_map, const char * key, cons
  * \param[inout] string_map rcutils_string_map_t to be updated
  * \param[in] key map key, must be null terminated c string
  * \param[in] value value for given map key, must be null terminated c string
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_NOT_ENOUGH_SPACE` if map is full, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_NOT_ENOUGH_SPACE if map is full, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -262,11 +266,11 @@ rcutils_string_map_set_no_resize(
  *
  * \param[inout] string_map rcutils_string_map_t to be updated
  * \param[in] key map key, must be null terminated c string
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_STRING_KEY_NOT_FOUND` if key not found, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_STRING_KEY_NOT_FOUND if key not found, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -286,7 +290,7 @@ rcutils_string_map_unset(rcutils_string_map_t * string_map, const char * key);
  * \return `true` if key is in the map, or
  * \return `false` if key is not in the map, or
  * \return `false` for invalid arguments, or
- * \return `false` if the string map is invalid
+ * \return `false` if the string map is invalid.
  */
 RCUTILS_PUBLIC
 bool
@@ -303,7 +307,7 @@ rcutils_string_map_key_exists(const rcutils_string_map_t * string_map, const cha
  * \return `true` if key is in the map, or
  * \return `false` if key is not in the map, or
  * \return `false` for invalid arguments, or
- * \return `false` if the string map is invalid
+ * \return `false` if the string map is invalid.
  */
 RCUTILS_PUBLIC
 bool
@@ -333,7 +337,7 @@ rcutils_string_map_key_existsn(
  * \return `NULL` for invalid arguments, or
  * \return `NULL` if the string map is invalid, or
  * \return `NULL` if key not found, or
- * \return `NULL` if an unknown error occurs
+ * \return `NULL` if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 const char *
@@ -351,7 +355,7 @@ rcutils_string_map_get(const rcutils_string_map_t * string_map, const char * key
  * \return `NULL` for invalid arguments, or
  * \return `NULL` if the string map is invalid, or
  * \return `NULL` if key not found, or
- * \return `NULL` if an unknown error occurs
+ * \return `NULL` if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 const char *
@@ -399,7 +403,7 @@ rcutils_string_map_getn(
  * \return `NULL` if the string map is invalid, or
  * \return `NULL` if key not found, or
  * \return `NULL` if there are no more keys in the map, or
- * \return `NULL` if an unknown error occurs
+ * \return `NULL` if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 const char *
@@ -419,11 +423,11 @@ rcutils_string_map_get_next_key(
  *
  * \param[in] src_string_map rcutils_string_map_t to be copied from
  * \param[inout] dst_string_map rcutils_string_map_t to be copied to
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` for invalid arguments, or
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, or
- * \return `RCUTILS_RET_STRING_MAP_INVALID` if the string map is invalid, or
- * \return `RCUTILS_RET_ERROR` if an unknown error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT for invalid arguments, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
+ * \return #RCUTILS_RET_STRING_MAP_INVALID if the string map is invalid, or
+ * \return #RCUTILS_RET_ERROR if an unknown error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/types/uint8_array.h
+++ b/include/rcutils/types/uint8_array.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// @file
+
 #ifndef RCUTILS__TYPES__UINT8_ARRAY_H_
 #define RCUTILS__TYPES__UINT8_ARRAY_H_
 
@@ -26,11 +28,19 @@ extern "C"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 
+/// The structure holding the metadata for a uint8 array.
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_uint8_array_t
 {
+  /// The allocated memory for the uint8 array.
   uint8_t * buffer;
+
+  /// The number of valid elements in the uint8 array.
   size_t buffer_length;
+
+  /// The maximum capacity of the uint8 array.
   size_t buffer_capacity;
+
+  /// The allocator used to allocate and free memory for the uint8 array.
   rcutils_allocator_t allocator;
 } rcutils_uint8_array_t;
 
@@ -52,10 +62,10 @@ rcutils_get_zero_initialized_uint8_array(void);
  * \param[inout] uint8_array a pointer to the to be initialized uint8 array struct
  * \param[in] buffer_capacity the size of the memory to allocate for the byte stream
  * \param[in] allocator the allocator to use for the memory allocation
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENTS` if any arguments are invalid, or
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return 'RCUTILS_RET_BAD_ALLOC` if no memory could be allocated correctly
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -74,9 +84,9 @@ rcutils_uint8_array_init(
  * behavior.
  *
  * \param[in] uint8_array pointer to the rcutils_uint8_array_t to be cleaned up
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENTS` if the uint8_array argument is invalid
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if the uint8_array argument is invalid
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
@@ -94,10 +104,10 @@ rcutils_uint8_array_fini(rcutils_uint8_array_t * uint8_array);
  * \param[inout] uint8_array pointer to the instance of rcutils_uint8_array_t which is
  * being resized
  * \param[in] new_size the new size of the internal buffer
- * \return `RCUTILS_RET_OK` if successful, or
- * \return `RCUTILS_RET_INVALID_ARGUMENT` if new_size is set to zero
- * \return `RCUTILS_RET_BAD_ALLOC` if memory allocation failed, or
- * \return `RCUTILS_RET_ERROR` if an unexpected error occurs
+ * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if new_size is set to zero
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation failed, or
+ * \return #RCUTILS_RET_ERROR if an unexpected error occurs.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED

--- a/include/rcutils/visibility_control_macros.h
+++ b/include/rcutils/visibility_control_macros.h
@@ -15,34 +15,34 @@
 #ifndef RCUTILS__VISIBILITY_CONTROL_MACROS_H_
 #define RCUTILS__VISIBILITY_CONTROL_MACROS_H_
 
-/// Defines macros to express whether a symbol is localed, imported, or exported
-///
-/// Those macros are compatible with GCC, clang, and Microsoft Visual C++. They
-/// can be used to enforce which symbols of a library are publicly accessible.
-///
-/// RCUTILS_IMPORT, RCUTILS_EXPORT, and RCUTILS_LOCAL are respectively declaring
-/// an imported, exported, or local symbol.
-/// RCUTILS_LOCAL can be used directly. However, RCUTILS_IMPORT, and
-/// RCUTILS_EXPORT may not be used directly. Every project need to provide
-/// an additional header called `visibility_macros.h` containing:
-///
-/// #ifdef <project>_BUILDING_DLL
-/// # define <project>_PUBLIC RCUTILS_EXPORT
-/// #else
-/// # define <project>_PUBLIC RCUTILS_IMPORT
-/// #endif // !<project>_BUILDING_DLL
-/// #define <project>_LOCAL RCUTILS_LOCAL
-///
-/// ...where "<project>" has been replaced by the project name, such as
-/// "MY_PROJECT".
-/// Your project CMakeLists.txt should also contain the following statement:
-///
-/// target_compile_definitions(<your library> PRIVATE "<project>_BUILDING_DLL")
-///
-/// A public (exported) class should then be tagged as <project>_PUBLIC, whereas
-/// a non-public class should be tagged with <project>_LOCAL.
-///
-/// See GCC documentation: https://gcc.gnu.org/wiki/Visibility
+// Defines macros to express whether a symbol is localed, imported, or exported
+//
+// Those macros are compatible with GCC, clang, and Microsoft Visual C++. They
+// can be used to enforce which symbols of a library are publicly accessible.
+//
+// RCUTILS_IMPORT, RCUTILS_EXPORT, and RCUTILS_LOCAL are respectively declaring
+// an imported, exported, or local symbol.
+// RCUTILS_LOCAL can be used directly. However, RCUTILS_IMPORT, and
+// RCUTILS_EXPORT may not be used directly. Every project need to provide
+// an additional header called `visibility_macros.h` containing:
+//
+// #ifdef <project>_BUILDING_DLL
+// # define <project>_PUBLIC RCUTILS_EXPORT
+// #else
+// # define <project>_PUBLIC RCUTILS_IMPORT
+// #endif // !<project>_BUILDING_DLL
+// #define <project>_LOCAL RCUTILS_LOCAL
+//
+// ...where "<project>" has been replaced by the project name, such as
+// "MY_PROJECT".
+// Your project CMakeLists.txt should also contain the following statement:
+//
+// target_compile_definitions(<your library> PRIVATE "<project>_BUILDING_DLL")
+//
+// A public (exported) class should then be tagged as <project>_PUBLIC, whereas
+// a non-public class should be tagged with <project>_LOCAL.
+//
+// See GCC documentation: https://gcc.gnu.org/wiki/Visibility
 
 #if defined(_MSC_VER) || defined(__CYGWIN__)
 // Use the Windows syntax when compiling with Microsoft Visual C++.


### PR DESCRIPTION
1. Switch \returns to \return
2. Document things that were missing
3. Switch enum linkage to use #RCUTILS_RET_OK so linking works
4. Add @file to all files we want to document

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>