### PR TITLE
Bring ament_add_gtest/target_link_libraries back together

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -568,6 +568,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_macros
     test/test_macros.cpp
   )
+  if(TARGET test_macros)
+    target_link_libraries(test_macros ${PROJECT_NAME})
+  endif()
 
   add_performance_test(benchmark_logging test/benchmark/benchmark_logging.cpp)
   if(TARGET benchmark_logging)
@@ -577,10 +580,6 @@ if(BUILD_TESTING)
   add_performance_test(benchmark_err_handle test/benchmark/benchmark_error_handling.cpp)
   if(TARGET benchmark_err_handle)
     target_link_libraries(benchmark_err_handle ${PROJECT_NAME})
-  endif()
-
-  if(TARGET test_macros)
-    target_link_libraries(test_macros ${PROJECT_NAME})
   endif()
 endif()
 


### PR DESCRIPTION
Simple cleanup. Some tests were added right in between `rcutils_custom_add_gtest()` and `target_link_libraries()` for `test_macros` in #288.