### PR TITLE
time_unix: uses ZEPHYR_VERSION_CODE instead

### DIFF
--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -26,7 +26,7 @@
 
 #if defined(__ZEPHYR__)
 #include <version.h>
-#if KERNELVERSION >= ZEPHYR_VERSION(3, 1, 0)
+#if ZEPHYR_VERSION_CODE >= ZEPHYR_VERSION(3, 1, 0)
 #include <zephyr/posix/time.h>  //  Points to Zephyr toolchain posix time implementation
 #else
 #include <posix/time.h>  //  Points to Zephyr toolchain posix time implementation


### PR DESCRIPTION
of KERNELVERSION, since zephyr from 2.7 does not use

it anymore.

Signed-off-by: Felipe Neves <felipe.neves@linaro.org>