### PR TITLE
Allow parsing of escape sequence in log format

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -87,8 +87,10 @@ bool g_rcutils_logging_initialized = false;
 static char g_rcutils_logging_output_format_string[RCUTILS_LOGGING_MAX_OUTPUT_FORMAT_LEN];
 static const char * g_rcutils_logging_default_output_format =
   "[{severity}] [{time}] [{name}]: {message}";
+#ifdef _WIN32
 static DWORD g_original_console_mode = 0;
 static bool g_consol_mode_modified = false;
+#endif 
 
 static rcutils_allocator_t g_rcutils_logging_allocator;
 
@@ -793,9 +795,11 @@ rcutils_ret_t rcutils_logging_shutdown(void)
   g_num_log_msg_handlers = 0;
   g_rcutils_logging_initialized = false;
 
+  #ifdef _WIN32
   if (g_consol_mode_modified){
     SetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), g_original_console_mode);
   }
+  #endif
   return ret;
 }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -440,14 +440,25 @@ static void create_format_string(
       break;
     } else {
       const char * expected_char = NULL;
-      switch (logging_output_format_string[i + back_slash_index + 1]) {
-        case 'a':  expected_char = "\a"; break;  // alert
-        case 'b':  expected_char = "\b"; break;  // backspace
-        case 'n':  expected_char = "\n"; break;  // new line
-        case 'r':  expected_char = "\r"; break;  // carriage return
-        case 't':  expected_char = "\t"; break;  // horizontal tab
-        default:
-          break;
+      int skip_chars = 0;
+
+      if (logging_output_format_string[i + back_slash_index + 1] == 'x' &&
+        logging_output_format_string[i + back_slash_index + 2] == '1' &&
+        logging_output_format_string[i + back_slash_index + 3] == 'b')
+      {
+        // detect escape sequence
+        expected_char = "\x1b";
+        skip_chars = 2;
+      } else {
+        switch (logging_output_format_string[i + back_slash_index + 1]) {
+          case 'a':  expected_char = "\a"; break;  // alert
+          case 'b':  expected_char = "\b"; break;  // backspace
+          case 'n':  expected_char = "\n"; break;  // new line
+          case 'r':  expected_char = "\r"; break;  // carriage return
+          case 't':  expected_char = "\t"; break;  // horizontal tab
+          default:
+            break;
+        }
       }
 
       if (expected_char) {
@@ -466,12 +477,12 @@ static void create_format_string(
         // copy the decoded character
         g_rcutils_logging_output_format_string[dest_buffer_index] = expected_char[0];
         dest_buffer_index += 1;
-        start_offset += 2;
+        start_offset += 2 + skip_chars;
       } else {
         start_offset_previous_not_copy += (back_slash_index + 2);
       }
 
-      i += (back_slash_index + 2);
+      i += (back_slash_index + 2 + skip_chars);
     }
   }
 }

--- a/src/logging.c
+++ b/src/logging.c
@@ -90,7 +90,7 @@ static const char * g_rcutils_logging_default_output_format =
 #ifdef _WIN32
 static DWORD g_original_console_mode = 0;
 static bool g_consol_mode_modified = false;
-#endif 
+#endif
 
 static rcutils_allocator_t g_rcutils_logging_allocator;
 
@@ -423,19 +423,16 @@ static const char * copy_from_orig(
 #define ACTIVATE_VIRTUAL_TERMINAL_PROCESSING() \
   { \
     HANDLE std_error_handle = GetStdHandle(STD_ERROR_HANDLE); \
-    if (std_error_handle == INVALID_HANDLE_VALUE) \
-    { \
-        RCUTILS_SET_ERROR_MSG("Could not get error handle to activating virtual terminal."); \
-        return; \
+    if (std_error_handle == INVALID_HANDLE_VALUE) { \
+      RCUTILS_SET_ERROR_MSG("Could not get error handle to activating virtual terminal."); \
+      return; \
     } \
-    if (! GetConsoleMode(std_error_handle, &g_original_console_mode)) \
-    { \
+    if (!GetConsoleMode(std_error_handle, &g_original_console_mode)) { \
       RCUTILS_SET_ERROR_MSG("Could not get consol mode to activating virtual terminal."); \
       return; \
     } \
     DWORD newDwMode = g_original_console_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING; \
-    if (! SetConsoleMode(std_error_handle, newDwMode)) \
-    { \
+    if (!SetConsoleMode(std_error_handle, newDwMode)) { \
       RCUTILS_SET_ERROR_MSG("Could not set consol mode to activating virtual terminal."); \
       return; \
     } \
@@ -796,7 +793,7 @@ rcutils_ret_t rcutils_logging_shutdown(void)
   g_rcutils_logging_initialized = false;
 
   #ifdef _WIN32
-  if (g_consol_mode_modified){
+  if (g_consol_mode_modified) {
     SetConsoleMode(GetStdHandle(STD_ERROR_HANDLE), g_original_console_mode);
   }
   #endif

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -91,6 +91,16 @@ def generate_test_description():
     ))
     processes_to_test.append(name)
 
+    env_escape_sequence = dict(os.environ)
+    # This custom output is to check that escape characters work correctly.
+    env_escape_sequence['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = \
+        r'{name} \x1b[0m {message}'
+    name = 'test_logging_output_format_escape_sequence'
+    launch_description.add_action(ExecuteProcess(
+        cmd=[executable], env=env_escape_sequence, name=name, output='screen'
+    ))
+    processes_to_test.append(name)
+
     launch_description.add_action(
         launch_testing.actions.ReadyToTest()
     )

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -127,7 +127,8 @@ class TestLoggingOutputFormatAfterShutdown(unittest.TestCase):
                     path=os.path.join(os.path.dirname(__file__), process_name),
                     encoding='unicode_escape'
                 ),
-                process=process_name
+                process=process_name,
+                strip_ansi_escape_sequences=False
             )
 
     def test_processes_exit_codes(self, proc_info):

--- a/test/test_logging_output_format.py
+++ b/test/test_logging_output_format.py
@@ -94,7 +94,7 @@ def generate_test_description():
     env_escape_sequence = dict(os.environ)
     # This custom output is to check that escape characters work correctly.
     env_escape_sequence['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = \
-        r'{name} \x1b[0m {message}'
+        '{name} \x1b[0m {message}'
     name = 'test_logging_output_format_escape_sequence'
     launch_description.add_action(ExecuteProcess(
         cmd=[executable], env=env_escape_sequence, name=name, output='screen'

--- a/test/test_logging_output_format_escape_sequence.regex
+++ b/test/test_logging_output_format_escape_sequence.regex
@@ -1,0 +1,2 @@
+name1 \x1b\[0m Xx{2045}X
+name2 \x1b\[0m X42x{2043}X


### PR DESCRIPTION
This is an extendion of https://github.com/ros2/rcutils/pull/426 which allowed the usage of control codes (i.e. \a, \b, \n, \r, \t) in the log format. This PR adds parsing of the escape character \x1b (also known as \033 or \e).
The motivation is that this allows using [Select Graphic Rendition parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters).
Their usage allows setting of bold, faint, italic and/or underline to make the logging output of the screen better readable. This is especially interesting to highlight parts of the logging output (the actual message) while giving less focus to additional information (e.g. the function name, file name or line number).

Example: 
`RCUTILS_CONSOLE_OUTPUT_FORMAT="\x1b[4m{name}\x1b[24m \x1b[1m{message}\x1b[0m \x1b[2m{function_name} \x1b[3m{file_name}:{line_number} \x1b[0m"`
![grafik](https://github.com/ros2/rcutils/assets/11520148/9f96de31-4ded-4a31-8d28-c29e5e9d9091)


Side node: 
I chose the '\x1b' representation instead of the '\e' since this would result in the following compiler warning:
`warning: non-ISO-standard escape sequence, '\e'`
This makes the parsing a bit more complex since we have a 4 character input that is parsed to a 2 character output (while the other control codes are 2->1).
I just decided on this approach to ensure sticking to the ISO standard. However, it would also be fine for me to use '\e'.

I will also add an update to the documentation if the PR is accepted.