### PR TITLE
strdup.c: fix one byte buffer overread

### DIFF
--- a/src/strdup.c
+++ b/src/strdup.c
@@ -49,7 +49,7 @@ rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allo
   if (NULL == new_string) {
     return NULL;
   }
-  memcpy(new_string, str, string_length + 1);
+  memcpy(new_string, str, string_length);
   new_string[string_length] = '\0';
   return new_string;
 }

--- a/test/test_strdup.cpp
+++ b/test/test_strdup.cpp
@@ -73,3 +73,19 @@ TEST(test_strdup, invalid_arguments) {
   EXPECT_EQ(NULL, rcutils_strndup(NULL, 5, allocator));
   EXPECT_EQ(NULL, rcutils_strdup("something", failing_allocator));
 }
+
+TEST(test_strndup, one_byte_overread) {
+  auto allocator = rcutils_get_default_allocator();
+  char str[4];
+  char * p;
+  memcpy(str, "test", sizeof(str));
+
+  // If there is a bug, a one byte overread happens here. Run this test under a
+  // memory sanitizer to guarantee it causes a crash.
+  p = rcutils_strndup(str, sizeof(str), allocator);
+  if (NULL == p) {
+    FAIL();
+  }
+  ASSERT_STREQ(p, "test");
+  allocator.deallocate(p, allocator.state);
+}


### PR DESCRIPTION
Consider the following code:
```c
char str[4];
strncpy(str, "test", sizeof(str));
rcutils_strndup(str, sizeof(str), allocator);
```
In such a case, `memcpy()` would overread the buffer by 1 byte. `strndup()` copies until `string_length` is exhausted or a null terminator is found, and the related `strncpy()` function does create such unterminated strings.

Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>
