### PR TITLE
disable noexcept-type warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
 
 if(BUILD_TESTING)
   if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wno-noexcept-type")
   endif()
 
   find_package(performance_test_fixture REQUIRED)


### PR DESCRIPTION
That's the only chance I've needed in order to compile ros2 master on ubuntu 18.04 with no warnings.
I know this not a target platform, but I thought I bring it up, because I think it's still valuable to compile on 18.04 without warnings.

I get quite a few warnings on 18.04 in the style of `will change in C++17 because the exception specification is part of a function type`:
```
/home/karsten/ros2_ws/src/ros2/rcutils/test/./mocking_utils/patch.hpp:236:11: error: mangled name for ‘mocking_utils::Patch<ID, ReturnT(ArgTs ...)>& mocking_utils::Patch<ID, ReturnT(ArgTs ...)>::operator=(mocking_utils::Patch<ID, ReturnT(ArgTs ...)>&&) [with long unsigned int ID = 5; ReturnT = int; ArgTs = {_IO_FILE*, char*, int, long unsigned int}]’ will change in C++17 because the exception specification is part of a function type [-Werror=noexcept-type]
   Patch & operator=(Patch && other)
           ^~~~~~~~
/home/karsten/ros2_ws/src/ros2/rcutils/test/./mocking_utils/patch.hpp:228:11: error: mangled name for ‘mocking_utils::Patch<ID, ReturnT(ArgTs ...)>& mocking_utils::Patch<ID, ReturnT(ArgTs ...)>::operator=(const mocking_utils::Patch<ID, ReturnT(ArgTs ...)>&) [with long unsigned int ID = 5; ReturnT = int; ArgTs = {_IO_FILE*, char*, int, long unsigned int}]’ will change in C++17 because the exception specification is part of a function type [-Werror=noexcept-type]
   Patch & operator=(const Patch &) = delete;
           ^~~~~~~~
/home/karsten/ros2_ws/src/ros2/rcutils/test/./mocking_utils/patch.hpp:227:3: error: mangled name for ‘mocking_utils::Patch<ID, ReturnT(ArgTs ...)>::Patch(const mocking_utils::Patch<ID, ReturnT(ArgTs ...)>&) [with long unsigned int ID = 5; ReturnT = int; ArgTs = {_IO_FILE*, char*, int, long unsigned int}]’ will change in C++17 because the exception specification is part of a function type [-Werror=noexcept-type]
   Patch(const Patch &) = delete;

```