### PR TITLE
Make the logging separate char an implementation detail.

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -33,7 +33,7 @@ extern "C"
 {
 #endif
 
-#define RCUTILS_LOGGING_SEPARATOR_CHAR '.'
+/// The separator used when logging node names.
 #define RCUTILS_LOGGING_SEPARATOR_STRING "."
 
 /**

--- a/src/logging.c
+++ b/src/logging.c
@@ -54,6 +54,9 @@ extern "C"
 #include "rcutils/time.h"
 #include "rcutils/types/string_map.h"
 
+
+#define RCUTILS_LOGGING_SEPARATOR_CHAR '.'
+
 #define RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN (2048)
 
 #if defined(_WIN32)


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

It is never used outside of the C file, so just put it in there.