### PR TITLE
Remove dst_size from strnlen usage

### DIFF
--- a/src/error_handling_helpers.h
+++ b/src/error_handling_helpers.h
@@ -54,7 +54,7 @@ __rcutils_copy_string(char * dst, size_t dst_size, const char * src)
   assert(dst_size > 0);
   assert(src != NULL);
   // doesn't matter how long src actually is if it is longer than dst, so limit to dst + 1
-  size_t src_length = strnlen(src, dst_size);
+  size_t src_length = strlen(src);
   size_t size_to_copy = src_length;
   // the destination must be one byte bigger to store the NULL terminating character
   if (src_length >= dst_size) {


### PR DESCRIPTION
Attempt to address #352 

There's already a comparison to get the min value from `dest_size` and `src_length` here:
https://github.com/ros2/rcutils/blob/befc608e21c653404f2fd876986969286125a527/src/error_handling_helpers.h#L60

So I just removed the dst_size from the calculation of the source size.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>