### PR TITLE
Updates for uncrustify 0.78.

### DIFF
--- a/include/rcutils/stdatomic_helper/win32/stdatomic.h
+++ b/include/rcutils/stdatomic_helper/win32/stdatomic.h
@@ -91,9 +91,7 @@
  */
 
 #define ATOMIC_VAR_INIT(value) {.__val = (value)}
-#define atomic_init(obj, value) do { \
-    (obj)->__val = (value); \
-} while (0)
+#define atomic_init(obj, value) do {(obj)->__val = (value);} while (0)
 
 /*
  * Clang and recent GCC both provide predefined macros for the memory

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -19,6 +19,8 @@
 #ifndef RCUTILS__LOGGING_MACROS_H_
 #define RCUTILS__LOGGING_MACROS_H_
 
+// *INDENT-OFF*
+
 #include "rcutils/logging.h"
 
 #include <stdio.h>
@@ -108,7 +110,7 @@ extern "C"
  * A macro finalizing the `once` condition.
  */
 #define RCUTILS_LOG_CONDITION_ONCE_AFTER } \
-}
+  }
 ///@@}
 
 /** @@name Macros for the `expression` condition which ignores the log calls
@@ -169,7 +171,7 @@ typedef bool (* RclLogFilter)();
  * A macro finalizing the `skipfirst` condition.
  */
 #define RCUTILS_LOG_CONDITION_SKIPFIRST_AFTER } \
-}
+  }
 ///@@}
 
 /** @@name Macros for the `throttle` condition which ignores log calls if the
@@ -181,28 +183,28 @@ typedef bool (* RclLogFilter)();
  * A macro initializing and checking the `throttle` condition.
  */
 #define RCUTILS_LOG_CONDITION_THROTTLE_BEFORE(get_time_point_value, duration) { \
-    static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS(RCUTILS_CAST_DURATION(duration)); \
-    static rcutils_time_point_value_t __rcutils_logging_last_logged = 0; \
-    rcutils_time_point_value_t __rcutils_logging_now = 0; \
-    bool __rcutils_logging_condition = true; \
-    if (get_time_point_value(&__rcutils_logging_now) != RCUTILS_RET_OK) { \
-      rcutils_log( \
-        &__rcutils_logging_location, RCUTILS_LOG_SEVERITY_ERROR, "", \
-        "%s() at %s:%d getting current steady time failed\n", \
-        __func__, __FILE__, __LINE__); \
-    } else { \
-      __rcutils_logging_condition = __rcutils_logging_now >= __rcutils_logging_last_logged + __rcutils_logging_duration; \
-    } \
+  static rcutils_duration_value_t __rcutils_logging_duration = RCUTILS_MS_TO_NS(RCUTILS_CAST_DURATION(duration)); \
+  static rcutils_time_point_value_t __rcutils_logging_last_logged = 0; \
+  rcutils_time_point_value_t __rcutils_logging_now = 0; \
+  bool __rcutils_logging_condition = true; \
+  if (get_time_point_value(&__rcutils_logging_now) != RCUTILS_RET_OK) { \
+  rcutils_log( \
+      &__rcutils_logging_location, RCUTILS_LOG_SEVERITY_ERROR, "", \
+      "%s() at %s:%d getting current steady time failed\n", \
+      __func__, __FILE__, __LINE__); \
+  } else { \
+  __rcutils_logging_condition = __rcutils_logging_now >= __rcutils_logging_last_logged + __rcutils_logging_duration; \
+  } \
  \
-    if (RCUTILS_LIKELY(__rcutils_logging_condition)) { \
-      __rcutils_logging_last_logged = __rcutils_logging_now;
+  if (RCUTILS_LIKELY(__rcutils_logging_condition)) { \
+  __rcutils_logging_last_logged = __rcutils_logging_now;
 
 /**
  * \def RCUTILS_LOG_CONDITION_THROTTLE_AFTER
  * A macro finalizing the `throttle` condition.
  */
 #define RCUTILS_LOG_CONDITION_THROTTLE_AFTER } \
-}
+  }
 ///@@}
 
 @{
@@ -256,6 +258,8 @@ from rcutils.logging import severities
 @[ end for]@
 #endif
 ///@@}
+
+// *INDENT-ON*
 
 @[end for]@
 #ifdef __cplusplus

--- a/test/test_find.cpp
+++ b/test/test_find.cpp
@@ -18,18 +18,7 @@
 
 #include "rcutils/find.h"
 
-#define ENABLE_LOGGING 1
-
-#if ENABLE_LOGGING
-#define LOG(expected, actual) do { \
-    printf("Expected: %zu Actual: %zu\n", expected, actual); \
-} while (0)
-#else
-#define LOG(X, arg) do { \
-    (void)(X); \
-    (void)(arg); \
-} while (0)
-#endif
+#define LOG(expected, actual) printf("Expected: %zu Actual: %zu\n", expected, actual);
 
 size_t test_find(const char * str, char delimiter, size_t expected_pos)
 {

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -20,14 +20,7 @@
 #include "rcutils/split.h"
 #include "rcutils/types/string_array.h"
 
-#define ENABLE_LOGGING 1
-
-#if ENABLE_LOGGING
-#define LOG(expected, actual) { \
-    printf("Expected: %s Actual: %s\n", expected, actual);}
-#else
-#define LOG(X, arg) {}
-#endif
+#define LOG(expected, actual) printf("Expected: %s Actual: %s\n", expected, actual);
 
 rcutils_string_array_t test_split(const char * str, char delimiter, size_t expected_token_size)
 {


### PR DESCRIPTION
Shorten some unnecessary macros, and add INDENT-OFF around the logging macros.