### PR TITLE
Add qsort to the excluded patterns.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -6,10 +6,9 @@ PROJECT_BRIEF          = "C API providing common utilities and data structures."
 
 # Use these lines to include the generated logging_macro.h (update install path if needed)
 #INPUT                  = README.md ../../../install_isolated/rcutils/include
-#STRIP_FROM_PATH        = /Users/william/ros2_ws/install_isolated/rcutils/include
 # Otherwise just generate for the local (non-generated header files)
 INPUT                  = README.md ./include
-EXCLUDE_PATTERNS       = */stdatomic_helper/*
+EXCLUDE_PATTERNS       = */stdatomic_helper/* */rcutils/qsort.h
 USE_MDFILE_AS_MAINPAGE = README.md
 RECURSIVE              = YES
 OUTPUT_DIRECTORY       = doc_output


### PR DESCRIPTION
This gets rid of the last rosdoc2 warning on the buildfarm.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The last warning can be seen at the end of the log here: https://build.ros2.org/view/Rdoc/job/Rdoc__rcutils__ubuntu_focal_amd64/4/console .

It's not ideal to be disabling the generation of the docs for this, but I think it is more important to get some green Rdoc builds going than fixing this one lightly-used API.  We can always try to make it work later.