### PR TITLE
Use rcutils_string_array_init in rcutils_split & handle alloc fail

### DIFF
--- a/src/split.c
+++ b/src/split.c
@@ -42,7 +42,6 @@ rcutils_split(
     *string_array = rcutils_get_zero_initialized_string_array();
     return RCUTILS_RET_OK;
   }
-  string_array->allocator = allocator;
 
   size_t string_size = strlen(str);
 
@@ -58,15 +57,13 @@ rcutils_split(
     rhs_offset = 1;
   }
 
-  string_array->size = 1;
+  size_t array_size = 1;
   for (size_t i = lhs_offset; i < string_size - rhs_offset; ++i) {
     if (str[i] == delimiter) {
-      ++string_array->size;
+      ++array_size;
     }
   }
-  // TODO(wjwwood): refactor this function so it can use rcutils_string_array_init() instead
-  string_array->data = allocator.allocate(string_array->size * sizeof(char *), allocator.state);
-  if (NULL == string_array->data) {
+  if (rcutils_string_array_init(string_array, array_size, &allocator) != RCUTILS_RET_OK) {
     goto fail;
   }
 
@@ -104,6 +101,9 @@ rcutils_split(
   } else {
     string_array->data[token_counter] =
       allocator.allocate((rhs - lhs + 2) * sizeof(char), allocator.state);
+    if (NULL == string_array->data[token_counter]) {
+      goto fail;
+    }
     snprintf(string_array->data[token_counter], (rhs - lhs + 1), "%s", str + lhs);
   }
 

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -64,14 +64,22 @@ TEST(test_split, split) {
     RCUTILS_RET_INVALID_ARGUMENT,
     rcutils_split("Test", '/', rcutils_get_default_allocator(), NULL));
 
-  // Allocating string_array->data fails
+  // Allocating initial string_array fails
   rcutils_allocator_t time_bomb_allocator = get_time_bomb_allocator();
+  set_time_bomb_allocator_calloc_count(time_bomb_allocator, 0);
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
+
+  // Allocating string_array->data fails
+  set_time_bomb_allocator_calloc_count(time_bomb_allocator, 1);
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 0);
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,
     rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
 
   // Allocating string_array->data[0] fails
+  set_time_bomb_allocator_calloc_count(time_bomb_allocator, 1);
   set_time_bomb_allocator_malloc_count(time_bomb_allocator, 1);
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,


### PR DESCRIPTION
Resolve the TODO by using `rcutils_string_array_init()` for the initial allocation in `rcutils_split()`, and properly handle allocation near the end of the function. Also, update the tests.

Kind of a follow-up to #444