### PR TITLE
strdup.c: fix arbitrary length overread

### DIFF
--- a/include/rcutils/strdup.h
+++ b/include/rcutils/strdup.h
@@ -54,14 +54,14 @@ rcutils_strdup(const char * str, rcutils_allocator_t allocator);
  * The returned string should be deallocated using the given allocator when
  * it is no longer needed.
  *
- * The string_length given does not include the null terminating character.
- * Therefore a string_length of 0 will still result in a duplicated string, but
+ * The max_length given does not include the null terminating character.
+ * Therefore a max_length of 0 will still result in a duplicated string, but
  * the string will be an empty string of strlen 0, but it still must be
  * deallocated.
  * All returned strings are null terminated.
  *
  * \param[in] str null terminated c string to be duplicated
- * \param[in] string_length length of the string to duplicate
+ * \param[in] max_length maximum length of the string to duplicate
  * \param[in] allocator the allocator to use for allocation
  * \return duplicated string, or
  * \return `NULL` if there is an error.
@@ -69,7 +69,7 @@ rcutils_strdup(const char * str, rcutils_allocator_t allocator);
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 char *
-rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allocator);
+rcutils_strndup(const char * str, size_t max_length, rcutils_allocator_t allocator);
 
 #ifdef __cplusplus
 }

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -19,6 +19,7 @@ extern "C"
 
 #include "rcutils/strdup.h"
 
+#include <limits.h>
 #include <stddef.h>
 #include <string.h>
 
@@ -31,20 +32,19 @@ rcutils_strdup(const char * str, rcutils_allocator_t allocator)
 {
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
 
-  if (NULL == str) {
-    return NULL;
-  }
-  return rcutils_strndup(str, strlen(str), allocator);
+  return rcutils_strndup(str, SIZE_MAX, allocator);
 }
 
 char *
-rcutils_strndup(const char * str, size_t string_length, rcutils_allocator_t allocator)
+rcutils_strndup(const char * str, size_t max_length, rcutils_allocator_t allocator)
 {
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
 
   if (NULL == str) {
     return NULL;
   }
+  char * p = memchr(str, '\0', max_length);
+  size_t string_length = p == NULL ? max_length : (size_t)(p - str);
   char * new_string = allocator.allocate(string_length + 1, allocator.state);
   if (NULL == new_string) {
     return NULL;


### PR DESCRIPTION
rcutils_strndup() would unconditionally read as many bytes as its 2nd argument said regardless of the source string's length, but strndup() is defined to read the minimum between the 2nd argument and the source string's length.

Signed-off-by: Guilherme Janczak <guilherme.janczak@yandex.com>

Hi, I'm back with the related but separate bug in strndup(). It should be easier to understand this time.