### PR TITLE
Update rcutils_steady_time_now to return the same data as std::chrono

### DIFF
--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -78,21 +78,13 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now)
   // If clock_gettime is available or on OS X, use a timespec.
   struct timespec timespec_now;
 #if defined(__MACH__)
-  // On OS X use clock_get_time.
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  timespec_now.tv_sec = mts.tv_sec;
-  timespec_now.tv_nsec = mts.tv_nsec;
+  // On macOS, use clock_get_time(CLOCK_MONOTONIC_RAW), which matches
+  // the clang implementation
+  // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
+  clock_gettime(CLOCK_MONOTONIC_RAW, &timespec_now);
 #else  // defined(__MACH__)
   // Otherwise use clock_gettime.
-#if defined(CLOCK_MONOTONIC_RAW)
-  clock_gettime(CLOCK_MONOTONIC_RAW, &timespec_now);
-#else  // defined(CLOCK_MONOTONIC_RAW)
   clock_gettime(CLOCK_MONOTONIC, &timespec_now);
-#endif  // defined(CLOCK_MONOTONIC_RAW)
 #endif  // defined(__MACH__)
   if (__WOULD_BE_NEGATIVE(timespec_now.tv_sec, timespec_now.tv_nsec)) {
     RCUTILS_SET_ERROR_MSG("unexpected negative time");

--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -51,14 +51,10 @@ rcutils_system_time_now(rcutils_time_point_value_t * now)
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
   struct timespec timespec_now;
 #if defined(__MACH__)
-  // On OS X use clock_get_time.
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  timespec_now.tv_sec = mts.tv_sec;
-  timespec_now.tv_nsec = mts.tv_nsec;
+  // On macOS, use clock_gettime(CLOCK_REALTIME), which matches
+  // the clang implementation
+  // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
+  clock_gettime(CLOCK_REALTIME, &timespec_now);
 #else  // defined(__MACH__)
   // Otherwise use clock_gettime.
   clock_gettime(CLOCK_REALTIME, &timespec_now);
@@ -78,7 +74,7 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now)
   // If clock_gettime is available or on OS X, use a timespec.
   struct timespec timespec_now;
 #if defined(__MACH__)
-  // On macOS, use clock_get_time(CLOCK_MONOTONIC_RAW), which matches
+  // On macOS, use clock_gettime(CLOCK_MONOTONIC_RAW), which matches
   // the clang implementation
   // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
   clock_gettime(CLOCK_MONOTONIC_RAW, &timespec_now);

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -193,17 +193,7 @@ TEST_F(TestTimeFixture, test_rcutils_steady_time_now) {
 
 #if !defined(_WIN32)
 
-// For mocking purposes
-#if defined(__MACH__)
-#include <mach/clock.h>
-#include <mach/mach.h>
-#define clock_gettime clock_get_time
-#endif
-
-// Tests rcutils_system_time_now() and rcutils_steady_time_now() functions
-// when system clocks misbehave.
 TEST_F(TestTimeFixture, test_rcutils_with_bad_system_clocks) {
-#if !defined (__MACH__)  // as tv_sec is an unsigned integer there
   {
     auto mock = mocking_utils::patch(
       "lib:rcutils", clock_gettime,
@@ -222,7 +212,6 @@ TEST_F(TestTimeFixture, test_rcutils_with_bad_system_clocks) {
     EXPECT_EQ(RCUTILS_RET_ERROR, ret);
     rcutils_reset_error();
   }
-#endif
   {
     auto mock = mocking_utils::patch(
       "lib:rcutils", clock_gettime,
@@ -243,9 +232,6 @@ TEST_F(TestTimeFixture, test_rcutils_with_bad_system_clocks) {
   }
 }
 
-#if defined(__MACH__)
-#undef clock_gettime
-#endif
 #endif  // !defined(_WIN32)
 
 // Tests the rcutils_time_point_value_as_nanoseconds_string() function.


### PR DESCRIPTION
Based on an investigation several years ago, rcutils_steady_time_now
has slightly different behavior than std::chrono::now .  In
particular, on Linux rcutils_steady_time_now was using
CLOCK_MONOTONIC_RAW, while std::chrono is using CLOCK_MONOTONIC.
On macOS, rcutils_steady_time_now was using SYSTEM_CLOCK, while std::chrono
was using CLOCK_MONOTONIC_RAW.  Fix both of these so they
match what std::chrono does, and in the case of macOS, significantly
simplify the code by switching to clock_gettime.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #43 .  Draft for now, as I haven't even compile tested this on macOS yet.