### PR TITLE
Stop double-defining structs.

### DIFF
--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -44,7 +44,7 @@ extern "C"
  * Developers should note that, while the fields of a const-qualified allocator
  * struct cannot be modified, the state of the allocator can be modified.
  */
-typedef struct rcutils_allocator_t
+typedef struct rcutils_allocator_s
 {
   /// Allocate memory, given a size and the `state` pointer.
   /** An error should be indicated by returning `NULL`. */

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -102,14 +102,14 @@ extern "C"
     1)
 
 /// Struct wrapping a fixed-size c string used for returning the formatted error string.
-typedef struct rcutils_error_string_t
+typedef struct rcutils_error_string_s
 {
   /// The fixed-size C string used for returning the formatted error string.
   char str[RCUTILS_ERROR_MESSAGE_MAX_LENGTH];
 } rcutils_error_string_t;
 
 /// Struct which encapsulates the error state set by RCUTILS_SET_ERROR_MSG().
-typedef struct rcutils_error_state_t
+typedef struct rcutils_error_state_s
 {
   /// User message storage, limited to RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH characters.
   char message[RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH];

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -246,7 +246,7 @@ size_t
 rcutils_get_file_size(const char * file_path);
 
 /// An iterator used for enumerating directory contents
-typedef struct rcutils_dir_iter_t
+typedef struct rcutils_dir_iter_s
 {
   /// The name of the enumerated file or directory
   const char * entry_name;

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -153,7 +153,7 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t rcutils_logging_shutdown(void);
 
 /// The structure identifying the caller location in the source code.
-typedef struct rcutils_log_location_t
+typedef struct rcutils_log_location_s
 {
   /// The name of the function containing the log call.
   const char * function_name;

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -30,7 +30,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// Handle to a loaded shared library.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_shared_library_s
 {
   /// The platform-specific pointer to the shared library
   void * lib_pointer;

--- a/include/rcutils/types/array_list.h
+++ b/include/rcutils/types/array_list.h
@@ -29,13 +29,13 @@ extern "C"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/visibility_control.h"
 
-struct rcutils_array_list_impl_t;
+struct rcutils_array_list_impl_s;
 
 /// The structure holding the metadata for an array list.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_array_list_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_array_list_s
 {
   /// A pointer to the PIMPL implementation type.
-  struct rcutils_array_list_impl_t * impl;
+  struct rcutils_array_list_impl_s * impl;
 } rcutils_array_list_t;
 
 /**

--- a/include/rcutils/types/char_array.h
+++ b/include/rcutils/types/char_array.h
@@ -29,7 +29,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// The structure holding the metadata for a char array.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_char_array_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_char_array_s
 {
   /// A pointer to the allocated memory for this char array.
   char * buffer;

--- a/include/rcutils/types/hash_map.h
+++ b/include/rcutils/types/hash_map.h
@@ -29,13 +29,13 @@ extern "C"
 #include "rcutils/macros.h"
 #include "rcutils/visibility_control.h"
 
-struct rcutils_hash_map_impl_t;
+struct rcutils_hash_map_impl_s;
 
 /// The structure holding the metadata for a hash map.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_hash_map_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_hash_map_s
 {
   /// A pointer to the PIMPL implementation type.
-  struct rcutils_hash_map_impl_t * impl;
+  struct rcutils_hash_map_impl_s * impl;
 } rcutils_hash_map_t;
 
 /// The function signature for a key hashing function.

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -32,7 +32,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// The structure holding the metadata for a string array.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_array_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_array_s
 {
   /// The number of strings that can be stored in the string array.
   size_t size;

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -29,13 +29,13 @@ extern "C"
 #include "rcutils/macros.h"
 #include "rcutils/visibility_control.h"
 
-struct rcutils_string_map_impl_t;
+struct rcutils_string_map_impl_s;
 
 /// The structure holding the metadata for a string map.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_map_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_map_s
 {
   /// A pointer to the PIMPL implementation type.
-  struct rcutils_string_map_impl_t * impl;
+  struct rcutils_string_map_impl_s * impl;
 } rcutils_string_map_t;
 
 /// Return an empty string map struct.

--- a/include/rcutils/types/uint8_array.h
+++ b/include/rcutils/types/uint8_array.h
@@ -29,7 +29,7 @@ extern "C"
 #include "rcutils/visibility_control.h"
 
 /// The structure holding the metadata for a uint8 array.
-typedef struct RCUTILS_PUBLIC_TYPE rcutils_uint8_array_t
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_uint8_array_s
 {
   /// The allocated memory for the uint8 array.
   uint8_t * buffer;

--- a/src/array_list.c
+++ b/src/array_list.c
@@ -32,7 +32,7 @@ extern "C"
     return RCUTILS_RET_INVALID_ARGUMENT; \
   }
 
-typedef struct rcutils_array_list_impl_t
+typedef struct rcutils_array_list_impl_s
 {
   size_t size;
   size_t capacity;

--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -32,14 +32,14 @@ extern "C"
 #define LOAD_FACTOR         (0.75)
 #define BUCKET_INITIAL_CAP  ((size_t)2)
 
-typedef struct rcutils_hash_map_entry_t
+typedef struct rcutils_hash_map_entry_s
 {
   size_t hashed_key;
   void * key;
   void * value;
 } rcutils_hash_map_entry_t;
 
-typedef struct rcutils_hash_map_impl_t
+typedef struct rcutils_hash_map_impl_s
 {
   // This is the array of buckets that will store the keypairs
   rcutils_array_list_t * map;

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -29,7 +29,7 @@ extern "C"
 #include "rcutils/format_string.h"
 #include "rcutils/types/rcutils_ret.h"
 
-typedef struct rcutils_string_map_impl_t
+typedef struct rcutils_string_map_impl_s
 {
   char ** keys;
   char ** values;


### PR DESCRIPTION
Currently we use something like:

```c
typedef struct foo_t
{
} foo_t;
```

But that actually double-defines the `foo_t` symbol
(at least, according to Doxygen).  Instead, use the
more traditional:

```c
typedef struct foo
{
} foo_t;
```

This is slightly controversial in that it is an API break;
any code that was using `struct foo_t` before will now fail
to compile (anything that was just using `foo_t` will be fine).

However, this should mostly affect low-level libraries
like client libraries and the such, so the scale of breakage
here should be low.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>