### PR TITLE
regression of thread-safety for logging macros

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -486,9 +486,20 @@ RCUTILS_ATTRIBUTE_PRINTF_FORMAT(4, 5)
  * ------------------ | -------------
  * Allocates Memory   | No, for formatted outputs <= 1023 characters
  *                    | Yes, for formatted outputs >= 1024 characters
- * Thread-Safe        | No
+ * Thread-Safe        | Yes, with itself [1]
  * Uses Atomics       | No
  * Lock-Free          | Yes
+ * <i>[1] should be thread-safe with itself but not with other logging functions</i>
+ *
+ * This should be thread-safe with itself, but is not thread-safe with other
+ * logging functions that do things like set logger levels.
+ *
+ * \todo There are no thread-safety gurantees between this function and other
+ *   logging functions in rcutils, even though it is likely users are calling
+ *   them concurrently today.
+ *   We need to revisit these functions with respect to this issue and make
+ *   guarantees where we can, and change functions higher in the stack to
+ *   provide the thread-safety where we cannot.
  *
  * \param[in] location The pointer to the location struct or NULL
  * \param[in] severity The severity level

--- a/src/logging.c
+++ b/src/logging.c
@@ -952,7 +952,7 @@ int rcutils_logging_get_logger_effective_level(const char * name)
       // Continue on if we failed to add the key to the hashmap.
       // This will affect performance but is not fatal.
       RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "Failed to cache severity; this is not fatal but will impact performance");
+        "Failed to cache severity; this is not fatal but will impact performance\n");
     }
   }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -949,9 +949,6 @@ int rcutils_logging_get_logger_effective_level(const char * name)
   // // lookup next time.  If the severity is UNSET, we don't bother because we are going to have to
   // // walk the hierarchy next time anyway.
   // if (severity != RCUTILS_LOG_SEVERITY_UNSET) {
-  //   fprintf(
-  //     stderr, "in optimization of rcutils_logging_get_logger_effective_level('%s') -> %d\n",
-  //     name, severity);
   //   ret = add_key_to_hash_map(name, severity, false);
   //   if (ret != RCUTILS_RET_OK) {
   //     // Continue on if we failed to add the key to the hashmap.

--- a/src/logging.c
+++ b/src/logging.c
@@ -943,18 +943,23 @@ int rcutils_logging_get_logger_effective_level(const char * name)
     severity = g_rcutils_logging_default_logger_level;
   }
 
-  // If the calculated severity is anything but UNSET, we place it into the hashmap for speedier
-  // lookup next time.  If the severity is UNSET, we don't bother because we are going to have to
-  // walk the hierarchy next time anyway.
-  if (severity != RCUTILS_LOG_SEVERITY_UNSET) {
-    ret = add_key_to_hash_map(name, severity, false);
-    if (ret != RCUTILS_RET_OK) {
-      // Continue on if we failed to add the key to the hashmap.
-      // This will affect performance but is not fatal.
-      RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "Failed to cache severity; this is not fatal but will impact performance\n");
-    }
-  }
+  // TODO(wjwwood): restore or replace this optimization when thread-safety is addressed
+  //   see: FIXME
+  // // If the calculated severity is anything but UNSET, we place it into the hashmap for speedier
+  // // lookup next time.  If the severity is UNSET, we don't bother because we are going to have to
+  // // walk the hierarchy next time anyway.
+  // if (severity != RCUTILS_LOG_SEVERITY_UNSET) {
+  //   fprintf(
+  //     stderr, "in optimization of rcutils_logging_get_logger_effective_level('%s') -> %d\n",
+  //     name, severity);
+  //   ret = add_key_to_hash_map(name, severity, false);
+  //   if (ret != RCUTILS_RET_OK) {
+  //     // Continue on if we failed to add the key to the hashmap.
+  //     // This will affect performance but is not fatal.
+  //     RCUTILS_SAFE_FWRITE_TO_STDERR(
+  //       "Failed to cache severity; this is not fatal but will impact performance\n");
+  //   }
+  // }
 
   return severity;
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -944,7 +944,7 @@ int rcutils_logging_get_logger_effective_level(const char * name)
   }
 
   // TODO(wjwwood): restore or replace this optimization when thread-safety is addressed
-  //   see: FIXME
+  //   see: https://github.com/ros2/rcutils/pull/393
   // // If the calculated severity is anything but UNSET, we place it into the hashmap for speedier
   // // lookup next time.  If the severity is UNSET, we don't bother because we are going to have to
   // // walk the hierarchy next time anyway.

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -495,7 +495,7 @@ TEST(TestLogging, test_logging_macro_thread_safety)
   // This test is based on an issue found in the optimization of the logging macros,
   // and therefore has a very specific trigger scenario, which is described more
   // in the steps below.
-  // See: FIXME
+  // See: https://github.com/ros2/rcutils/pull/393
 
   // This test is likely to be flakey false-positive, meaning it's possible that
   // it will pass even if the macros are not thread-safe and may require running


### PR DESCRIPTION
This came up in one of our projects using rolling and they noticed an uptick in crashes originating in logging calls.

It turns out it is related to optimizations made in https://github.com/ros2/rcutils/pull/381, and is only triggered in specific scenarios, namely when some loggers have had their severity set by the user, but not all the ones being called. This triggers a code path that was part of https://github.com/ros2/rcutils/pull/381 which can cause a global hash map to be added to, and sometimes grown, and this seems to be the root of many of the crashes, though it crashes in many different ways.

In this pr I added a regression test that catches these kind of problems most runs, but it isn't perfect since it is a race condition.

After some investigation and talking with @clalancette, this code block seems to be the offender:

https://github.com/ros2/rcutils/blob/3485f1bdc805ead1e9c26509479dc8c1f94b6951/src/logging.c#L946-L957

After removing that, this test passes even if I use `--gtest_repeat=1000` to run it 1000 times. Whereas it fails with that code uncommented almost every time. So I don't know if this makes the logging macros completely (conceptually) thread-safe, but it does undo this regression, it seems.