### PR TITLE
Remove unused 'max' functions from sha256.c

### DIFF
--- a/src/sha256.c
+++ b/src/sha256.c
@@ -22,11 +22,6 @@ static inline size_t min(size_t a, size_t b)
   return a < b ? a : b;
 }
 
-static inline size_t max(size_t a, size_t b)
-{
-  return a > b ? a : b;
-}
-
 static inline uint32_t rotright(uint32_t a, const uint8_t b)
 {
   assert(b < 32);


### PR DESCRIPTION
Pointed out by building with clang.  I'm actually quite surprised that none of the rest of our compilers pointed this out.

@emersonknapp FYI