### PR TITLE
Fix memory leak when adding the same key to the logger hash map multiple times

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -796,7 +796,6 @@ static rcutils_ret_t add_key_to_hash_map(const char * name, int level, bool set_
 
   rcutils_ret_t hash_map_ret =
     rcutils_hash_map_set(&g_rcutils_logging_severities_map, &copy_name, &level);
-
   if (hash_map_ret != RCUTILS_RET_OK) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error setting severity level for logger named '%s': %s",


### PR DESCRIPTION
The first time a key is added the hash map will retain a copy of the pointer and later will deallocate the memory during shutdown. Subsequent times the same key is added to the hash map, it will NOT retain a copy of the new pointer, and hence not deallocate the memory during shutdown.

This fixes the issue by checking if we're adding an entry for an existing key and if so, deallocate the key.

Previously, ASAN was reporting memory leaks: https://ci.ros2.org/view/nightly/job/nightly_linux_address_sanitizer/1287/
With this change, we no longer see the memory leak reported: https://ci.ros2.org/job/ci_linux/17486/