### PR TITLE
.gitignore: Add Emacs backup file pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*~
 __pycache__
 doc_output


### PR DESCRIPTION
Emacs uses *~ as a backup file.  Ignore them.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>