### PR TITLE
Upgrade rcutils to C++17.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ project(rcutils)
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
 endif()
-# Default to C++14
+# Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 include(CheckLibraryExists)
@@ -143,16 +143,18 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   RUNTIME DESTINATION bin)
 
 if(BUILD_TESTING)
-  if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-  endif()
-
   find_package(performance_test_fixture REQUIRED)
 
   find_package(ament_cmake_gmock REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
+  # cppcheck 1.90 doesn't understand some of the syntax in remove_noexcept.hpp
+  # Since we already have cppcheck disabled on Linux, just disable it completely
+  # for this package.
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_cppcheck
+  )
   ament_lint_auto_find_test_dependencies()
 
   find_package(launch_testing_ament_cmake REQUIRED)

--- a/test/mocking_utils/filesystem.hpp
+++ b/test/mocking_utils/filesystem.hpp
@@ -33,6 +33,7 @@
 #endif
 #endif
 
+#include <functional>
 #include <map>
 #include <string>
 #include <type_traits>

--- a/test/mocking_utils/patch.hpp
+++ b/test/mocking_utils/patch.hpp
@@ -35,6 +35,8 @@
 #include "mimick/mimick.h"
 #include "rcutils/macros.h"
 
+#include "remove_noexcept.hpp"
+
 namespace mocking_utils
 {
 
@@ -215,7 +217,9 @@ public:
    *   trampoline, as setup by the dynamic linker.
    * \return a mocking_utils::Patch instance.
    */
-  explicit Patch(const std::string & target, std::function<ReturnT(ArgTs...)> proxy)
+  explicit Patch(
+    const std::string & target,
+    std::function<remove_noexcept_t<ReturnT(ArgTs...)>> proxy)
   : proxy_(proxy)
   {
     auto MMK_MANGLE(mock_type, create) =
@@ -291,9 +295,9 @@ private:
  * \sa mocking_utils::Patch for further reference.
  */
 template<size_t ID, typename SignatureT>
-auto make_patch(const std::string & target, std::function<SignatureT> proxy)
+auto make_patch(const std::string & target, std::function<remove_noexcept_t<SignatureT>> proxy)
 {
-  return Patch<ID, SignatureT>(target, proxy);
+  return Patch<ID, remove_noexcept_t<SignatureT>>(target, proxy);
 }
 
 /// Define a dummy operator `op` for a given `type`.

--- a/test/mocking_utils/remove_noexcept.hpp
+++ b/test/mocking_utils/remove_noexcept.hpp
@@ -1,0 +1,1006 @@
+// TODO(clalancette): no license until I get a licensing answer from
+// the original author.
+
+// This code originally comes from https://stackoverflow.com/a/55701361,
+// and more specifically from the "live demo" at https://wandbox.org/permlink/bXRiKZBzhjKPaRel .
+// As per the Stackoverflow guidelines, all code contributed on the site since 2018 is
+// licensed under CC BY-SA 4.0 (https://stackoverflow.com/help/licensing).  Unfortunately,
+// this is not specified as compatible with Apache License 2.0
+// (see https://creativecommons.org/share-your-work/licensing-considerations/compatible-licenses/).
+// Therefore, I reached out directly to the original author to get permission to license this
+// as Apache 2.0.  As of 2022-10-13, I'm still waiting for an answer.
+
+#ifndef MOCKING_UTILS__REMOVE_NOEXCEPT_HPP_
+#define MOCKING_UTILS__REMOVE_NOEXCEPT_HPP_
+
+#include <type_traits>
+
+template<typename T, bool noexcept_state = true>
+struct make_noexcept { using type = T; };
+
+// MSVC++ 2019 (v142) doesn't allow `noexcept(x)` with a template parameter `x` in the template
+// specialization list.
+// (e.g., `struct make_noexcept<R(Args...) noexcept(noexcept_state)>` gives
+// - C2057: expected constant expression)
+// GCC 7.1.0 and Clang 5.0.0 (and later versions) were tested and do allow this, so MSVC++ is
+// probably wrong.
+// $ g++ prog.cc -Wall -Wextra -std=c++17 -pedantic
+// $ clang++ prog.cc -Wall -Wextra -std=c++17 -pedantic
+
+// Additionally, MSVC++ 2019 (v142) discards `noexcept(noexcept)` state in the actual type
+// declaration as well.
+// (e.g., `using type = R(Args...) noexcept(noexcept_state);`
+// always evaluates to `using type = R(Args...);`)
+// GCC and Clang produce the correct results in these cases.
+
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) noexcept, true>
+{
+  using type = R(Args ...) noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const noexcept, true>
+{
+  using type = R(Args ...) const noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile noexcept, true>
+{
+  using type = R(Args ...) volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile noexcept, true>
+{
+  using type = R(Args ...) const volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) noexcept, true>
+{
+  using type = R(Args ..., ...) noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const noexcept, true>
+{
+  using type = R(Args ..., ...) const noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile noexcept, true>
+{
+  using type = R(Args ..., ...) volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile noexcept, true>
+{
+  using type = R(Args ..., ...) const volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) & noexcept, true>
+{
+  using type = R(Args ... ) & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const & noexcept, true>
+{
+  using type = R(Args ...) const & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile & noexcept, true>
+{
+  using type = R(Args ...) volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile & noexcept, true>
+{
+  using type = R(Args ...) const volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) & noexcept, true>
+{
+  using type = R(Args ..., ... ) & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const & noexcept, true>
+{
+  using type = R(Args ..., ...) const & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile & noexcept, true>
+{
+  using type = R(Args ..., ...) volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile & noexcept, true>
+{
+  using type = R(Args ..., ...) const volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) && noexcept, true>
+{
+  using type = R(Args ...) && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const && noexcept, true>
+{
+  using type = R(Args ...) const && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile && noexcept, true>
+{
+  using type = R(Args ...) volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile && noexcept, true>
+{
+  using type = R(Args ...) const volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) && noexcept, true>
+{
+  using type = R(Args ..., ...) && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const && noexcept, true>
+{
+  using type = R(Args ..., ...) const && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile && noexcept, true>
+{
+  using type = R(Args ..., ...) volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile && noexcept, true>
+{
+  using type = R(Args ..., ...) const volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) noexcept, true>
+{
+  using type = R (C::*)(Args...) noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const noexcept, true>
+{
+  using type = R (C::*)(Args...) const noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile noexcept, true>
+{
+  using type = R (C::*)(Args...) volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile noexcept, true>
+{
+  using type = R (C::*)(Args...) const volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const noexcept, true>
+{
+  using type = R (C::*)(Args...) const noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile noexcept, true>
+{
+  using type = R (C::*)(Args...) volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile noexcept, true>
+{
+  using type = R (C::*)(Args...) const volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) & noexcept, true>
+{
+  using type = R (C::*)(Args... ) & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const & noexcept, true>
+{
+  using type = R (C::*)(Args...) const & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile & noexcept, true>
+{
+  using type = R (C::*)(Args...) volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile & noexcept, true>
+{
+  using type = R (C::*)(Args...) const volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) & noexcept, true>
+{
+  using type = R (C::*)(Args..., ... ) & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const & noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) const & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile & noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile & noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) const volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) && noexcept, true>
+{
+  using type = R (C::*)(Args...) && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const && noexcept, true>
+{
+  using type = R (C::*)(Args...) const && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile && noexcept, true>
+{
+  using type = R (C::*)(Args...) volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile && noexcept, true>
+{
+  using type = R (C::*)(Args...) const volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) && noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const && noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) const && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile && noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile && noexcept, true>
+{
+  using type = R (C::*)(Args..., ...) const volatile && noexcept;
+};
+
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...), true>
+{
+  using type = R(Args ...) noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const, true>
+{
+  using type = R(Args ...) const noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile, true>
+{
+  using type = R(Args ...) volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile, true>
+{
+  using type = R(Args ...) const volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...), true>
+{
+  using type = R(Args ..., ...) noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const, true>
+{
+  using type = R(Args ..., ...) const noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile, true>
+{
+  using type = R(Args ..., ...) volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile, true>
+{
+  using type = R(Args ..., ...) const volatile noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) &, true>
+{
+  using type = R(Args ... ) & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const &, true>
+{
+  using type = R(Args ...) const & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile &, true>
+{
+  using type = R(Args ...) volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile &, true>
+{
+  using type = R(Args ...) const volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) &, true>
+{
+  using type = R(Args ..., ... ) & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const &, true>
+{
+  using type = R(Args ..., ...) const & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile &, true>
+{
+  using type = R(Args ..., ...) volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile &, true>
+{
+  using type = R(Args ..., ...) const volatile & noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) &&, true>
+{
+  using type = R(Args ...) && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const &&, true>
+{
+  using type = R(Args ...) const && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile &&, true>
+{
+  using type = R(Args ...) volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile &&, true>
+{
+  using type = R(Args ...) const volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) &&, true>
+{
+  using type = R(Args ..., ...) && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const &&, true>
+{
+  using type = R(Args ..., ...) const && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile &&, true>
+{
+  using type = R(Args ..., ...) volatile && noexcept;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile &&, true>
+{
+  using type = R(Args ..., ...) const volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...), true>
+{
+  using type = R (C::*)(Args...) noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const, true>
+{
+  using type = R (C::*)(Args...) const noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile, true>
+{
+  using type = R (C::*)(Args...) volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile, true>
+{
+  using type = R (C::*)(Args...) const volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...), true>
+{
+  using type = R (C::*)(Args..., ...) noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const, true>
+{
+  using type = R (C::*)(Args...) const noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile, true>
+{
+  using type = R (C::*)(Args...) volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile, true>
+{
+  using type = R (C::*)(Args...) const volatile noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) &, true>
+{
+  using type = R (C::*)(Args... ) & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const &, true>
+{
+  using type = R (C::*)(Args...) const & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile &, true>
+{
+  using type = R (C::*)(Args...) volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile &, true>
+{
+  using type = R (C::*)(Args...) const volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) &, true>
+{
+  using type = R (C::*)(Args..., ... ) & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const &, true>
+{
+  using type = R (C::*)(Args..., ...) const & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile &, true>
+{
+  using type = R (C::*)(Args..., ...) volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile &, true>
+{
+  using type = R (C::*)(Args..., ...) const volatile & noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) &&, true>
+{
+  using type = R (C::*)(Args...) && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const &&, true>
+{
+  using type = R (C::*)(Args...) const && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile &&, true>
+{
+  using type = R (C::*)(Args...) volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile &&, true>
+{
+  using type = R (C::*)(Args...) const volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) &&, true>
+{
+  using type = R (C::*)(Args..., ...) && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const &&, true>
+{
+  using type = R (C::*)(Args..., ...) const && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile &&, true>
+{
+  using type = R (C::*)(Args..., ...) volatile && noexcept;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile &&, true>
+{
+  using type = R (C::*)(Args..., ...) const volatile && noexcept;
+};
+
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) noexcept, false>
+{
+  using type = R(Args ...);
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const noexcept, false>
+{
+  using type = R(Args ...) const;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile noexcept, false>
+{
+  using type = R(Args ...) volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile noexcept, false>
+{
+  using type = R(Args ...) const volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) noexcept, false>
+{
+  using type = R(Args ..., ...);
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const noexcept, false>
+{
+  using type = R(Args ..., ...) const;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile noexcept, false>
+{
+  using type = R(Args ..., ...) volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile noexcept, false>
+{
+  using type = R(Args ..., ...) const volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) & noexcept, false>
+{
+  using type = R(Args ... ) &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const & noexcept, false>
+{
+  using type = R(Args ...) const &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile & noexcept, false>
+{
+  using type = R(Args ...) volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile & noexcept, false>
+{
+  using type = R(Args ...) const volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) & noexcept, false>
+{
+  using type = R(Args ..., ... ) &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const & noexcept, false>
+{
+  using type = R(Args ..., ...) const &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile & noexcept, false>
+{
+  using type = R(Args ..., ...) volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile & noexcept, false>
+{
+  using type = R(Args ..., ...) const volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) && noexcept, false>
+{
+  using type = R(Args ...) &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const && noexcept, false>
+{
+  using type = R(Args ...) const &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile && noexcept, false>
+{
+  using type = R(Args ...) volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile && noexcept, false>
+{
+  using type = R(Args ...) const volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) && noexcept, false>
+{
+  using type = R(Args ..., ...) &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const && noexcept, false>
+{
+  using type = R(Args ..., ...) const &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile && noexcept, false>
+{
+  using type = R(Args ..., ...) volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile && noexcept, false>
+{
+  using type = R(Args ..., ...) const volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) noexcept, false>
+{
+  using type = R (C::*)(Args...);
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const noexcept, false>
+{
+  using type = R (C::*)(Args...) const;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile noexcept, false>
+{
+  using type = R (C::*)(Args...) volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile noexcept, false>
+{
+  using type = R (C::*)(Args...) const volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) noexcept, false>
+{
+  using type = R (C::*)(Args..., ...);
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const noexcept, false>
+{
+  using type = R (C::*)(Args...) const;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile noexcept, false>
+{
+  using type = R (C::*)(Args...) volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile noexcept, false>
+{
+  using type = R (C::*)(Args...) const volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) & noexcept, false>
+{
+  using type = R (C::*)(Args... ) &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const & noexcept, false>
+{
+  using type = R (C::*)(Args...) const &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile & noexcept, false>
+{
+  using type = R (C::*)(Args...) volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile & noexcept, false>
+{
+  using type = R (C::*)(Args...) const volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) & noexcept, false>
+{
+  using type = R (C::*)(Args..., ... ) &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const & noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) const &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile & noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile & noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) const volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) && noexcept, false>
+{
+  using type = R (C::*)(Args...) &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const && noexcept, false>
+{
+  using type = R (C::*)(Args...) const &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile && noexcept, false>
+{
+  using type = R (C::*)(Args...) volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile && noexcept, false>
+{
+  using type = R (C::*)(Args...) const volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) && noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const && noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) const &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile && noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile && noexcept, false>
+{
+  using type = R (C::*)(Args..., ...) const volatile &&;
+};
+
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...), false>
+{
+  using type = R(Args ...);
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const, false>
+{
+  using type = R(Args ...) const;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile, false>
+{
+  using type = R(Args ...) volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile, false>
+{
+  using type = R(Args ...) const volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...), false>
+{
+  using type = R(Args ..., ...);
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const, false>
+{
+  using type = R(Args ..., ...) const;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile, false>
+{
+  using type = R(Args ..., ...) volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile, false>
+{
+  using type = R(Args ..., ...) const volatile;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) &, false>
+{
+  using type = R(Args ... ) &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const &, false>
+{
+  using type = R(Args ...) const &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile &, false>
+{
+  using type = R(Args ...) volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile &, false>
+{
+  using type = R(Args ...) const volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) &, false>
+{
+  using type = R(Args ..., ... ) &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const &, false>
+{
+  using type = R(Args ..., ...) const &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile &, false>
+{
+  using type = R(Args ..., ...) volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile &, false>
+{
+  using type = R(Args ..., ...) const volatile &;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) &&, false>
+{
+  using type = R(Args ...) &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const &&, false>
+{
+  using type = R(Args ...) const &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) volatile &&, false>
+{
+  using type = R(Args ...) volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args...) const volatile &&, false>
+{
+  using type = R(Args ...) const volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) &&, false>
+{
+  using type = R(Args ..., ...) &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const &&, false>
+{
+  using type = R(Args ..., ...) const &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) volatile &&, false>
+{
+  using type = R(Args ..., ...) volatile &&;
+};
+template<typename R, typename ... Args>
+struct make_noexcept<R(Args..., ...) const volatile &&, false>
+{
+  using type = R(Args ..., ...) const volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...), false>
+{
+  using type = R (C::*)(Args...);
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const, false>
+{
+  using type = R (C::*)(Args...) const;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile, false>
+{
+  using type = R (C::*)(Args...) volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile, false>
+{
+  using type = R (C::*)(Args...) const volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...), false>
+{
+  using type = R (C::*)(Args..., ...);
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const, false>
+{
+  using type = R (C::*)(Args...) const;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile, false>
+{
+  using type = R (C::*)(Args...) volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile, false>
+{
+  using type = R (C::*)(Args...) const volatile;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) &, false>
+{
+  using type = R (C::*)(Args... ) &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const &, false>
+{
+  using type = R (C::*)(Args...) const &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile &, false>
+{
+  using type = R (C::*)(Args...) volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile &, false>
+{
+  using type = R (C::*)(Args...) const volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) &, false>
+{
+  using type = R (C::*)(Args..., ... ) &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const &, false>
+{
+  using type = R (C::*)(Args..., ...) const &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile &, false>
+{
+  using type = R (C::*)(Args..., ...) volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile &, false>
+{
+  using type = R (C::*)(Args..., ...) const volatile &;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) &&, false>
+{
+  using type = R (C::*)(Args...) &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const &&, false>
+{
+  using type = R (C::*)(Args...) const &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) volatile &&, false>
+{
+  using type = R (C::*)(Args...) volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args...) const volatile &&, false>
+{
+  using type = R (C::*)(Args...) const volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) &&, false>
+{
+  using type = R (C::*)(Args..., ...) &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const &&, false>
+{
+  using type = R (C::*)(Args..., ...) const &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) volatile &&, false>
+{
+  using type = R (C::*)(Args..., ...) volatile &&;
+};
+template<typename R, typename C, typename ... Args>
+struct make_noexcept<R (C::*)(Args..., ...) const volatile &&, false>
+{
+  using type = R (C::*)(Args..., ...) const volatile &&;
+};
+
+template<typename T, bool noexcept_state = true>
+using make_noexcept_t = typename make_noexcept<T, noexcept_state>::type;
+
+template<typename T>
+using remove_noexcept_t = make_noexcept_t<T, false>;
+
+#endif  // MOCKING_UTILS__REMOVE_NOEXCEPT_HPP_

--- a/test/mocking_utils/remove_noexcept.hpp
+++ b/test/mocking_utils/remove_noexcept.hpp
@@ -1,14 +1,22 @@
-// TODO(clalancette): no license until I get a licensing answer from
-// the original author.
+// Copyright 2019 Michael "monkey0506" Rittenhouse
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 // This code originally comes from https://stackoverflow.com/a/55701361,
-// and more specifically from the "live demo" at https://wandbox.org/permlink/bXRiKZBzhjKPaRel .
-// As per the Stackoverflow guidelines, all code contributed on the site since 2018 is
-// licensed under CC BY-SA 4.0 (https://stackoverflow.com/help/licensing).  Unfortunately,
-// this is not specified as compatible with Apache License 2.0
-// (see https://creativecommons.org/share-your-work/licensing-considerations/compatible-licenses/).
-// Therefore, I reached out directly to the original author to get permission to license this
-// as Apache 2.0.  As of 2022-10-13, I'm still waiting for an answer.
+// and more specifically from the "live demo" at https://wandbox.org/permlink/GUqJFwMnczKEKlzX.
+// That code is licensed under the WTFPL license, which allows basically anything.
+// We relicense the code to Apache 2.0 for compatibility with the rest of our code,
+// with Copyright to the original author, Michael "monkey0506" Rittenhouse.
 
 #ifndef MOCKING_UTILS__REMOVE_NOEXCEPT_HPP_
 #define MOCKING_UTILS__REMOVE_NOEXCEPT_HPP_


### PR DESCRIPTION
This upgrade was more involved than just increasing the CMAKE_CXX_STANDARD version.  In C++17, apparently 'noexcept' became part of the type system.  This is problematic because some functions that we use from the underlying libc, like 'stat', actually specify nothrow in their function declaration. This causes the type system to reject our mock shims, since the types are no longer totally compatible.

To work around this, introduce a 'remove_noexcept' type into the system which effectively removes the 'noexcept' specifier for any function that it uses.  With that in place, everything here works with C++17.  See the comments in remove_noexcept.hpp for details on the provenance of that code.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

The motivation for upgrading for C++17 is to fix a memory leak down in https://github.com/osrf/osrf_testing_tools_cpp , which will require C++17 support in this package and a few others.  That will come separately.

Opening as a draft pull request for now, as we still need to figure out the licensing on remove_except.hpp.  @monkey0506, if you would be willing to explicitly license that code as Apache 2.0, MIT, or BSD, we can include it here.