### PR TITLE
[Logging] Clarify duration arg description in macros

### DIFF
--- a/rcutils/logging.py
+++ b/rcutils/logging.py
@@ -56,7 +56,7 @@ skipfirst_doc_lines = [
 throttle_params = OrderedDict((
     ('get_time_point_value', 'Function that returns rcutils_ret_t and expects a '
         'rcutils_time_point_value_t pointer.'),
-    ('duration', 'The duration of the throttle interval'),
+    ('duration', 'The duration of the throttle interval as an integral value in milliseconds.'),
 ))
 throttle_args = {
     'condition_before': 'RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(get_time_point_value, duration)',


### PR DESCRIPTION
Quoting from https://github.com/ros2/rclcpp/issues/1929:

> Currently `RCLCPP_*_THROTTLE` (and the `RCUTILS_LOG_*_THROTTLE_NAMED` which they cal) arbitrarily accept the duration as an integral value of milliseconds. This is highly confusing, especially since it is not documented anywhere but deep in the source, in `RCUTILS_LOG_CONDITION_THROTTLE_BEFORE`, where it calls:
> ```
> static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS((rcutils_duration_value_t)duration); 
> ```

The expectation that the `duration` argument to the logging macros will be an integral value in milliseconds is not explicit at all, and as such the documentation for this argument should be clarified.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>