### PR TITLE
Cleanup time_unix.c

### DIFF
--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -16,11 +16,6 @@
 # error time_unix.c is not intended to be used with win32 based systems
 #endif  // defined(_WIN32)
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include "rcutils/time.h"
 
 #if defined(__MACH__) && defined(__APPLE__)
@@ -40,36 +35,38 @@ extern "C"
 #include <time.h>
 #endif  //  defined(__ZEPHYR__)
 
+#include <errno.h>
 #include <unistd.h>
-#include "./common.h"
+
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 
 #if !defined(__MACH__) && !defined(__APPLE__)   // Assume clock_get_time is available on OS X.
-// This id an appropriate check for clock_gettime() according to:
+// This is an appropriate check for clock_gettime() according to:
 //   http://man7.org/linux/man-pages/man2/clock_gettime.2.html
 # if !defined(_POSIX_TIMERS) || !_POSIX_TIMERS
 #  error no monotonic clock function available
 # endif  // !defined(_POSIX_TIMERS) || !_POSIX_TIMERS
 #endif  // !defined(__MACH__) && !defined(__APPLE__)
 
-#define __WOULD_BE_NEGATIVE(seconds, subseconds) (seconds < 0 || (subseconds < 0 && seconds == 0))
+static inline bool would_be_negative(const struct timespec * const now)
+{
+  return now->tv_sec < 0 || (now->tv_nsec < 0 && now->tv_sec == 0);
+}
 
 rcutils_ret_t
 rcutils_system_time_now(rcutils_time_point_value_t * now)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
   struct timespec timespec_now;
-#if defined(__MACH__) && defined(__APPLE__)
-  // On macOS, use clock_gettime(CLOCK_REALTIME), which matches
-  // the clang implementation
+  // Using clock_gettime(CLOCK_REALTIME) matches what both Linux and macOS use.
+  // For macOS, see the clang implementation at
   // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
-  clock_gettime(CLOCK_REALTIME, &timespec_now);
-#else  // defined(__MACH__) && defined(__APPLE__)
-  // Otherwise use clock_gettime.
-  clock_gettime(CLOCK_REALTIME, &timespec_now);
-#endif  // defined(__MACH__) && defined(__APPLE__)
-  if (__WOULD_BE_NEGATIVE(timespec_now.tv_sec, timespec_now.tv_nsec)) {
+  if (clock_gettime(CLOCK_REALTIME, &timespec_now) < 0) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Failed to get system time: %d", errno);
+    return RCUTILS_RET_ERROR;
+  }
+  if (would_be_negative(&timespec_now)) {
     RCUTILS_SET_ERROR_MSG("unexpected negative time");
     return RCUTILS_RET_ERROR;
   }
@@ -81,25 +78,23 @@ rcutils_ret_t
 rcutils_steady_time_now(rcutils_time_point_value_t * now)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
-  // If clock_gettime is available or on OS X, use a timespec.
   struct timespec timespec_now;
+  clockid_t monotonic_clock = CLOCK_MONOTONIC;
+
 #if defined(__MACH__) && defined(__APPLE__)
-  // On macOS, use clock_gettime(CLOCK_MONOTONIC_RAW), which matches
-  // the clang implementation
+  // On macOS, use CLOCK_MONOTONIC_RAW, which matches the clang implementation
   // (https://github.com/llvm/llvm-project/blob/baebe12ad0d6f514cd33e418d6504075d3e79c0a/libcxx/src/chrono.cpp)
-  clock_gettime(CLOCK_MONOTONIC_RAW, &timespec_now);
-#else  // defined(__MACH__) && defined(__APPLE__)
-  // Otherwise use clock_gettime.
-  clock_gettime(CLOCK_MONOTONIC, &timespec_now);
+  monotonic_clock = CLOCK_MONOTONIC_RAW;
 #endif  // defined(__MACH__) && defined(__APPLE__)
-  if (__WOULD_BE_NEGATIVE(timespec_now.tv_sec, timespec_now.tv_nsec)) {
+
+  if (clock_gettime(monotonic_clock, &timespec_now) < 0) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Failed to get steady time: %d", errno);
+    return RCUTILS_RET_ERROR;
+  }
+  if (would_be_negative(&timespec_now)) {
     RCUTILS_SET_ERROR_MSG("unexpected negative time");
     return RCUTILS_RET_ERROR;
   }
   *now = RCUTILS_S_TO_NS((int64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCUTILS_RET_OK;
 }
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
The file was pretty messy.  Cleanups:

1.  Remove totally unnecessary #ifdef __cplusplus; that is only necessary in headers.
2.  Remove unnecessary include to ./common.h.
3.  Change WOULD_BE_NEGATIVE to an inline function, which will at least give us some type checking.
4.  Get rid of unnecessary duplicated code for macOS.  Most of the time the code was exactly the same.
5.  Make sure to check the return value from clock_gettime.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The diff is pretty hard to read, but it makes a lot more sense if you just look at the resulting file.