### PR TITLE
validate the allocator before use.

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -179,7 +179,6 @@ rcutils_join_path(
   const char * right_hand_path,
   rcutils_allocator_t allocator)
 {
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == left_hand_path) {
     return NULL;
   }
@@ -198,7 +197,6 @@ rcutils_to_native_path(
   const char * path,
   rcutils_allocator_t allocator)
 {
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == path) {
     return NULL;
   }
@@ -209,7 +207,6 @@ rcutils_to_native_path(
 char *
 rcutils_expand_user(const char * path, rcutils_allocator_t allocator)
 {
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == path) {
     return NULL;
   }
@@ -352,7 +349,6 @@ rcutils_calculate_directory_size_with_recursion(
   rcutils_ret_t ret = RCUTILS_RET_OK;
   rcutils_dir_iter_t * iter = NULL;
 
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == directory_path) {
     RCUTILS_SAFE_FWRITE_TO_STDERR("directory_path is NULL !");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -369,6 +365,7 @@ rcutils_calculate_directory_size_with_recursion(
     return RCUTILS_RET_ERROR;
   }
 
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   dir_list = allocator.zero_allocate(1, sizeof(dir_list_t), allocator.state);
   if (NULL == dir_list) {
     RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory !\n");

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -179,6 +179,7 @@ rcutils_join_path(
   const char * right_hand_path,
   rcutils_allocator_t allocator)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == left_hand_path) {
     return NULL;
   }
@@ -197,6 +198,7 @@ rcutils_to_native_path(
   const char * path,
   rcutils_allocator_t allocator)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == path) {
     return NULL;
   }
@@ -207,6 +209,7 @@ rcutils_to_native_path(
 char *
 rcutils_expand_user(const char * path, rcutils_allocator_t allocator)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == path) {
     return NULL;
   }
@@ -349,6 +352,7 @@ rcutils_calculate_directory_size_with_recursion(
   rcutils_ret_t ret = RCUTILS_RET_OK;
   rcutils_dir_iter_t * iter = NULL;
 
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == directory_path) {
     RCUTILS_SAFE_FWRITE_TO_STDERR("directory_path is NULL !");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -508,6 +512,8 @@ rcutils_dir_iter_end(rcutils_dir_iter_t * iter)
   }
 
   rcutils_allocator_t allocator = iter->allocator;
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "allocator is invalid", return );
   rcutils_dir_iter_state_t * state = (rcutils_dir_iter_state_t *)iter->state;
   if (NULL != state) {
 #ifdef _WIN32

--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -402,6 +402,8 @@ rcutils_hash_map_set(rcutils_hash_map_t * hash_map, const void * key, const void
   } else {
     // We need to create a new entry in the map
     rcutils_allocator_t * allocator = &hash_map->impl->allocator;
+    RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+      allocator, "allocator is invalid", return RCUTILS_RET_INVALID_ARGUMENT);
 
     // Start by trying to allocate the memory we need for the new entry
     entry = allocator->allocate(sizeof(rcutils_hash_map_entry_t), allocator->state);

--- a/src/repl_str.c
+++ b/src/repl_str.c
@@ -49,6 +49,7 @@ rcutils_repl_str(
   const char * to,
   const rcutils_allocator_t * allocator)
 {
+  RCUTILS_CHECK_ALLOCATOR(allocator, return NULL);
   /* Adjust each of the below values to suit your needs. */
 
   /* Increment positions cache size initially by this number. */

--- a/src/split.c
+++ b/src/split.c
@@ -34,6 +34,7 @@ rcutils_split(
   rcutils_allocator_t allocator,
   rcutils_string_array_t * string_array)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == string_array) {
     RCUTILS_SET_ERROR_MSG("string_array is null");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -128,6 +129,7 @@ rcutils_split_last(
   rcutils_allocator_t allocator,
   rcutils_string_array_t * string_array)
 {
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == str || strlen(str) == 0) {
     *string_array = rcutils_get_zero_initialized_string_array();
     return RCUTILS_RET_OK;

--- a/src/split.c
+++ b/src/split.c
@@ -34,7 +34,6 @@ rcutils_split(
   rcutils_allocator_t allocator,
   rcutils_string_array_t * string_array)
 {
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == string_array) {
     RCUTILS_SET_ERROR_MSG("string_array is null");
     return RCUTILS_RET_INVALID_ARGUMENT;
@@ -129,7 +128,6 @@ rcutils_split_last(
   rcutils_allocator_t allocator,
   rcutils_string_array_t * string_array)
 {
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return RCUTILS_RET_INVALID_ARGUMENT);
   if (NULL == str || strlen(str) == 0) {
     *string_array = rcutils_get_zero_initialized_string_array();
     return RCUTILS_RET_OK;

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -40,10 +40,10 @@ rcutils_strndup(const char * str, size_t max_length, rcutils_allocator_t allocat
 {
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
 
-  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == str) {
     return NULL;
   }
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   char * p = memchr(str, '\0', max_length);
   size_t string_length = p == NULL ? max_length : (size_t)(p - str);
   char * new_string = allocator.allocate(string_length + 1, allocator.state);

--- a/src/strdup.c
+++ b/src/strdup.c
@@ -40,6 +40,7 @@ rcutils_strndup(const char * str, size_t max_length, rcutils_allocator_t allocat
 {
   RCUTILS_CAN_RETURN_WITH_ERROR_OF(NULL);
 
+  RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
   if (NULL == str) {
     return NULL;
   }

--- a/src/string_map.c
+++ b/src/string_map.c
@@ -101,6 +101,8 @@ rcutils_string_map_fini(rcutils_string_map_t * string_map)
     return ret;
   }
   rcutils_allocator_t allocator = string_map->impl->allocator;
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "allocator is invalid", return RCUTILS_RET_INVALID_ARGUMENT);
 
   allocator.deallocate(string_map->impl, allocator.state);
   string_map->impl = NULL;
@@ -152,6 +154,8 @@ rcutils_string_map_reserve(rcutils_string_map_t * string_map, size_t capacity)
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     string_map->impl, "invalid string map", return RCUTILS_RET_STRING_MAP_INVALID);
   rcutils_allocator_t allocator = string_map->impl->allocator;
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "allocator is invalid", return RCUTILS_RET_INVALID_ARGUMENT);
   // short circuit, if requested capacity is less than the size of the map
   if (capacity < string_map->impl->size) {
     // set the capacity to the current size instead
@@ -276,6 +280,8 @@ rcutils_string_map_set_no_resize(
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(key, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(value, RCUTILS_RET_INVALID_ARGUMENT);
   rcutils_allocator_t allocator = string_map->impl->allocator;
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    &allocator, "allocator is invalid", return RCUTILS_RET_INVALID_ARGUMENT);
   size_t key_index;
   bool should_free_key_on_error = false;
   bool key_exists = __get_index_of_key_if_exists(string_map->impl, key, strlen(key), &key_index);


### PR DESCRIPTION
minor patch to avoid possible segmentation fault in rcutils function scope.

related to https://github.com/ros2/rcl_logging/pull/116