### PR TITLE
Declare dependency on libatomic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,8 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>python3-empy</buildtool_depend>
 
+  <depend>libatomic</depend>
+
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>


### PR DESCRIPTION
To prefer the system atomics implementation over the fallback implementation in rcutils, declare a dependency on it to ensure it's available on systems that have it.

Current RPM builds for RHEL are using the fallback implementation due to this missing dependency.

Backing rosdep rules: https://github.com/ros/rosdistro/blob/96e2f40ae3400f6d2dc22cce9333f42fa6e4e4be/rosdep/base.yaml#L1856-L1861