### PR TITLE
Add SHA256 utility implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,13 @@ if(BUILD_TESTING)
     target_link_libraries(test_repl_str ${PROJECT_NAME})
   endif()
 
+  ament_add_gtest(test_sha256
+    test/test_sha256.cpp
+  )
+  if(TARGET test_sha256)
+    target_link_libraries(test_sha256 ${PROJECT_NAME})
+  endif()
+
   macro(add_dummy_shared_library target)
     add_library(${target} test/dummy_shared_library/dummy_shared_library.c)
     if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(rcutils_sources
   src/process.c
   src/qsort.c
   src/repl_str.c
+  src/sha256.c
   src/shared_library.c
   src/snprintf.c
   src/split.c

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -18,20 +18,17 @@
 /// Implementation originally copied from Brad Conte
 /// https://github.com/B-Con/crypto-algorithms/blob/master/sha256.c
 
-/// Simple SHA256 implementation
-/*********************************************************************
-* Filename:   sha256.c
-* Author:     Brad Conte (brad AT bradconte.com)
-* Copyright:
-* Disclaimer: This code is presented "as is" without any guarantees.
-* Details:    Implementation of the SHA-256 hashing algorithm.
-              SHA-256 is one of the three algorithms in the SHA2
-              specification. The others, SHA-384 and SHA-512, are not
-              offered in this implementation.
-              Algorithm specification can be found here:
-               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
-              This implementation uses little endian byte order.
-*********************************************************************/
+/** \file sha256.h
+ *  \brief SHA256 implementation
+ *
+ *  This contains an implementation of the SHA256 algorithm
+ *  It was originally copied from Brad Conte
+ *  https://github.com/B-Con/crypto-algorithms/blob/master/sha256.c
+ *  and modified to meet ros2 code formatting and compiler warning requirements.
+ *  Algorithm specification can be found here:
+ *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+ *  This implementation uses little endian byte order.
+ */
 
 #ifndef RCUTILS__SHA256_H_
 #define RCUTILS__SHA256_H_
@@ -55,8 +52,9 @@ typedef struct
   uint32_t state[8];
 } rcutils_sha256_ctx_t;
 
+/// Initialize the sha256 algorithm context with starting state.
 /**
- *
+ * Call this on any new context before starting to input data.
  *
  * \param[inout] ctx
  * \return void
@@ -64,22 +62,24 @@ typedef struct
 RCUTILS_PUBLIC
 void rcutils_sha256_init(rcutils_sha256_ctx_t * ctx);
 
+/// Add data to the sha256 algorithm
 /**
+ * This may be called repeatedly on an initialized context.
  *
- *
- * \param ctx
- * \param data
- * \param len
+ * \param[inout] ctx Initialized sha256 context struct
+ * \param[in] data Data to add to the total message being hashed
+ * \param[in] data_len Size of the input data.
  * \return void
  */
 RCUTILS_PUBLIC
 void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, size_t data_len);
 
+/// Finalize and output sha256 hash for all data added.
 /**
+ * Call only once on a context that has been initialized, and optionally updated with data.
  *
- *
- * \param ctx
- * \param hash
+ * \param[inout] ctx Initialized sha256 context struct
+ * \param[out] hash Calculated sha256 message digest
  * \return void
  */
 RCUTILS_PUBLIC

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -47,7 +47,7 @@ extern "C"
 typedef struct RCUTILS_PUBLIC_TYPE rcutils_sha256_ctx_s
 {
   uint8_t data[64];
-  uint32_t datalen;
+  size_t datalen;
   uint64_t bitlen;
   uint32_t state[8];
 } rcutils_sha256_ctx_t;
@@ -83,7 +83,7 @@ void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, siz
  * \return void
  */
 RCUTILS_PUBLIC
-void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[RCUTILS_SHA256_BLOCK_SIZE]);
+void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t output_hash[RCUTILS_SHA256_BLOCK_SIZE]);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -32,11 +32,12 @@ extern "C"
 
 #define RCUTILS_SHA256_BLOCK_SIZE 32
 
-typedef struct {
-	uint8_t data[64];
-	uint32_t datalen;
-	uint64_t bitlen;
-	uint32_t state[8];
+typedef struct
+{
+  uint8_t data[64];
+  uint32_t datalen;
+  uint64_t bitlen;
+  uint32_t state[8];
 } rcutils_sha256_ctx_t;
 
 /// Simple SHA256 implementation
@@ -92,4 +93,4 @@ rcutils_ret_t sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[]);
 }
 #endif
 
-#endif  // RCUTILS__QSORT_H_
+#endif  // RCUTILS__SHA256_H_

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -49,10 +49,10 @@ extern "C"
 
 typedef struct
 {
-  unsigned char data[64];
-  unsigned int datalen;
-  unsigned long long bitlen;
-  unsigned int state[8];
+  uint8_t data[64];
+  uint32_t datalen;
+  uint64_t bitlen;
+  uint32_t state[8];
 } rcutils_sha256_ctx_t;
 
 /**

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -83,7 +83,9 @@ void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, siz
  * \return void
  */
 RCUTILS_PUBLIC
-void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t output_hash[RCUTILS_SHA256_BLOCK_SIZE]);
+void rcutils_sha256_final(
+  rcutils_sha256_ctx_t * ctx,
+  uint8_t output_hash[RCUTILS_SHA256_BLOCK_SIZE]);
 
 #ifdef __cplusplus
 }

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -79,7 +79,7 @@ void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, siz
  * Call only once on a context that has been initialized, and optionally updated with data.
  *
  * \param[inout] ctx Initialized sha256 context struct
- * \param[out] hash Calculated sha256 message digest
+ * \param[out] output_hash Calculated sha256 message digest to be filled
  * \return void
  */
 RCUTILS_PUBLIC

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -38,13 +38,13 @@ extern "C"
 {
 #endif
 
-#include "rcutils/macros.h"
-#include "rcutils/types/rcutils_ret.h"
+#include <stdint.h>
+
 #include "rcutils/visibility_control.h"
 
 #define RCUTILS_SHA256_BLOCK_SIZE 32
 
-typedef struct
+typedef struct RCUTILS_PUBLIC_TYPE rcutils_sha256_ctx_s
 {
   uint8_t data[64];
   uint32_t datalen;

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -1,0 +1,95 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// \file Provides a simple SHA256 algorithm for hashing.
+/// This implementation makes no security guarantees, its use case
+/// is for non-sensitive comparison of message digests
+/// Implementation originally copied from Brad Conte
+/// https://github.com/B-Con/crypto-algorithms/blob/master/sha256.c
+
+#ifndef RCUTILS__SHA256_H_
+#define RCUTILS__SHA256_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/macros.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/visibility_control.h"
+
+#define RCUTILS_SHA256_BLOCK_SIZE 32
+
+typedef struct {
+	uint8_t data[64];
+	uint32_t datalen;
+	uint64_t bitlen;
+	uint32_t state[8];
+} rcutils_sha256_ctx_t;
+
+/// Simple SHA256 implementation
+/*********************************************************************
+* Filename:   sha256.c
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Implementation of the SHA-256 hashing algorithm.
+              SHA-256 is one of the three algorithms in the SHA2
+              specification. The others, SHA-384 and SHA-512, are not
+              offered in this implementation.
+              Algorithm specification can be found here:
+               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+              This implementation uses little endian byte order.
+*********************************************************************/
+
+
+/**
+ *
+ *
+ * \param[inout] ctx
+ * \return rcutils_ret_t
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t rcutils_sha256_init(rcutils_sha256_ctx_t * ctx);
+
+/**
+ *
+ *
+ * \param ctx
+ * \param data
+ * \param len
+ * \return rcutils_ret_t
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data[], size_t len);
+
+/**
+ *
+ *
+ * \param ctx
+ * \param hash
+ * \return rcutils_ret_t
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCUTILS__QSORT_H_

--- a/include/rcutils/sha256.h
+++ b/include/rcutils/sha256.h
@@ -18,6 +18,21 @@
 /// Implementation originally copied from Brad Conte
 /// https://github.com/B-Con/crypto-algorithms/blob/master/sha256.c
 
+/// Simple SHA256 implementation
+/*********************************************************************
+* Filename:   sha256.c
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Implementation of the SHA-256 hashing algorithm.
+              SHA-256 is one of the three algorithms in the SHA2
+              specification. The others, SHA-384 and SHA-512, are not
+              offered in this implementation.
+              Algorithm specification can be found here:
+               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+              This implementation uses little endian byte order.
+*********************************************************************/
+
 #ifndef RCUTILS__SHA256_H_
 #define RCUTILS__SHA256_H_
 
@@ -34,37 +49,20 @@ extern "C"
 
 typedef struct
 {
-  uint8_t data[64];
-  uint32_t datalen;
-  uint64_t bitlen;
-  uint32_t state[8];
+  unsigned char data[64];
+  unsigned int datalen;
+  unsigned long long bitlen;
+  unsigned int state[8];
 } rcutils_sha256_ctx_t;
-
-/// Simple SHA256 implementation
-/*********************************************************************
-* Filename:   sha256.c
-* Author:     Brad Conte (brad AT bradconte.com)
-* Copyright:
-* Disclaimer: This code is presented "as is" without any guarantees.
-* Details:    Implementation of the SHA-256 hashing algorithm.
-              SHA-256 is one of the three algorithms in the SHA2
-              specification. The others, SHA-384 and SHA-512, are not
-              offered in this implementation.
-              Algorithm specification can be found here:
-               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
-              This implementation uses little endian byte order.
-*********************************************************************/
-
 
 /**
  *
  *
  * \param[inout] ctx
- * \return rcutils_ret_t
+ * \return void
  */
 RCUTILS_PUBLIC
-RCUTILS_WARN_UNUSED
-rcutils_ret_t rcutils_sha256_init(rcutils_sha256_ctx_t * ctx);
+void rcutils_sha256_init(rcutils_sha256_ctx_t * ctx);
 
 /**
  *
@@ -72,22 +70,20 @@ rcutils_ret_t rcutils_sha256_init(rcutils_sha256_ctx_t * ctx);
  * \param ctx
  * \param data
  * \param len
- * \return rcutils_ret_t
+ * \return void
  */
 RCUTILS_PUBLIC
-RCUTILS_WARN_UNUSED
-rcutils_ret_t rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data[], size_t len);
+void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, size_t data_len);
 
 /**
  *
  *
  * \param ctx
  * \param hash
- * \return rcutils_ret_t
+ * \return void
  */
 RCUTILS_PUBLIC
-RCUTILS_WARN_UNUSED
-rcutils_ret_t sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[]);
+void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[RCUTILS_SHA256_BLOCK_SIZE]);
 
 #ifdef __cplusplus
 }

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,158 +12,177 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include <string.h>
 
 #include "rcutils/sha256.h"
 
-#define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
-#define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))
+static inline uint32_t rotright(uint32_t value, uint8_t bits)
+{
+  return (value >> bits) | (value << (32 - bits));
+}
 
-#define CH(x,y,z) (((x) & (y)) ^ (~(x) & (z)))
-#define MAJ(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
-#define EP0(x) (ROTRIGHT(x,2) ^ ROTRIGHT(x,13) ^ ROTRIGHT(x,22))
-#define EP1(x) (ROTRIGHT(x,6) ^ ROTRIGHT(x,11) ^ ROTRIGHT(x,25))
-#define SIG0(x) (ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3))
-#define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
+static inline uint32_t ch(uint32_t x, uint32_t y, uint32_t z)
+{
+  return (x & y) ^ (~x & z);
+}
+
+static inline uint32_t maj(uint32_t x, uint32_t y, uint32_t z)
+{
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+static inline uint32_t ep0(uint32_t x)
+{
+  return rotright(x, 2) ^ rotright(x, 13) ^ rotright(x, 22);
+}
+
+static inline uint32_t ep1(uint32_t x)
+{
+  return rotright(x, 6) ^ rotright(x, 11) ^ rotright(x, 25);
+}
+
+static inline uint32_t sig0(uint32_t x)
+{
+  return rotright(x, 7) ^ rotright(x, 18) ^ (x >> 3);
+}
+
+static inline uint32_t sig1(uint32_t x)
+{
+  return rotright(x, 17) ^ rotright(x, 19) ^ (x >> 10);
+}
 
 static const uint32_t k[64] = {
-	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
-	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
-	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
-	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
-	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
-	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
-	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
-	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
 };
 
 void sha256_transform(rcutils_sha256_ctx_t * ctx, const uint8_t data[])
 {
-	uint32_t a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+  uint32_t a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
 
-	for (i = 0, j = 0; i < 16; ++i, j += 4)
-		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
-	for ( ; i < 64; ++i)
-		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+  for (i = 0, j = 0; i < 16; ++i, j += 4) {
+    m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+  }
+  for ( ; i < 64; ++i) {
+    m[i] = sig1(m[i - 2]) + m[i - 7] + sig0(m[i - 15]) + m[i - 16];
+  }
 
-	a = ctx->state[0];
-	b = ctx->state[1];
-	c = ctx->state[2];
-	d = ctx->state[3];
-	e = ctx->state[4];
-	f = ctx->state[5];
-	g = ctx->state[6];
-	h = ctx->state[7];
+  a = ctx->state[0];
+  b = ctx->state[1];
+  c = ctx->state[2];
+  d = ctx->state[3];
+  e = ctx->state[4];
+  f = ctx->state[5];
+  g = ctx->state[6];
+  h = ctx->state[7];
 
-	for (i = 0; i < 64; ++i) {
-		t1 = h + EP1(e) + CH(e,f,g) + k[i] + m[i];
-		t2 = EP0(a) + MAJ(a,b,c);
-		h = g;
-		g = f;
-		f = e;
-		e = d + t1;
-		d = c;
-		c = b;
-		b = a;
-		a = t1 + t2;
-	}
+  for (i = 0; i < 64; ++i) {
+    t1 = h + ep1(e) + ch(e, f, g) + k[i] + m[i];
+    t2 = ep0(a) + maj(a, b, c);
+    h = g;
+    g = f;
+    f = e;
+    e = d + t1;
+    d = c;
+    c = b;
+    b = a;
+    a = t1 + t2;
+  }
 
-	ctx->state[0] += a;
-	ctx->state[1] += b;
-	ctx->state[2] += c;
-	ctx->state[3] += d;
-	ctx->state[4] += e;
-	ctx->state[5] += f;
-	ctx->state[6] += g;
-	ctx->state[7] += h;
+  ctx->state[0] += a;
+  ctx->state[1] += b;
+  ctx->state[2] += c;
+  ctx->state[3] += d;
+  ctx->state[4] += e;
+  ctx->state[5] += f;
+  ctx->state[6] += g;
+  ctx->state[7] += h;
 }
 
 rcutils_ret_t rcutils_sha256_init(rcutils_sha256_ctx_t * ctx)
 {
-	ctx->datalen = 0;
-	ctx->bitlen = 0;
-	ctx->state[0] = 0x6a09e667;
-	ctx->state[1] = 0xbb67ae85;
-	ctx->state[2] = 0x3c6ef372;
-	ctx->state[3] = 0xa54ff53a;
-	ctx->state[4] = 0x510e527f;
-	ctx->state[5] = 0x9b05688c;
-	ctx->state[6] = 0x1f83d9ab;
-	ctx->state[7] = 0x5be0cd19;
+  ctx->datalen = 0;
+  ctx->bitlen = 0;
+  ctx->state[0] = 0x6a09e667;
+  ctx->state[1] = 0xbb67ae85;
+  ctx->state[2] = 0x3c6ef372;
+  ctx->state[3] = 0xa54ff53a;
+  ctx->state[4] = 0x510e527f;
+  ctx->state[5] = 0x9b05688c;
+  ctx->state[6] = 0x1f83d9ab;
+  ctx->state[7] = 0x5be0cd19;
 
-    return RCUTILS_RET_OK;
+  return RCUTILS_RET_OK;
 }
 
 rcutils_ret_t rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data[], size_t len)
 {
-	uint32_t i;
+  uint32_t i;
 
-	for (i = 0; i < len; ++i) {
-		ctx->data[ctx->datalen] = data[i];
-		ctx->datalen++;
-		if (ctx->datalen == 64) {
-			sha256_transform(ctx, ctx->data);
-			ctx->bitlen += 512;
-			ctx->datalen = 0;
-		}
-	}
+  for (i = 0; i < len; ++i) {
+    ctx->data[ctx->datalen] = data[i];
+    ctx->datalen++;
+    if (ctx->datalen == 64) {
+      sha256_transform(ctx, ctx->data);
+      ctx->bitlen += 512;
+      ctx->datalen = 0;
+    }
+  }
 
-    return RCUTILS_RET_OK;
+  return RCUTILS_RET_OK;
 }
 
 rcutils_ret_t rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[])
 {
-	uint32_t i;
+  uint32_t i;
 
-	i = ctx->datalen;
+  i = ctx->datalen;
 
-	// Pad whatever data is left in the buffer.
-	if (ctx->datalen < 56) {
-		ctx->data[i++] = 0x80;
-		while (i < 56)
-			ctx->data[i++] = 0x00;
-	}
-	else {
-		ctx->data[i++] = 0x80;
-		while (i < 64)
-			ctx->data[i++] = 0x00;
-		sha256_transform(ctx, ctx->data);
-		memset(ctx->data, 0, 56);
-	}
+  // Pad whatever data is left in the buffer.
+  if (ctx->datalen < 56) {
+    ctx->data[i++] = 0x80;
+    while (i < 56) {
+      ctx->data[i++] = 0x00;
+    }
+  } else {
+    ctx->data[i++] = 0x80;
+    while (i < 64) {
+      ctx->data[i++] = 0x00;
+    }
+    sha256_transform(ctx, ctx->data);
+    memset(ctx->data, 0, 56);
+  }
 
-	// Append to the padding the total message's length in bits and transform.
-	ctx->bitlen += ctx->datalen * 8;
-	ctx->data[63] = (uint8_t)(ctx->bitlen);
-	ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
-	ctx->data[61] = (uint8_t)(ctx->bitlen >> 16);
-	ctx->data[60] = (uint8_t)(ctx->bitlen >> 24);
-	ctx->data[59] = (uint8_t)(ctx->bitlen >> 32);
-	ctx->data[58] = (uint8_t)(ctx->bitlen >> 40);
-	ctx->data[57] = (uint8_t)(ctx->bitlen >> 48);
-	ctx->data[56] = (uint8_t)(ctx->bitlen >> 56);
-	sha256_transform(ctx, ctx->data);
+  // Append to the padding the total message's length in bits and transform.
+  ctx->bitlen += ctx->datalen * 8;
+  ctx->data[63] = (uint8_t)(ctx->bitlen);
+  ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
+  ctx->data[61] = (uint8_t)(ctx->bitlen >> 16);
+  ctx->data[60] = (uint8_t)(ctx->bitlen >> 24);
+  ctx->data[59] = (uint8_t)(ctx->bitlen >> 32);
+  ctx->data[58] = (uint8_t)(ctx->bitlen >> 40);
+  ctx->data[57] = (uint8_t)(ctx->bitlen >> 48);
+  ctx->data[56] = (uint8_t)(ctx->bitlen >> 56);
+  sha256_transform(ctx, ctx->data);
 
-	// Since this implementation uses little endian byte ordering and SHA uses big endian,
-	// reverse all the bytes when copying the final state to the output hash.
-	for (i = 0; i < 4; ++i) {
-		hash[i]      = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 4]  = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 8]  = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
-		hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
-	}
+  // Since this implementation uses little endian byte ordering and SHA uses big endian,
+  // reverse all the bytes when copying the final state to the output hash.
+  for (i = 0; i < 4; ++i) {
+    hash[i + 0] = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 4] = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 8] = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+  }
 
-    return RCUTILS_RET_OK;
+  return RCUTILS_RET_OK;
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -119,7 +119,7 @@ void rcutils_sha256_init(rcutils_sha256_ctx_t * ctx)
   ctx->state[7] = 0x5be0cd19;
 }
 
-void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data, size_t len)
+void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, size_t len)
 {
   uint32_t i;
 
@@ -136,9 +136,9 @@ void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data, size_
 
 void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[RCUTILS_SHA256_BLOCK_SIZE])
 {
-  uint32_t i
-  i = ctx->datalen;
+  uint32_t i = ctx->datalen;
 
+  // Pad whatever data is left in the buffer.
   if (ctx->datalen < 56) {
     ctx->data[i++] = 0x80;
     while (i < 56) {
@@ -155,7 +155,7 @@ void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[RCUTILS_SHA25
 
   // Append to the padding the total message's length in bits and transform.
   ctx->bitlen += ctx->datalen * 8;
-  ctx->data[63] = (uint8_t)(ctx->bitlen);
+  ctx->data[63] = (uint8_t)(ctx->bitlen >> 0);
   ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
   ctx->data[61] = (uint8_t)(ctx->bitlen >> 16);
   ctx->data[60] = (uint8_t)(ctx->bitlen >> 24);
@@ -168,7 +168,7 @@ void rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[RCUTILS_SHA25
   // Since this implementation uses little endian byte ordering and SHA uses big endian,
   // reverse all the bytes when copying the final state to the output hash.
   for (i = 0; i < 4; ++i) {
-    hash[i] = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+    hash[i + 0] = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
     hash[i + 4] = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
     hash[i + 8] = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
     hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -132,7 +132,6 @@ void rcutils_sha256_init(rcutils_sha256_ctx_t * ctx)
   ctx->state[7] = 0x5be0cd19;
 }
 
-#include <stdio.h>
 void rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t * data, size_t len)
 {
   size_t i, data_remaining, block_remaining, copy_len;
@@ -163,13 +162,11 @@ void rcutils_sha256_final(
   // Pad whatever data is left in the buffer.
   if (ctx->datalen < 56) {
     ctx->data[i++] = 0x80;
-    while (i < 56) {
-      ctx->data[i++] = 0x00;
-    }
+    memset(ctx->data + i, 0x00, 56 - i);
   } else {
     ctx->data[i++] = 0x80;
-    while (i < 64) {
-      ctx->data[i++] = 0x00;
+    if (i < 64) {
+      memset(ctx->data + i, 0x00, 64 - i);
     }
     sha256_transform(ctx);
     memset(ctx->data, 0, 56);

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -1,0 +1,169 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <string.h>
+
+#include "rcutils/sha256.h"
+
+#define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
+#define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))
+
+#define CH(x,y,z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x,y,z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x,2) ^ ROTRIGHT(x,13) ^ ROTRIGHT(x,22))
+#define EP1(x) (ROTRIGHT(x,6) ^ ROTRIGHT(x,11) ^ ROTRIGHT(x,25))
+#define SIG0(x) (ROTRIGHT(x,7) ^ ROTRIGHT(x,18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x,17) ^ ROTRIGHT(x,19) ^ ((x) >> 10))
+
+static const uint32_t k[64] = {
+	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
+void sha256_transform(rcutils_sha256_ctx_t * ctx, const uint8_t data[])
+{
+	uint32_t a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+
+	for (i = 0, j = 0; i < 16; ++i, j += 4)
+		m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+	for ( ; i < 64; ++i)
+		m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+	a = ctx->state[0];
+	b = ctx->state[1];
+	c = ctx->state[2];
+	d = ctx->state[3];
+	e = ctx->state[4];
+	f = ctx->state[5];
+	g = ctx->state[6];
+	h = ctx->state[7];
+
+	for (i = 0; i < 64; ++i) {
+		t1 = h + EP1(e) + CH(e,f,g) + k[i] + m[i];
+		t2 = EP0(a) + MAJ(a,b,c);
+		h = g;
+		g = f;
+		f = e;
+		e = d + t1;
+		d = c;
+		c = b;
+		b = a;
+		a = t1 + t2;
+	}
+
+	ctx->state[0] += a;
+	ctx->state[1] += b;
+	ctx->state[2] += c;
+	ctx->state[3] += d;
+	ctx->state[4] += e;
+	ctx->state[5] += f;
+	ctx->state[6] += g;
+	ctx->state[7] += h;
+}
+
+rcutils_ret_t rcutils_sha256_init(rcutils_sha256_ctx_t * ctx)
+{
+	ctx->datalen = 0;
+	ctx->bitlen = 0;
+	ctx->state[0] = 0x6a09e667;
+	ctx->state[1] = 0xbb67ae85;
+	ctx->state[2] = 0x3c6ef372;
+	ctx->state[3] = 0xa54ff53a;
+	ctx->state[4] = 0x510e527f;
+	ctx->state[5] = 0x9b05688c;
+	ctx->state[6] = 0x1f83d9ab;
+	ctx->state[7] = 0x5be0cd19;
+
+    return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t rcutils_sha256_update(rcutils_sha256_ctx_t * ctx, const uint8_t data[], size_t len)
+{
+	uint32_t i;
+
+	for (i = 0; i < len; ++i) {
+		ctx->data[ctx->datalen] = data[i];
+		ctx->datalen++;
+		if (ctx->datalen == 64) {
+			sha256_transform(ctx, ctx->data);
+			ctx->bitlen += 512;
+			ctx->datalen = 0;
+		}
+	}
+
+    return RCUTILS_RET_OK;
+}
+
+rcutils_ret_t rcutils_sha256_final(rcutils_sha256_ctx_t * ctx, uint8_t hash[])
+{
+	uint32_t i;
+
+	i = ctx->datalen;
+
+	// Pad whatever data is left in the buffer.
+	if (ctx->datalen < 56) {
+		ctx->data[i++] = 0x80;
+		while (i < 56)
+			ctx->data[i++] = 0x00;
+	}
+	else {
+		ctx->data[i++] = 0x80;
+		while (i < 64)
+			ctx->data[i++] = 0x00;
+		sha256_transform(ctx, ctx->data);
+		memset(ctx->data, 0, 56);
+	}
+
+	// Append to the padding the total message's length in bits and transform.
+	ctx->bitlen += ctx->datalen * 8;
+	ctx->data[63] = (uint8_t)(ctx->bitlen);
+	ctx->data[62] = (uint8_t)(ctx->bitlen >> 8);
+	ctx->data[61] = (uint8_t)(ctx->bitlen >> 16);
+	ctx->data[60] = (uint8_t)(ctx->bitlen >> 24);
+	ctx->data[59] = (uint8_t)(ctx->bitlen >> 32);
+	ctx->data[58] = (uint8_t)(ctx->bitlen >> 40);
+	ctx->data[57] = (uint8_t)(ctx->bitlen >> 48);
+	ctx->data[56] = (uint8_t)(ctx->bitlen >> 56);
+	sha256_transform(ctx, ctx->data);
+
+	// Since this implementation uses little endian byte ordering and SHA uses big endian,
+	// reverse all the bytes when copying the final state to the output hash.
+	for (i = 0; i < 4; ++i) {
+		hash[i]      = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 4]  = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 8]  = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+		hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+	}
+
+    return RCUTILS_RET_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/test_sha256.cpp
+++ b/test/test_sha256.cpp
@@ -1,0 +1,69 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcutils/sha256.h"
+
+TEST(TestSHA256, test_text1) {
+  uint8_t text1[] = {"abc"};
+  uint8_t hash1[RCUTILS_SHA256_BLOCK_SIZE] = {
+    0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+    0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+    0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad};
+  uint8_t buf[RCUTILS_SHA256_BLOCK_SIZE];
+
+
+  rcutils_sha256_ctx_t ctx;
+  rcutils_sha256_init(&ctx);
+  rcutils_sha256_update(&ctx, text1, sizeof(text1));
+  rcutils_sha256_final(&ctx, buf);
+
+  for (int i = 0; i < 32; i++) {
+    printf("%x ", buf[0]);
+  }
+  printf("\n");
+
+  ASSERT_EQ(0, memcmp(hash1, buf, RCUTILS_SHA256_BLOCK_SIZE));
+}
+
+// int sha256_test()
+// {
+//   BYTE text2[] = {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"};
+//   BYTE text3[] = {"aaaaaaaaaa"};
+//   BYTE hash2[SHA256_BLOCK_SIZE] = {
+// 0x24,0x8d,0x6a,0x61,0xd2,0x06,0x38,0xb8,0xe5,0xc0,0x26,0x93,0x0c,0x3e,0x60,0x39,
+// 0xa3,0x3c,0xe4,0x59,0x64,0xff,0x21,0x67,0xf6,0xec,0xed,0xd4,0x19,0xdb,0x06,0xc1};
+//   BYTE hash3[SHA256_BLOCK_SIZE] = {
+// 0xcd,0xc7,0x6e,0x5c,0x99,0x14,0xfb,0x92,0x81,0xa1,0xc7,0xe2,0x84,0xd7,0x3e,0x67,
+// 0xf1,0x80,0x9a,0x48,0xa4,0x97,0x20,0x0e,0x04,0x6d,0x39,0xcc,0xc7,0x11,0x2c,0xd0};
+//   BYTE buf[SHA256_BLOCK_SIZE];
+//   SHA256_CTX ctx;
+//   int idx;
+//   int pass = 1;
+
+//   sha256_init(&ctx);
+//   sha256_update(&ctx, text2, strlen(text2));
+//   sha256_final(&ctx, buf);
+//   pass = pass && !memcmp(hash2, buf, SHA256_BLOCK_SIZE);
+
+//   sha256_init(&ctx);
+//   for (idx = 0; idx < 100000; ++idx)
+//      sha256_update(&ctx, text3, strlen(text3));
+//   sha256_final(&ctx, buf);
+//   pass = pass && !memcmp(hash3, buf, SHA256_BLOCK_SIZE);
+
+//   return(pass);
+// }

--- a/test/test_sha256.cpp
+++ b/test/test_sha256.cpp
@@ -19,7 +19,7 @@
 TEST(TestSHA256, test_text1) {
   uint8_t text1[] = {"abc"};
   size_t text1_len = sizeof(text1) - 1;
-  uint8_t hash1[RCUTILS_SHA256_BLOCK_SIZE] = {
+  uint8_t expected_hash1[RCUTILS_SHA256_BLOCK_SIZE] = {
     0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
     0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
     0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
@@ -32,13 +32,13 @@ TEST(TestSHA256, test_text1) {
   rcutils_sha256_update(&ctx, text1, text1_len);
   rcutils_sha256_final(&ctx, buf);
 
-  ASSERT_EQ(0, memcmp(hash1, buf, RCUTILS_SHA256_BLOCK_SIZE));
+  ASSERT_EQ(0, memcmp(expected_hash1, buf, RCUTILS_SHA256_BLOCK_SIZE));
 }
 
 TEST(TestSHA256, test_text2) {
   uint8_t text2[] = {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"};
   size_t text2_len = sizeof(text2) - 1;
-  uint8_t hash2[RCUTILS_SHA256_BLOCK_SIZE] = {
+  uint8_t expected_hash2[RCUTILS_SHA256_BLOCK_SIZE] = {
     0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8,
     0xe5, 0xc0, 0x26, 0x93, 0x0c, 0x3e, 0x60, 0x39,
     0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
@@ -50,14 +50,14 @@ TEST(TestSHA256, test_text2) {
   rcutils_sha256_update(&ctx, text2, text2_len);
   rcutils_sha256_final(&ctx, buf);
 
-  ASSERT_EQ(0, memcmp(hash2, buf, RCUTILS_SHA256_BLOCK_SIZE));
+  ASSERT_EQ(0, memcmp(expected_hash2, buf, RCUTILS_SHA256_BLOCK_SIZE));
 }
 
 TEST(TestSHA256, test_multi_update) {
   uint8_t text[] = {"aaaaaaaaaa"};
   size_t text_len = sizeof(text) - 1;
 
-  uint8_t hash[RCUTILS_SHA256_BLOCK_SIZE] = {
+  uint8_t expected_hash[RCUTILS_SHA256_BLOCK_SIZE] = {
     0x28, 0x16, 0x59, 0x78, 0x88, 0xe4, 0xa0, 0xd3,
     0xa3, 0x6b, 0x82, 0xb8, 0x33, 0x16, 0xab, 0x32,
     0x68, 0x0e, 0xb8, 0xf0, 0x0f, 0x8c, 0xd3, 0xb9,
@@ -71,5 +71,5 @@ TEST(TestSHA256, test_multi_update) {
   }
   rcutils_sha256_final(&ctx, buf);
 
-  ASSERT_EQ(0, memcmp(hash, buf, RCUTILS_SHA256_BLOCK_SIZE));
+  ASSERT_EQ(0, memcmp(expected_hash, buf, RCUTILS_SHA256_BLOCK_SIZE));
 }

--- a/test/test_sha256.cpp
+++ b/test/test_sha256.cpp
@@ -18,6 +18,7 @@
 
 TEST(TestSHA256, test_text1) {
   uint8_t text1[] = {"abc"};
+  size_t text1_len = sizeof(text1) - 1;
   uint8_t hash1[RCUTILS_SHA256_BLOCK_SIZE] = {
     0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
     0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
@@ -28,42 +29,47 @@ TEST(TestSHA256, test_text1) {
 
   rcutils_sha256_ctx_t ctx;
   rcutils_sha256_init(&ctx);
-  rcutils_sha256_update(&ctx, text1, sizeof(text1));
+  rcutils_sha256_update(&ctx, text1, text1_len);
   rcutils_sha256_final(&ctx, buf);
-
-  for (int i = 0; i < 32; i++) {
-    printf("%x ", buf[0]);
-  }
-  printf("\n");
 
   ASSERT_EQ(0, memcmp(hash1, buf, RCUTILS_SHA256_BLOCK_SIZE));
 }
 
-// int sha256_test()
-// {
-//   BYTE text2[] = {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"};
-//   BYTE text3[] = {"aaaaaaaaaa"};
-//   BYTE hash2[SHA256_BLOCK_SIZE] = {
-// 0x24,0x8d,0x6a,0x61,0xd2,0x06,0x38,0xb8,0xe5,0xc0,0x26,0x93,0x0c,0x3e,0x60,0x39,
-// 0xa3,0x3c,0xe4,0x59,0x64,0xff,0x21,0x67,0xf6,0xec,0xed,0xd4,0x19,0xdb,0x06,0xc1};
-//   BYTE hash3[SHA256_BLOCK_SIZE] = {
-// 0xcd,0xc7,0x6e,0x5c,0x99,0x14,0xfb,0x92,0x81,0xa1,0xc7,0xe2,0x84,0xd7,0x3e,0x67,
-// 0xf1,0x80,0x9a,0x48,0xa4,0x97,0x20,0x0e,0x04,0x6d,0x39,0xcc,0xc7,0x11,0x2c,0xd0};
-//   BYTE buf[SHA256_BLOCK_SIZE];
-//   SHA256_CTX ctx;
-//   int idx;
-//   int pass = 1;
+TEST(TestSHA256, test_text2) {
+  uint8_t text2[] = {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"};
+  size_t text2_len = sizeof(text2) - 1;
+  uint8_t hash2[RCUTILS_SHA256_BLOCK_SIZE] = {
+    0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8,
+    0xe5, 0xc0, 0x26, 0x93, 0x0c, 0x3e, 0x60, 0x39,
+    0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
+    0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1};
+  uint8_t buf[RCUTILS_SHA256_BLOCK_SIZE];
 
-//   sha256_init(&ctx);
-//   sha256_update(&ctx, text2, strlen(text2));
-//   sha256_final(&ctx, buf);
-//   pass = pass && !memcmp(hash2, buf, SHA256_BLOCK_SIZE);
+  rcutils_sha256_ctx_t ctx;
+  rcutils_sha256_init(&ctx);
+  rcutils_sha256_update(&ctx, text2, text2_len);
+  rcutils_sha256_final(&ctx, buf);
 
-//   sha256_init(&ctx);
-//   for (idx = 0; idx < 100000; ++idx)
-//      sha256_update(&ctx, text3, strlen(text3));
-//   sha256_final(&ctx, buf);
-//   pass = pass && !memcmp(hash3, buf, SHA256_BLOCK_SIZE);
+  ASSERT_EQ(0, memcmp(hash2, buf, RCUTILS_SHA256_BLOCK_SIZE));
+}
 
-//   return(pass);
-// }
+TEST(TestSHA256, test_multi_update) {
+  uint8_t text[] = {"aaaaaaaaaa"};
+  size_t text_len = sizeof(text) - 1;
+
+  uint8_t hash[RCUTILS_SHA256_BLOCK_SIZE] = {
+    0x28, 0x16, 0x59, 0x78, 0x88, 0xe4, 0xa0, 0xd3,
+    0xa3, 0x6b, 0x82, 0xb8, 0x33, 0x16, 0xab, 0x32,
+    0x68, 0x0e, 0xb8, 0xf0, 0x0f, 0x8c, 0xd3, 0xb9,
+    0x04, 0xd6, 0x81, 0x24, 0x6d, 0x28, 0x5a, 0x0e};
+  uint8_t buf[RCUTILS_SHA256_BLOCK_SIZE];
+
+  rcutils_sha256_ctx_t ctx;
+  rcutils_sha256_init(&ctx);
+  for (int i = 0; i < 10; i++) {
+    rcutils_sha256_update(&ctx, text, text_len);
+  }
+  rcutils_sha256_final(&ctx, buf);
+
+  ASSERT_EQ(0, memcmp(hash, buf, RCUTILS_SHA256_BLOCK_SIZE));
+}


### PR DESCRIPTION
To be used for REP-2011 type version hashing.
Simple sha256 implementation to generate a 256-byte message digest for any data. Implementation originally copied from Brad Conte https://github.com/B-Con/crypto-algorithms, with modifications to fit code style and fix compiler warnings.

Prereq for ros2/rcl#1027
Part of https://github.com/ros2/ros2/issues/1159