### PR TITLE
Export -latomic even if BUILD_TESTING is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,14 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
 
+check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
+
+if(HAVE_LIBATOMICS AND NOT WIN32)
+  # Exporting link flag since it won't pass ament_export_libraries() existance check
+  ament_export_link_flags("-latomic")
+  target_link_libraries(${PROJECT_NAME} atomic)
+endif()
+
 # Needed if pthread is used for thread local storage.
 if(IOS AND IOS_SDK_VERSION LESS 10.0)
   ament_export_libraries(pthread)
@@ -156,13 +164,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   find_package(launch_testing_ament_cmake REQUIRED)
-
-  check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
-
-  if(HAVE_LIBATOMICS AND NOT WIN32)
-    # Exporting link flag since it won't pass ament_export_libraries() existance check
-    ament_export_link_flags("-latomic")
-  endif()
 
   if(ament_cmake_cppcheck_FOUND)
     ament_cppcheck(


### PR DESCRIPTION
On some architectures, libatomic is needed and should not be dependent on tests being enabled.
