### PR TITLE
Make rcutils_split() return RCUTILS_RET_BAD_ALLOC if alloc fails

### DIFF
--- a/include/rcutils/split.h
+++ b/include/rcutils/split.h
@@ -52,6 +52,7 @@ rcutils_split(
  * \param[in] allocator for allocating new memory for the output array
  * \param[out] string_array with the split tokens
  * \return #RCUTILS_RET_OK if successful, or
+ * \return #RCUTILS_RET_BAD_ALLOC if memory allocation fails, or
  * \return #RCUTILS_RET_ERROR if an unknown error occurs
  */
 RCUTILS_PUBLIC

--- a/src/split.c
+++ b/src/split.c
@@ -118,7 +118,7 @@ fail:
   }
 
   RCUTILS_SET_ERROR_MSG("unable to allocate memory for string array data");
-  return RCUTILS_RET_ERROR;
+  return RCUTILS_RET_BAD_ALLOC;
 }
 
 rcutils_ret_t

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -68,13 +68,13 @@ TEST(test_split, split) {
   rcutils_allocator_t time_bomb_allocator = get_time_bomb_allocator();
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
   EXPECT_EQ(
-    RCUTILS_RET_ERROR,
+    RCUTILS_RET_BAD_ALLOC,
     rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
 
   // Allocating string_array->data[0] fails
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
   EXPECT_EQ(
-    RCUTILS_RET_ERROR,
+    RCUTILS_RET_BAD_ALLOC,
     rcutils_split("hello/world", '/', time_bomb_allocator, &tokens_fail));
 
   rcutils_string_array_t tokens0 = test_split("", '/', 0);


### PR DESCRIPTION
`rcutils_split()`'s documentation says that it returns `RCUTILS_RET_BAD_ALLOC` if memory allocation fails, but it doesn't. Fix it and update the tests.

Also, mention `RCUTILS_RET_BAD_ALLOC` in `rcutils_split_last()`'s doc.

Note that there only seems to be one user of `rcutils_split()` in the ROS 2 core (`rcl_get_discovery_static_peers()`) and it doesn't seem to be affected by this change. I doubt it would change a caller's behaviour that much anyway.