### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -23,10 +23,10 @@ extern "C"
 
 #include "rcutils/time.h"
 
-#if defined(__MACH__)
+#if defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
-#endif  // defined(__MACH__)
+#endif  // defined(__MACH__) && defined(__APPLE__)
 #include <math.h>
 
 #if defined(__ZEPHYR__)
@@ -40,13 +40,13 @@ extern "C"
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 
-#if !defined(__MACH__)  // Assume clock_get_time is available on OS X.
+#if !defined(__MACH__) && !defined(__APPLE__)   // Assume clock_get_time is available on OS X.
 // This id an appropriate check for clock_gettime() according to:
 //   http://man7.org/linux/man-pages/man2/clock_gettime.2.html
 # if !defined(_POSIX_TIMERS) || !_POSIX_TIMERS
 #  error no monotonic clock function available
 # endif  // !defined(_POSIX_TIMERS) || !_POSIX_TIMERS
-#endif  // !defined(__MACH__)
+#endif  // !defined(__MACH__) && !defined(__APPLE__)
 
 #define __WOULD_BE_NEGATIVE(seconds, subseconds) (seconds < 0 || (subseconds < 0 && seconds == 0))
 
@@ -55,15 +55,15 @@ rcutils_system_time_now(rcutils_time_point_value_t * now)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
   struct timespec timespec_now;
-#if defined(__MACH__)
+#if defined(__MACH__) && defined(__APPLE__)
   // On macOS, use clock_gettime(CLOCK_REALTIME), which matches
   // the clang implementation
   // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
   clock_gettime(CLOCK_REALTIME, &timespec_now);
-#else  // defined(__MACH__)
+#else  // defined(__MACH__) && defined(__APPLE__)
   // Otherwise use clock_gettime.
   clock_gettime(CLOCK_REALTIME, &timespec_now);
-#endif  // defined(__MACH__)
+#endif  // defined(__MACH__) && defined(__APPLE__)
   if (__WOULD_BE_NEGATIVE(timespec_now.tv_sec, timespec_now.tv_nsec)) {
     RCUTILS_SET_ERROR_MSG("unexpected negative time");
     return RCUTILS_RET_ERROR;
@@ -78,15 +78,15 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now)
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
   // If clock_gettime is available or on OS X, use a timespec.
   struct timespec timespec_now;
-#if defined(__MACH__)
+#if defined(__MACH__) && defined(__APPLE__)
   // On macOS, use clock_gettime(CLOCK_MONOTONIC_RAW), which matches
   // the clang implementation
   // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
   clock_gettime(CLOCK_MONOTONIC_RAW, &timespec_now);
-#else  // defined(__MACH__)
+#else  // defined(__MACH__) && defined(__APPLE__)
   // Otherwise use clock_gettime.
   clock_gettime(CLOCK_MONOTONIC, &timespec_now);
-#endif  // defined(__MACH__)
+#endif  // defined(__MACH__) && defined(__APPLE__)
   if (__WOULD_BE_NEGATIVE(timespec_now.tv_sec, timespec_now.tv_nsec)) {
     RCUTILS_SET_ERROR_MSG("unexpected negative time");
     return RCUTILS_RET_ERROR;


### PR DESCRIPTION
As said on line 43, this check is only intended for OSX.
```
 // Assume clock_get_time is available on OS X.
```

Hurd uses a different version of Mach that does not have `mach/clock.h`.
https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```

Signed-off-by: Maximilian Downey Twiss <creatorsmithmdt@gmail.com>