### PR TITLE
Various cleanups in the logging code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,16 +226,8 @@ if(BUILD_TESTING)
     set(SKIP_MEMORY_TOOLS_TEST "SKIP_TEST")
   endif()
 
-  macro(rcutils_custom_add_gtest target)
-    ament_add_gtest(${target} ${ARGN})
-  endmacro()
-
-  macro(rcutils_custom_add_gmock target)
-    ament_add_gmock(${target} ${ARGN})
-  endmacro()
-
   # Gtests
-  rcutils_custom_add_gtest(test_allocator test/test_allocator.cpp
+  ament_add_gtest(test_allocator test/test_allocator.cpp
     ENV ${memory_tools_test_env_vars}
     ${SKIP_MEMORY_TOOLS_TEST}
   )
@@ -243,7 +235,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_allocator ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gtest(test_char_array
+  ament_add_gtest(test_char_array
     test/test_char_array.cpp
   )
   if(TARGET test_char_array)
@@ -265,7 +257,7 @@ if(BUILD_TESTING)
 
   add_test(NAME test_atomics COMMAND test_atomics_executable)
 
-  rcutils_custom_add_gmock(test_error_handling test/test_error_handling.cpp
+  ament_add_gmock(test_error_handling test/test_error_handling.cpp
     # Append the directory of librcutils so it is found at test time.
     APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
     ENV ${memory_tools_test_env_vars}
@@ -274,7 +266,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_error_handling ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gmock(test_error_handling_helpers test/test_error_handling_helpers.cpp
+  ament_add_gmock(test_error_handling_helpers test/test_error_handling_helpers.cpp
     # Append the directory of librcutils so it is found at test time.
     APPEND_LIBRARY_DIRS "$<TARGET_FILE_DIR:${PROJECT_NAME}>"
     ENV ${memory_tools_test_env_vars}
@@ -284,35 +276,35 @@ if(BUILD_TESTING)
     target_link_libraries(test_error_handling_helpers osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gtest(test_split
+  ament_add_gtest(test_split
     test/test_split.cpp
   )
   if(TARGET test_split)
     target_link_libraries(test_split ${PROJECT_NAME} mimick)
   endif()
 
-  rcutils_custom_add_gtest(test_find
+  ament_add_gtest(test_find
     test/test_find.cpp
   )
   if(TARGET test_find)
     target_link_libraries(test_find ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_strerror
+  ament_add_gtest(test_strerror
     test/test_strerror.cpp
   )
   if(TARGET test_strerror)
     target_link_libraries(test_strerror ${PROJECT_NAME} mimick)
   endif()
 
-  rcutils_custom_add_gtest(test_string_array
+  ament_add_gtest(test_string_array
     test/test_string_array.cpp
   )
   if(TARGET test_string_array)
     target_link_libraries(test_string_array ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_env test/test_env.cpp
+  ament_add_gtest(test_env test/test_env.cpp
     ENV
       EMPTY_TEST=
       NORMAL_TEST=foo
@@ -322,7 +314,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_env ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_filesystem
+  ament_add_gtest(test_filesystem
     test/test_filesystem.cpp
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
@@ -332,21 +324,21 @@ if(BUILD_TESTING)
     target_compile_definitions(test_filesystem PRIVATE BUILD_DIR="${CMAKE_CURRENT_BINARY_DIR}")
   endif()
 
-  rcutils_custom_add_gtest(test_strdup
+  ament_add_gtest(test_strdup
     test/test_strdup.cpp
   )
   if(TARGET test_strdup)
     target_link_libraries(test_strdup ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_format_string
+  ament_add_gtest(test_format_string
     test/test_format_string.cpp
   )
   if(TARGET test_format_string)
     target_link_libraries(test_format_string ${PROJECT_NAME} mimick)
   endif()
 
-  rcutils_custom_add_gtest(test_string_map
+  ament_add_gtest(test_string_map
     test/test_string_map.cpp
   )
   if(TARGET test_string_map)
@@ -354,14 +346,14 @@ if(BUILD_TESTING)
     target_link_libraries(test_string_map ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_isalnum_no_locale
+  ament_add_gtest(test_isalnum_no_locale
     test/test_isalnum_no_locale.cpp
   )
   if(TARGET test_isalnum_no_locale)
     target_link_libraries(test_isalnum_no_locale ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_repl_str
+  ament_add_gtest(test_repl_str
     test/test_repl_str.cpp
   )
   if(TARGET test_repl_str)
@@ -441,63 +433,63 @@ if(BUILD_TESTING)
     target_link_libraries(test_shared_library_preloaded ${PROJECT_NAME} mimick)
   endif()
 
-  rcutils_custom_add_gtest(test_time
+  ament_add_gtest(test_time
     test/test_time.cpp
     ENV ${memory_tools_test_env_vars})
   if(TARGET test_time)
     target_link_libraries(test_time ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gtest(test_snprintf
+  ament_add_gtest(test_snprintf
     test/test_snprintf.cpp
   )
   if(TARGET test_snprintf)
     target_link_libraries(test_snprintf ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_strcasecmp
+  ament_add_gtest(test_strcasecmp
     test/test_strcasecmp.cpp
   )
   if(TARGET test_strcasecmp)
     target_link_libraries(test_strcasecmp ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_uint8_array
+  ament_add_gtest(test_uint8_array
     test/test_uint8_array.cpp
   )
   if(TARGET test_uint8_array)
     target_link_libraries(test_uint8_array ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_array_list
+  ament_add_gtest(test_array_list
     test/test_array_list.cpp
   )
   if(TARGET test_array_list)
     target_link_libraries(test_array_list ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_hash_map
+  ament_add_gtest(test_hash_map
     test/test_hash_map.cpp
   )
   if(TARGET test_hash_map)
     target_link_libraries(test_hash_map ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_cmdline_parser
+  ament_add_gtest(test_cmdline_parser
     test/test_cmdline_parser.cpp
   )
   if(TARGET test_cmdline_parser)
     target_link_libraries(test_cmdline_parser ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_process
+  ament_add_gtest(test_process
     test/test_process.cpp
   )
   if(TARGET test_process)
     target_link_libraries(test_process ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_logging_custom_env test/test_logging_custom_env.cpp
+  ament_add_gtest(test_logging_custom_env test/test_logging_custom_env.cpp
     ENV
       RCUTILS_CONSOLE_OUTPUT_FORMAT=
         "[{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}"
@@ -515,7 +507,7 @@ if(BUILD_TESTING)
     set(_output_format
       "${_output_format} [{severity}] [{time},{time_as_nanoseconds}] [{name},{function_name},{file_name}]: {line_number}-{message}")
   endforeach(i)
-  rcutils_custom_add_gtest(test_logging_custom_env2 test/test_logging_custom_env.cpp
+  ament_add_gtest(test_logging_custom_env2 test/test_logging_custom_env.cpp
     ENV
       RCUTILS_CONSOLE_OUTPUT_FORMAT="${_output_format}"
       RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED=0
@@ -527,7 +519,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_logging_custom_env2 ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools mimick)
   endif()
 
-  rcutils_custom_add_gtest(test_logging_bad_env test/test_logging_bad_env.cpp
+  ament_add_gtest(test_logging_bad_env test/test_logging_bad_env.cpp
     ENV
       RCUTILS_LOGGING_USE_STDOUT=42
   )
@@ -535,7 +527,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_logging_bad_env ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_logging_bad_env2 test/test_logging_bad_env.cpp
+  ament_add_gtest(test_logging_bad_env2 test/test_logging_bad_env.cpp
     ENV
       RCUTILS_COLORIZED_OUTPUT=42
   )
@@ -543,7 +535,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_logging_bad_env2 ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_logging_bad_env3 test/test_logging_bad_env.cpp
+  ament_add_gtest(test_logging_bad_env3 test/test_logging_bad_env.cpp
     ENV
       RCUTILS_LOGGING_BUFFERED_STREAM=42
   )
@@ -551,21 +543,21 @@ if(BUILD_TESTING)
     target_link_libraries(test_logging_bad_env3 ${PROJECT_NAME})
   endif()
 
-  rcutils_custom_add_gtest(test_logging_enable_for
+  ament_add_gtest(test_logging_enable_for
     test/test_logging_enable_for.cpp
   )
   if(TARGET test_logging_enable_for)
     target_link_libraries(test_logging_enable_for ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gtest(test_logging_console_output_handler
+  ament_add_gtest(test_logging_console_output_handler
     test/test_logging_console_output_handler.cpp
   )
   if(TARGET test_logging_console_output_handler)
     target_link_libraries(test_logging_console_output_handler ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools)
   endif()
 
-  rcutils_custom_add_gtest(test_macros
+  ament_add_gtest(test_macros
     test/test_macros.cpp
   )
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -290,11 +290,10 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
       "Failed to initialize map for logger severities [%s]. Severities will not be configurable.",
       rcutils_get_error_string().str);
     g_rcutils_logging_severities_map_valid = false;
-    ret = RCUTILS_RET_STRING_MAP_INVALID;
-  } else {
-    g_rcutils_logging_severities_map_valid = true;
+    return RCUTILS_RET_STRING_MAP_INVALID;
   }
 
+  g_rcutils_logging_severities_map_valid = true;
   g_rcutils_logging_initialized = true;
 
   return ret;

--- a/src/logging.c
+++ b/src/logging.c
@@ -815,16 +815,6 @@ rcutils_ret_t rcutils_logging_format_message(
 # define IS_STREAM_A_TTY(stream) (isatty(fileno(stream)) != 0)
 #endif
 
-#define IS_OUTPUT_COLORIZED(is_colorized) \
-  { \
-    if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE) { \
-      is_colorized = true; \
-    } else if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE) { \
-      is_colorized = false; \
-    } else { \
-      is_colorized = IS_STREAM_A_TTY(g_output_stream); \
-    } \
-  }
 #define SET_COLOR_WITH_SEVERITY(status, severity, color) \
   { \
     switch (severity) { \
@@ -946,7 +936,13 @@ void rcutils_logging_console_output_handler(
       return;
   }
 
-  IS_OUTPUT_COLORIZED(is_colorized)
+  if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_ENABLE) {
+    is_colorized = true;
+  } else if (g_colorized_output == RCUTILS_COLORIZED_OUTPUT_FORCE_DISABLE) {
+    is_colorized = false;
+  } else {
+    is_colorized = IS_STREAM_A_TTY(g_output_stream);
+  }
 
   char msg_buf[1024] = "";
   rcutils_char_array_t msg_array = {

--- a/src/logging.c
+++ b/src/logging.c
@@ -158,7 +158,6 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     return RCUTILS_RET_OK;
   }
 
-  rcutils_ret_t ret = RCUTILS_RET_OK;
   if (!rcutils_allocator_is_valid(&allocator)) {
     RCUTILS_SET_ERROR_MSG("Provided allocator is invalid.");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -290,7 +289,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
   g_rcutils_logging_severities_map_valid = true;
   g_rcutils_logging_initialized = true;
 
-  return ret;
+  return RCUTILS_RET_OK;
 }
 
 rcutils_ret_t rcutils_logging_shutdown(void)

--- a/src/logging.c
+++ b/src/logging.c
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
@@ -1006,7 +1001,3 @@ void rcutils_logging_console_output_handler(
     RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to fini array.\n");
   }
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/logging.c
+++ b/src/logging.c
@@ -88,7 +88,7 @@ enum rcutils_colorized_output
 
 bool g_rcutils_logging_initialized = false;
 
-char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
+static char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
 static const char * g_rcutils_logging_default_output_format =
   "[{severity}] [{time}] [{name}]: {message}";
 
@@ -99,13 +99,13 @@ static rcutils_string_map_t g_rcutils_logging_severities_map;
 
 // If this is false, attempts to use the severities map will be skipped.
 // This can happen if allocation of the map fails at initialization.
-bool g_rcutils_logging_severities_map_valid = false;
+static bool g_rcutils_logging_severities_map_valid = false;
 
 int g_rcutils_logging_default_logger_level = 0;
 
 static FILE * g_output_stream = NULL;
 
-enum rcutils_colorized_output g_colorized_output = RCUTILS_COLORIZED_OUTPUT_AUTO;
+static enum rcutils_colorized_output g_colorized_output = RCUTILS_COLORIZED_OUTPUT_AUTO;
 
 rcutils_ret_t rcutils_logging_initialize(void)
 {

--- a/src/logging.c
+++ b/src/logging.c
@@ -598,7 +598,7 @@ typedef struct token_map_entry
   token_handler handler;
 } token_map_entry;
 
-const char * expand_time(
+static const char * expand_time(
   const logging_input * logging_input, rcutils_char_array_t * logging_output,
   rcutils_ret_t (* time_func)(const rcutils_time_point_value_t *, char *, size_t))
 {
@@ -612,21 +612,21 @@ const char * expand_time(
   APPEND_AND_RETURN_LOG_OUTPUT(numeric_storage);
 }
 
-const char * expand_time_as_seconds(
+static const char * expand_time_as_seconds(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
   return expand_time(logging_input, logging_output, rcutils_time_point_value_as_seconds_string);
 }
 
-const char * expand_time_as_nanoseconds(
+static const char * expand_time_as_nanoseconds(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
   return expand_time(logging_input, logging_output, rcutils_time_point_value_as_nanoseconds_string);
 }
 
-const char * expand_line_number(
+static const char * expand_line_number(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
@@ -652,7 +652,7 @@ const char * expand_line_number(
   APPEND_AND_RETURN_LOG_OUTPUT(line_number_expansion);
 }
 
-const char * expand_severity(
+static const char * expand_severity(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
@@ -660,7 +660,9 @@ const char * expand_severity(
   APPEND_AND_RETURN_LOG_OUTPUT(severity_string);
 }
 
-const char * expand_name(const logging_input * logging_input, rcutils_char_array_t * logging_output)
+static const char * expand_name(
+  const logging_input * logging_input,
+  rcutils_char_array_t * logging_output)
 {
   if (NULL != logging_input->name) {
     APPEND_AND_RETURN_LOG_OUTPUT(logging_input->name);
@@ -668,7 +670,7 @@ const char * expand_name(const logging_input * logging_input, rcutils_char_array
   return logging_output->buffer;
 }
 
-const char * expand_message(
+static const char * expand_message(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
@@ -676,7 +678,7 @@ const char * expand_message(
   return logging_output->buffer;
 }
 
-const char * expand_function_name(
+static const char * expand_function_name(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
@@ -686,7 +688,7 @@ const char * expand_function_name(
   return logging_output->buffer;
 }
 
-const char * expand_file_name(
+static const char * expand_file_name(
   const logging_input * logging_input,
   rcutils_char_array_t * logging_output)
 {
@@ -707,7 +709,7 @@ static const token_map_entry tokens[] = {
   {.token = "line_number", .handler = expand_line_number},
 };
 
-token_handler find_token_handler(const char * token)
+static token_handler find_token_handler(const char * token)
 {
   int token_number = sizeof(tokens) / sizeof(tokens[0]);
   for (int token_index = 0; token_index < token_number; token_index++) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -175,17 +175,17 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
 
   const char * line_buffered = NULL;
   const char * ret_str = rcutils_get_env("RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED", &line_buffered);
-  if (NULL == ret_str) {
-    if (strcmp(line_buffered, "") != 0) {
-      RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored. "
-        "Please set RCUTILS_LOGGING_USE_STDOUT and RCUTILS_LOGGING_BUFFERED_STREAM "
-        "to control the stream and the buffering of log messages.\n");
-    }
-  } else {
+  if (NULL != ret_str) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting environment variable RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED: %s", ret_str);
     return RCUTILS_RET_ERROR;
+  }
+
+  if (strcmp(line_buffered, "") != 0) {
+    RCUTILS_SAFE_FWRITE_TO_STDERR(
+      "RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED is now ignored. "
+      "Please set RCUTILS_LOGGING_USE_STDOUT and RCUTILS_LOGGING_BUFFERED_STREAM "
+      "to control the stream and the buffering of log messages.\n");
   }
 
   // Set the default output stream for all severities to stderr so that errors

--- a/src/logging.c
+++ b/src/logging.c
@@ -262,24 +262,23 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
   // Check for the environment variable for custom output formatting
   const char * output_format;
   ret_str = rcutils_get_env("RCUTILS_CONSOLE_OUTPUT_FORMAT", &output_format);
-  if (NULL == ret_str && strcmp(output_format, "") != 0) {
-    size_t chars_to_copy = strlen(output_format);
-    if (chars_to_copy > RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN - 1) {
-      chars_to_copy = RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN - 1;
-    }
-    memcpy(g_rcutils_logging_output_format_string, output_format, chars_to_copy);
-    g_rcutils_logging_output_format_string[chars_to_copy] = '\0';
+  if (NULL != ret_str) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Failed to get output format from env. variable [%s]. Using default output format.",
+      ret_str);
+    output_format = g_rcutils_logging_default_output_format;
   } else {
-    if (NULL != ret_str) {
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "Failed to get output format from env. variable [%s]. Using default output format.",
-        ret_str);
-      ret = RCUTILS_RET_INVALID_ARGUMENT;
+    if (strcmp(output_format, "") == 0) {
+      output_format = g_rcutils_logging_default_output_format;
     }
-    memcpy(
-      g_rcutils_logging_output_format_string, g_rcutils_logging_default_output_format,
-      strlen(g_rcutils_logging_default_output_format) + 1);
   }
+
+  size_t chars_to_copy = strlen(output_format);
+  if (chars_to_copy > RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN - 1) {
+    chars_to_copy = RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN - 1;
+  }
+  memcpy(g_rcutils_logging_output_format_string, output_format, chars_to_copy);
+  g_rcutils_logging_output_format_string[chars_to_copy] = '\0';
 
   g_rcutils_logging_severities_map = rcutils_get_zero_initialized_string_map();
   rcutils_ret_t string_map_ret = rcutils_string_map_init(

--- a/src/logging.c
+++ b/src/logging.c
@@ -579,27 +579,27 @@ void rcutils_log_internal(
   va_end(args);
 }
 
-typedef struct logging_input
+typedef struct logging_input_s
 {
   const char * name;
   const rcutils_log_location_t * location;
   const char * msg;
   int severity;
   rcutils_time_point_value_t timestamp;
-} logging_input;
+} logging_input_t;
 
 typedef const char * (* token_handler)(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output);
 
-typedef struct token_map_entry
+typedef struct token_map_entry_s
 {
   const char * token;
   token_handler handler;
-} token_map_entry;
+} token_map_entry_t;
 
 static const char * expand_time(
-  const logging_input * logging_input, rcutils_char_array_t * logging_output,
+  const logging_input_t * logging_input, rcutils_char_array_t * logging_output,
   rcutils_ret_t (* time_func)(const rcutils_time_point_value_t *, char *, size_t))
 {
   // Temporary, local storage for integer/float conversion to string
@@ -613,21 +613,21 @@ static const char * expand_time(
 }
 
 static const char * expand_time_as_seconds(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   return expand_time(logging_input, logging_output, rcutils_time_point_value_as_seconds_string);
 }
 
 static const char * expand_time_as_nanoseconds(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   return expand_time(logging_input, logging_output, rcutils_time_point_value_as_nanoseconds_string);
 }
 
 static const char * expand_line_number(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   // Allow 9 digits for the expansion of the line number (otherwise, truncate).
@@ -653,7 +653,7 @@ static const char * expand_line_number(
 }
 
 static const char * expand_severity(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   const char * severity_string = g_rcutils_log_severity_names[logging_input->severity];
@@ -661,7 +661,7 @@ static const char * expand_severity(
 }
 
 static const char * expand_name(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   if (NULL != logging_input->name) {
@@ -671,7 +671,7 @@ static const char * expand_name(
 }
 
 static const char * expand_message(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   OK_OR_RETURN_NULL(rcutils_char_array_strcat(logging_output, logging_input->msg));
@@ -679,7 +679,7 @@ static const char * expand_message(
 }
 
 static const char * expand_function_name(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   if (logging_input->location) {
@@ -689,7 +689,7 @@ static const char * expand_function_name(
 }
 
 static const char * expand_file_name(
-  const logging_input * logging_input,
+  const logging_input_t * logging_input,
   rcutils_char_array_t * logging_output)
 {
   if (logging_input->location) {
@@ -698,7 +698,7 @@ static const char * expand_file_name(
   return logging_output->buffer;
 }
 
-static const token_map_entry tokens[] = {
+static const token_map_entry_t tokens[] = {
   {.token = "severity", .handler = expand_severity},
   {.token = "name", .handler = expand_name},
   {.token = "message", .handler = expand_message},
@@ -733,7 +733,7 @@ rcutils_ret_t rcutils_logging_format_message(
   const char * str = g_rcutils_logging_output_format_string;
   size_t size = strlen(g_rcutils_logging_output_format_string);
 
-  const logging_input logging_input = {
+  const logging_input_t logging_input = {
     .location = location,
     .severity = severity,
     .name = name,

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -21,14 +21,7 @@
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging_initialization) {
+TEST(TestLogging, test_logging_initialization) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -66,7 +59,7 @@ struct LogEvent
 };
 LogEvent g_last_log_event;
 
-TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
+TEST(TestLogging, test_logging) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -147,7 +140,7 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logging) {
   rcutils_logging_set_output_handler(original_function);
 }
 
-TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
+TEST(TestLogging, test_log_severity) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   int severity;
   // check supported severities
@@ -187,7 +180,7 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_log_severity) {
     rcutils_logging_severity_level_from_string("Info", failing_allocator, &severity));
 }
 
-TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
+TEST(TestLogging, test_logger_severities) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
@@ -262,7 +255,7 @@ TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severities) {
     rcutils_logging_set_logger_level("rcutils_test_loggers", 51));
 }
 
-TEST(CLASSNAME(TestLogging, RMW_IMPLEMENTATION), test_logger_severity_hierarchy) {
+TEST(TestLogging, test_logger_severity_hierarchy) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {

--- a/test/test_logging_custom_env.cpp
+++ b/test/test_logging_custom_env.cpp
@@ -22,14 +22,7 @@
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging) {
+TEST(TestLoggingCustomEnv, test_logging) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
@@ -56,7 +49,7 @@ TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging) {
   EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_fini(&msg_buf));
 }
 
-TEST(CLASSNAME(TestLoggingCustomEnv, RMW_IMPLEMENTATION), test_logging_with_buffering_issues) {
+TEST(TestLoggingCustomEnv, test_logging_with_buffering_issues) {
   auto mock = mocking_utils::patch("lib:rcutils", setvbuf, [](auto && ...) {return -1;});
   EXPECT_FALSE(g_rcutils_logging_initialized);
   EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_logging_initialize());


### PR DESCRIPTION
This PR, by itself, just does a bunch of minor cleanup in the logging code.  Besides code cleanliness, the main reason to put this in is to facilitate a further optimization in the rcutils logging infrastructure, which I'll open up after this one is in.

The changes in this PR generally revolve around making the code easier to read, removing unnecessary infrastructure, and generally just cleaning things up.  For review, it is easiest to review this PR patch-by-patch, as each one does a targeted thing.  If necessary, I can open up separate PRs for each one, but that seemed....tedious :).