### PR TITLE
Use FindPython3 explicitly instead of FindPythonInterp implicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(rcutils)
 
@@ -15,6 +15,8 @@ include(CheckLibraryExists)
 
 find_package(ament_cmake_python REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -102,7 +104,7 @@ em.invoke( \
 string(REPLACE ";" "$<SEMICOLON>" python_code "${python_code}")
 add_custom_command(OUTPUT include/rcutils/logging_macros.h
   COMMAND ${CMAKE_COMMAND} -E make_directory "include/rcutils"
-  COMMAND ${PYTHON_EXECUTABLE} ARGS -c "${python_code}"
+  COMMAND Python3::Interpreter ARGS -c "${python_code}"
   DEPENDS
     "${CMAKE_CURRENT_BINARY_DIR}/logging_macros.h.em.watch"
     "${CMAKE_CURRENT_BINARY_DIR}/logging.py.watch"


### PR DESCRIPTION
Rcutils implicitly depends on FindPythonInterp being called by `ament_cmake_core`. I noticed it will fail to build while testing a branch to use `FindPython3` in `ament_cmake`. This PR makes the python interpreter dependency explicit, and uses `FindPython3` instead of `FindPythonInterp`

Related to ros2/python_cmake_module#6
Blocks ament/ament_cmake#355