### PR TITLE
Optimize calls via the RCUTILS_LOG macros.

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -476,6 +476,7 @@ int rcutils_logging_get_logger_effective_level(const char * name);
  * \param[in] format The format string
  * \param[in] ... The variable arguments
  */
+RCUTILS_PUBLIC
 void rcutils_log_internal(
   const rcutils_log_location_t * location,
   int severity,

--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -451,10 +451,45 @@ RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 int rcutils_logging_get_logger_effective_level(const char * name);
 
+/// Internal call to log a message.
+/**
+ * Unconditionally log a message.
+ * This is an internal function, and assumes that the caller has already called
+ * rcutils_logging_logger_is_enabled_for().
+ * End-user software should never call this, and instead should call rcutils_log()
+ * or one of the RCUTILS_LOG_ macros.
+ *
+ * The attributes of this function are influenced by the currently set output handler.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No, for formatted outputs <= 1023 characters
+ *                    | Yes, for formatted outputs >= 1024 characters
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] location The pointer to the location struct or NULL
+ * \param[in] severity The severity level
+ * \param[in] name The name of the logger, must be null terminated c string or NULL
+ * \param[in] format The format string
+ * \param[in] ... The variable arguments
+ */
+void rcutils_log_internal(
+  const rcutils_log_location_t * location,
+  int severity,
+  const char * name,
+  const char * format,
+  ...)
+/// @cond Doxygen_Suppress
+RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5)
+/// @endcond
+;
+
 /// Log a message.
 /**
- * The attributes of this function are also being influenced by the currently
- * set output handler.
+ * The attributes of this function are influenced by the currently set output handler.
  *
  * <hr>
  * Attribute          | Adherence

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -69,7 +69,7 @@ extern "C"
     static rcutils_log_location_t __rcutils_logging_location = {__func__, __FILE__, __LINE__}; \
     if (rcutils_logging_logger_is_enabled_for(name, severity)) { \
       condition_before \
-      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
+      rcutils_log_internal(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
       condition_after \
     } \
   } while (0)


### PR DESCRIPTION
It turns out that when we call RCUTILS_LOG_DEBUG (and friends),
we were calling rcutils_logging_logger_is_enabled_for() twice;
once in the macro itself (where we want to avoid evaluating
conditions if the logger is disabled), and once in the rcutils_log()
call.  Since rcutils_logging_logger_is_enabled_for() is a pretty
expensive function, this means we were doing unnecessary work.

Improve this by splitting rcutils_log() into rcutils_log() and
rcutils_log_internal(), the latter of which does not do the
enabled check.  Then change the macros to call the internal
version of the API, which avoids the double check while still
maintaining the safety guarantees we want if a user calls
rcutils_log() directly.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>