### PR TITLE
Optimize the implementation of rcutils_char_array_strncpy.

### DIFF
--- a/src/char_array.c
+++ b/src/char_array.c
@@ -213,22 +213,23 @@ rcutils_char_array_strcpy(rcutils_char_array_t * char_array, const char * src)
 rcutils_ret_t
 rcutils_char_array_strncat(rcutils_char_array_t * char_array, const char * src, size_t n)
 {
-  size_t current_strlen = strlen(char_array->buffer);
+  size_t current_strlen;
+  if (char_array->buffer_length == 0) {
+    current_strlen = 0;
+  } else {
+    // The buffer length always contains the trailing \0, so the strlen is one less than that.
+    current_strlen = char_array->buffer_length - 1;
+  }
   size_t new_length = current_strlen + n + 1;
   rcutils_ret_t ret = rcutils_char_array_expand_as_needed(char_array, new_length);
   if (ret != RCUTILS_RET_OK) {
     RCUTILS_SET_ERROR_MSG("char array failed to expand");
     return ret;
   }
-#ifndef _WIN32
-  strncat(char_array->buffer, src, n);
-#else
-  errno_t err = strncat_s(char_array->buffer, new_length, src, n);
-  if (0 != err) {
-    RCUTILS_SET_ERROR_MSG("strncat_s failed");
-    return RCUTILS_RET_ERROR;
-  }
-#endif
+
+  memcpy(char_array->buffer + current_strlen, src, n);
+  char_array->buffer[new_length - 1] = '\0';
+
   char_array->buffer_length = new_length;
   return RCUTILS_RET_OK;
 }


### PR DESCRIPTION
It turns out that this function is used a lot in the rcutils
logging code, so it is on a hot-path.  Thus it is worth optimizing.

The optimization itself consists of recognizing that the current
implementation of rcutils_char_array_strncpy is calling strlen
twice; once explicitly at the beginning of the function, and then
again implicitly while calling strncat.  However, it turns out
that we don't need to recalculate the length either time; we
already know that information based on the buffer_length.  Thus
we use the information we already have and speed up the calculation,
particularly for long strings.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

In my local testing, I found (using `perf`) that this patch significantly cuts down on the number of strlen invocations.  For very long strings, this can be up to 40% faster (for shorter strings, the speed increase is more modest, around 10%).

I'll note that this also fixes a subtle bug in the interaction of `rcutils_char_array_memcpy` and `rcutils_char_array_strncat`.  Previously, if you ended up calling `rcutils_char_array_memcpy` and did *not* copy a '\0' in, then a following call to `rcutils_char_array_strncat` would run off into arbitrary memory looking for a '\0' during the strlen call.  While this sequence of calls would be a strange usage, it would cause UB before.  Now it would work properly.