### PR TITLE
Fix a bug in hash_map_get_next_key_and_data.

### DIFF
--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -539,7 +539,8 @@ rcutils_hash_map_get_next_key_and_data(
   }
 
   if (NULL != previous_key) {
-    already_exists = hash_map_find(hash_map, key, &key_hash, &map_index, &bucket_index, &entry);
+    already_exists = hash_map_find(
+      hash_map, previous_key, &key_hash, &map_index, &bucket_index, &entry);
     if (!already_exists) {
       return RCUTILS_RET_NOT_FOUND;
     }

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -431,7 +431,8 @@ TEST_F(HashMapPreInitTest, get_next_key_and_data_working) {
   last_key = ret_key;
 
   // Get the next entry
-  ret = rcutils_hash_map_get_next_key_and_data(&map, &ret_key, &ret_key, &ret_data);
+  ret_key = 0;
+  ret = rcutils_hash_map_get_next_key_and_data(&map, &last_key, &ret_key, &ret_data);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_TRUE(1 == ret_key || 2 == ret_key);  // we only put these two keys in the map
   EXPECT_NE(last_key, ret_key);


### PR DESCRIPTION
What was happening was that we were incorrectly using the
previous_key for finding our last "spot" in the hash_map
for iteration.  That's because of a silly typo.

This wasn't picked up in the tests because the tests also
had a bug; they were reusing the same key pointer for the
previous and the current key, and because of that they
didn't pick up on the bug.  Fix both of these issues, which
fixes iteration over the hash map.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>