### PR TITLE
Add rcutils_static_assert to abstract platform

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -121,8 +121,7 @@ typedef struct rcutils_error_state_s
 } rcutils_error_state_t;
 
 // make sure our math is right...
-#if __STDC_VERSION__ >= 201112L
-static_assert(
+RCUTILS_STATIC_ASSERT(
   sizeof(rcutils_error_string_t) == (
     RCUTILS_ERROR_STATE_MESSAGE_MAX_LENGTH +
     RCUTILS_ERROR_STATE_FILE_MAX_LENGTH +
@@ -130,7 +129,6 @@ static_assert(
     RCUTILS_ERROR_FORMATTING_CHARACTERS +
     1 /* null terminating character */),
   "Maximum length calculations incorrect");
-#endif
 
 /// Forces initialization of thread-local storage if called in a newly created thread.
 /**

--- a/include/rcutils/macros.h
+++ b/include/rcutils/macros.h
@@ -157,6 +157,14 @@ extern "C"
 # define RCUTILS_HAS_NONNULL 0
 #endif  // _WIN32
 
+#ifndef static_assert
+# if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201100L)
+#  define RCUTILS_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+# endif   // defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201100L)
+#else
+# define RCUTILS_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#endif
+
 #if defined RCUTILS_ENABLE_FAULT_INJECTION
 #include "rcutils/testing/fault_injection.h"
 

--- a/src/error_handling.c
+++ b/src/error_handling.c
@@ -200,7 +200,7 @@ rcutils_set_error_state(
   // Only warn of overwritting if the new error is different from the old ones.
   size_t characters_to_compare = strnlen(error_string, RCUTILS_ERROR_MESSAGE_MAX_LENGTH);
   // assumption is that message length is <= max error string length
-  static_assert(
+  RCUTILS_STATIC_ASSERT(
     sizeof(gtls_rcutils_error_state.message) <= sizeof(gtls_rcutils_error_string.str),
     "expected error state's max message length to be less than or equal to error string max");
   if (

--- a/src/error_handling_helpers.h
+++ b/src/error_handling_helpers.h
@@ -145,7 +145,7 @@ __rcutils_format_error_string(
   static const char format_1[] = ", at ";
   static const char format_2[] = ":";
   char line_number_buffer[21];
-  static_assert(
+  RCUTILS_STATIC_ASSERT(
     sizeof(error_string->str) == (
       sizeof(error_state->message) +
       sizeof(format_1) - 1 /* minus the null-term */ +


### PR DESCRIPTION
Some compiler combinations seem to have an issue with `static_assert`.  In this case, I'm specifically running into the `gcc12` version that comes by default with conda not having the macro defined at all.  Similar issues have been reported in other places (https://github.com/ggerganov/llama.cpp/issues/2024) and patched here: https://github.com/RoboStack/ros-humble/blob/main/patch/ros-humble-rcutils.patch

This seems like a cleaner approach by just making a universal RCUTILS macro and defining it as necessary.