### PR TITLE
Support ROS2 on Hololens 2

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -233,6 +233,7 @@ rcutils_calculate_directory_size(const char * directory_path, rcutils_allocator_
     return dir_size;
   }
 #ifdef _WIN32
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   char * path = rcutils_join_path(directory_path, "*", allocator);
   WIN32_FIND_DATA data;
   HANDLE handle = FindFirstFile(path, &data);
@@ -252,6 +253,9 @@ rcutils_calculate_directory_size(const char * directory_path, rcutils_allocator_
     } while (FindNextFile(handle, &data));
     FindClose(handle);
   }
+#else
+  // Don't enumerate UWP filesystems
+#endif
   return dir_size;
 #else
   DIR * dir = opendir(directory_path);

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -83,7 +83,11 @@ rcutils_load_shared_library(
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %s", dlerror());
 #else
+#if WINDOWS_UWP
   lib->lib_pointer = (void *)(LoadLibrary(lib->library_path));
+#else
+  lib->lib_pointer = (void *)(LoadPackagedLibrary(lib->library_path, 0));
+#endif
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %lu", GetLastError());
 #endif  // _WIN32

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -83,7 +83,7 @@ rcutils_load_shared_library(
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %s", dlerror());
 #else
-#ifdef WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   lib->lib_pointer = (void *)(LoadLibrary(lib->library_path));
 #else
   lib->lib_pointer = (void *)(LoadPackagedLibrary(lib->library_path, 0));

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -83,7 +83,7 @@ rcutils_load_shared_library(
   if (!lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("LoadLibrary error: %s", dlerror());
 #else
-#if WINDOWS_UWP
+#ifdef WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
   lib->lib_pointer = (void *)(LoadLibrary(lib->library_path));
 #else
   lib->lib_pointer = (void *)(LoadPackagedLibrary(lib->library_path, 0));


### PR DESCRIPTION
Hololens 2 uses a version of Windows which specifically prohibits certain APIs from being used. In this repository, prohibited APIs are used - `FindFirstFile`/`FindNextFile`/`FindClose` and `LoadLibrary`. On Universal Windows Platform (UWP), filesystem enumeration is not required, so simply removed. `LoadLibrary` is replaced with `LoadPackagedLibrary`, which loads from the UWP package.

These changes are in the `WIN32` block, using the family partition, so do not affect other build types.