### PR TITLE
Quiet down a warning in release mode.

### DIFF
--- a/test/benchmark/benchmark_error_handling.cpp
+++ b/test/benchmark/benchmark_error_handling.cpp
@@ -24,6 +24,7 @@ static void benchmark_err_handling(benchmark::State & state)
     rcutils_ret_t ret =
       rcutils_initialize_error_handling_thread_local_storage(rcutils_get_default_allocator());
     assert(ret == RCUTILS_RET_OK);
+    (void)ret;
     rcutils_reset_error();
     const char * test_message = "test message";
     RCUTILS_SET_ERROR_MSG(test_message);


### PR DESCRIPTION
Since assert gets compiled away in release mode, there's a
warning thrown that ret is unused.  Just quiet it down here
since it is in benchmark code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>