### PR TITLE
Out of bounds range check

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -976,7 +976,7 @@ rcutils_ret_t rcutils_logging_set_logger_level(const char * name, int level)
 
   // Convert the severity value into a string for storage.
   if (level < 0 ||
-    level >=
+    level >
     (int)(sizeof(g_rcutils_log_severity_names) / sizeof(g_rcutils_log_severity_names[0])))
   {
     RCUTILS_SET_ERROR_MSG("Invalid severity level specified for logger");


### PR DESCRIPTION
Not tested!

I think this should be ">" instead of ">= ":
https://github.com/ros2/rcutils/blob/1db1f16a49378f4693b74296449ee920ff53cffe/src/logging.c#L978-L980
As you want `level` to be in the range [0, 5] and not [0, 6]. https://github.com/ros2/rcutils/blob/1db1f16a49378f4693b74296449ee920ff53cffe/src/logging.c#L68-L75

Similar to this:
https://github.com/ros2/rcutils/blob/1db1f16a49378f4693b74296449ee920ff53cffe/src/logging.c#L720-L721