### PR TITLE
Optimize rcutils_logging_get_logger_effective_level()

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -164,6 +164,10 @@ typedef struct rcutils_log_location_s
 } rcutils_log_location_t;
 
 /// The severity levels of log messages / loggers.
+/**
+ * Note: all logging levels have their Least Significant Bit as 0, which is used as an
+ * optimization.  If adding new logging levels, ensure that the new levels keep this property.
+ */
 enum RCUTILS_LOG_SEVERITY
 {
   RCUTILS_LOG_SEVERITY_UNSET = 0,  ///< The unset log level

--- a/src/logging.c
+++ b/src/logging.c
@@ -959,11 +959,6 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level)
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
 
-  size_t name_length = strlen(name);
-  if (name_length == 0) {
-    g_rcutils_logging_default_logger_level = level;
-    return RCUTILS_RET_OK;
-  }
   if (!g_rcutils_logging_severities_map_valid) {
     RCUTILS_SET_ERROR_MSG("Logger severity level map is invalid");
     return RCUTILS_RET_LOGGING_SEVERITY_MAP_INVALID;
@@ -982,6 +977,8 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level)
     RCUTILS_SET_ERROR_MSG("Unable to determine severity_string for severity");
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
+
+  size_t name_length = strlen(name);
 
   if (rcutils_hash_map_key_exists(&g_rcutils_logging_severities_map, &name)) {
     // Iterate over the entire contents of the severities map, looking for entries that start with
@@ -1048,6 +1045,12 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level)
       "Error setting severity level for logger named '%s': %s",
       name, rcutils_get_error_string().str);
   }
+
+  if (name_length == 0) {
+    // If the name was empty, this also means we should update the default logger level
+    g_rcutils_logging_default_logger_level = level;
+  }
+
   return add_key_ret;
 }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -416,13 +416,14 @@ static const char * copy_from_orig(
 
 static bool add_handler(token_handler handler, size_t start_offset, size_t end_offset)
 {
-  g_handlers[g_num_log_msg_handlers].handler = handler;
-  g_handlers[g_num_log_msg_handlers].start_offset = start_offset;
-  g_handlers[g_num_log_msg_handlers].end_offset = end_offset;
-  if (g_num_log_msg_handlers >= sizeof(g_handlers) - 1) {
+  if (g_num_log_msg_handlers >= (sizeof(g_handlers) / sizeof(g_handlers[0]))) {
     RCUTILS_SET_ERROR_MSG("Too many substitutions in the logging output format string; truncating");
     return false;
   }
+
+  g_handlers[g_num_log_msg_handlers].handler = handler;
+  g_handlers[g_num_log_msg_handlers].start_offset = start_offset;
+  g_handlers[g_num_log_msg_handlers].end_offset = end_offset;
 
   g_num_log_msg_handlers++;
 

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -438,3 +438,47 @@ TEST(TestLogging, test_logger_allocated_names) {
     rcutils_logging_get_logger_level("rcutils_test_loggers"));
   rcutils_reset_error();
 }
+
+TEST(TestLogging, test_root_logger_after_nonexistent)
+{
+  // This tests whether the root logger remains unset after setting the logger name for a
+  // non-existent logger.
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_logging_initialize());
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCUTILS_RET_OK, rcutils_logging_shutdown());
+  });
+
+  int original_severity = rcutils_logging_get_logger_effective_level("my_internal_logger_name");
+
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_level(
+      "my_internal_logger_name", RCUTILS_LOG_SEVERITY_DEBUG));
+
+  EXPECT_EQ(
+    RCUTILS_LOG_SEVERITY_DEBUG,
+    rcutils_logging_get_logger_effective_level("my_internal_logger_name"));
+
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_level(
+      "my_internal_logger_name", original_severity));
+
+  int original_root_severity = rcutils_logging_get_logger_effective_level("");
+
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_level(
+      "", RCUTILS_LOG_SEVERITY_UNSET));
+
+  EXPECT_EQ(
+    RCUTILS_LOG_SEVERITY_UNSET,
+    rcutils_logging_get_logger_effective_level(""));
+
+  ASSERT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_logging_set_logger_level(
+      "", original_root_severity));
+}

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -20,6 +20,7 @@
 #include "./allocator_testing_utils.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging.h"
+#include "rcutils/strdup.h"
 
 TEST(TestLogging, test_logging_initialization) {
   EXPECT_FALSE(g_rcutils_logging_initialized);
@@ -423,7 +424,9 @@ TEST(TestLogging, test_logger_allocated_names) {
 
   rcutils_logging_set_default_logger_level(RCUTILS_LOG_SEVERITY_INFO);
 
-  const char * allocated_name = strdup("rcutils_test_loggers");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  const char * allocated_name = rcutils_strdup("rcutils_test_loggers", allocator);
 
   // check setting of acceptable severities
   ASSERT_EQ(
@@ -431,7 +434,7 @@ TEST(TestLogging, test_logger_allocated_names) {
     rcutils_logging_set_logger_level(
       allocated_name, RCUTILS_LOG_SEVERITY_WARN));
 
-  free(const_cast<char *>(allocated_name));
+  allocator.deallocate(const_cast<char *>(allocated_name), allocator.state);
 
   ASSERT_EQ(
     RCUTILS_LOG_SEVERITY_WARN,


### PR DESCRIPTION
This function is the most expensive part of
rcutils_logging_logger_is_enabled_for(), which is called on every
RCUTILS_LOG_* invocation.
    
We notice a couple of things:
    
1. The current name -> logger level lookup is using a "string map"
structure.  A "string map" isn't a map at all, but is really a linear
array of strings.  Thus searching it can be slow when there are
a lot of strings in the map.  Since this is a global map, this
can happen when many ROS 2 nodes are loaded in to the same process.
    
2. When looking up the severity of a particular name, we need to
check the full name, plus any ancestors (separated by '.') to find
the severity level.  This requires a bunch of work, including
copying a string, running strlen on it, searching through it for
periods, etc.  This can be expensive, and in the common case it isn't
needed; the fully-qualified string is usually in the map already.
    
To fix both of these, we switch to a hash map, and look up the
current logger level via the hash map.  If the full logger name
isn't in the hash map, we fall back to the slow path where we
do the additional work of finding the severity via the hierarchy.
Note that even in this slow path, once we've computed the severity
level we place that in the map as well so that subsequent lookups
will take the fast path.
    
The benchmarks I ran on this change give very good improvements
for most cases.  For cases where there are multiple set logger
names, and those logger names have ancestors, this change is
~9x faster than the current implementation.  For cases where there
are multiple set logger names and those logger names have no
ancestors (one of the most common cases in ROS 2), this change is ~3x
faster than the current implementation.  For cases where we
have a single logger name (another common case), this change is
~2x faster than the current implementation.
    
Finally, note that rcutils_logging_set_logger_level() is
more expensive than before, due to having to traverse the hash map
to find other logger names in the hierarchy.  Since we don't expect
users to change logger levels often, this tradeoff seems worth it
to speed up lookups (which are called for every log message).
    
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should solve https://github.com/ros2/rcutils/issues/364 (at least, as much as it can be solved given the current design).