### PR TITLE
Change syntax __VAR_ARGS__ to __VA_ARGS__

### DIFF
--- a/include/rcutils/stdatomic_helper.h
+++ b/include/rcutils/stdatomic_helper.h
@@ -32,9 +32,9 @@
 // The my__has_feature avoids a preprocessor error when you check for it and
 // use it on the same line below.
 #if defined(__has_feature)
-#define my__has_feature(...) __has_feature(__VA_ARGS__)
+#define my__has_feature __has_feature
 #else
-#define my__has_feature(...) 0
+#define my__has_feature(x) 0
 #endif
 
 #if !defined(__clang__) && defined(__GNUC__) && __GNUC__ <= 4 && __GNUC_MINOR__ <= 9

--- a/include/rcutils/stdatomic_helper.h
+++ b/include/rcutils/stdatomic_helper.h
@@ -32,7 +32,7 @@
 // The my__has_feature avoids a preprocessor error when you check for it and
 // use it on the same line below.
 #if defined(__has_feature)
-#define my__has_feature(...) __has_feature(__VAR_ARGS__)
+#define my__has_feature(...) __has_feature(__VA_ARGS__)
 #else
 #define my__has_feature(...) 0
 #endif


### PR DESCRIPTION
According to these 2 links ([quora](https://www.quora.com/What-is-VAR__ARGS__-in-C-programming), [epics](https://epics-modules.github.io/master/asyn/R4-40-1/RELEASE_NOTES.html)), __VA_ARGS__ should be preferred over __VAR_ARGS__.