### PR TITLE
Fixing up documentation build when using rosdoc2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -9,6 +9,7 @@ PROJECT_BRIEF          = "C API providing common utilities and data structures."
 #STRIP_FROM_PATH        = /Users/william/ros2_ws/install_isolated/rcutils/include
 # Otherwise just generate for the local (non-generated header files)
 INPUT                  = README.md ./include
+EXCLUDE_PATTERNS       = */stdatomic_helper/*
 USE_MDFILE_AS_MAINPAGE = README.md
 RECURSIVE              = YES
 OUTPUT_DIRECTORY       = doc_output

--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__ALLOCATOR_H_
 #define RCUTILS__ALLOCATOR_H_

--- a/include/rcutils/cmdline_parser.h
+++ b/include/rcutils/cmdline_parser.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__CMDLINE_PARSER_H_
 #define RCUTILS__CMDLINE_PARSER_H_

--- a/include/rcutils/env.h
+++ b/include/rcutils/env.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__ENV_H_
 #define RCUTILS__ENV_H_

--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__ERROR_HANDLING_H_
 #define RCUTILS__ERROR_HANDLING_H_

--- a/include/rcutils/filesystem.h
+++ b/include/rcutils/filesystem.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__FILESYSTEM_H_
 #define RCUTILS__FILESYSTEM_H_

--- a/include/rcutils/find.h
+++ b/include/rcutils/find.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__FIND_H_
 #define RCUTILS__FIND_H_

--- a/include/rcutils/get_env.h
+++ b/include/rcutils/get_env.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__GET_ENV_H_
 #define RCUTILS__GET_ENV_H_

--- a/include/rcutils/isalnum_no_locale.h
+++ b/include/rcutils/isalnum_no_locale.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__ISALNUM_NO_LOCALE_H_
 #define RCUTILS__ISALNUM_NO_LOCALE_H_

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__LOGGING_H_
 #define RCUTILS__LOGGING_H_

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__MACROS_H_
 #define RCUTILS__MACROS_H_

--- a/include/rcutils/process.h
+++ b/include/rcutils/process.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__PROCESS_H_
 #define RCUTILS__PROCESS_H_

--- a/include/rcutils/qsort.h
+++ b/include/rcutils/qsort.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__QSORT_H_
 #define RCUTILS__QSORT_H_

--- a/include/rcutils/repl_str.h
+++ b/include/rcutils/repl_str.h
@@ -23,7 +23,7 @@
 // It has been modified to take a custom allocator and to fit some of our
 // style standards.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__REPL_STR_H_
 #define RCUTILS__REPL_STR_H_

--- a/include/rcutils/shared_library.h
+++ b/include/rcutils/shared_library.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__SHARED_LIBRARY_H_
 #define RCUTILS__SHARED_LIBRARY_H_

--- a/include/rcutils/snprintf.h
+++ b/include/rcutils/snprintf.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__SNPRINTF_H_
 #define RCUTILS__SNPRINTF_H_

--- a/include/rcutils/split.h
+++ b/include/rcutils/split.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__SPLIT_H_
 #define RCUTILS__SPLIT_H_

--- a/include/rcutils/strcasecmp.h
+++ b/include/rcutils/strcasecmp.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__STRCASECMP_H_
 #define RCUTILS__STRCASECMP_H_

--- a/include/rcutils/strdup.h
+++ b/include/rcutils/strdup.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__STRDUP_H_
 #define RCUTILS__STRDUP_H_

--- a/include/rcutils/strerror.h
+++ b/include/rcutils/strerror.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__STRERROR_H_
 #define RCUTILS__STRERROR_H_

--- a/include/rcutils/time.h
+++ b/include/rcutils/time.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TIME_H_
 #define RCUTILS__TIME_H_

--- a/include/rcutils/types/array_list.h
+++ b/include/rcutils/types/array_list.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__ARRAY_LIST_H_
 #define RCUTILS__TYPES__ARRAY_LIST_H_

--- a/include/rcutils/types/char_array.h
+++ b/include/rcutils/types/char_array.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__CHAR_ARRAY_H_
 #define RCUTILS__TYPES__CHAR_ARRAY_H_

--- a/include/rcutils/types/hash_map.h
+++ b/include/rcutils/types/hash_map.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__HASH_MAP_H_
 #define RCUTILS__TYPES__HASH_MAP_H_

--- a/include/rcutils/types/rcutils_ret.h
+++ b/include/rcutils/types/rcutils_ret.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__RCUTILS_RET_H_
 #define RCUTILS__TYPES__RCUTILS_RET_H_

--- a/include/rcutils/types/string_array.h
+++ b/include/rcutils/types/string_array.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__STRING_ARRAY_H_
 #define RCUTILS__TYPES__STRING_ARRAY_H_

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__STRING_MAP_H_
 #define RCUTILS__TYPES__STRING_MAP_H_

--- a/include/rcutils/types/uint8_array.h
+++ b/include/rcutils/types/uint8_array.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/// @file
+/// \file
 
 #ifndef RCUTILS__TYPES__UINT8_ARRAY_H_
 #define RCUTILS__TYPES__UINT8_ARRAY_H_


### PR DESCRIPTION
The main this this pull request does is eliminate a bunch of issues caused by files in `stdatomic_helpers`. I spent a lot of time trying to squash the issues, but I think that, in the end, we won't run into these issues elsewhere and these files are implementation details really, so I've just excluded them completely from Doxygen.

I also changed the `@file` to be `\file` in the headers, just to match the style throughout the rest of the package.

In order to eliminate the rest of the warnings we have to resolve https://github.com/ros2/rcutils/pull/333 and https://github.com/svenevs/exhale/issues/111. As well as either resolve https://github.com/michaeljones/breathe/issues/722 or pin the version of `breathe` back to a version without that warning.