### PR TITLE
Creating More Accuracy in NS_TO_S

### DIFF
--- a/include/rcutils/time.h
+++ b/include/rcutils/time.h
@@ -36,7 +36,10 @@ extern "C"
 #define RCUTILS_US_TO_NS(microseconds) ((microseconds) * 1000LL)
 
 /// Convenience macro to convert nanoseconds to seconds.
-#define RCUTILS_NS_TO_S(nanoseconds) ((nanoseconds) / (1000LL * 1000LL * 1000LL))
+#define RCUTILS_NS_TO_S(nanoseconds) \
+((1e-9 * (double)((int32_t)(nanoseconds % 1000000000l))) + \
+((double)((int32_t)((nanoseconds - ((int32_t)(nanoseconds % 1000000000l))) / 1000000000l))))
+
 /// Convenience macro to convert nanoseconds to milliseconds.
 #define RCUTILS_NS_TO_MS(nanoseconds) ((nanoseconds) / (1000LL * 1000LL))
 /// Convenience macro to convert nanoseconds to microseconds.

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -94,11 +94,6 @@ TEST_F(TestTimeFixture, test_rcutils_time_conversion_macros) {
   EXPECT_EQ(RCUTILS_NS_TO_S(1000000000ll), 1ll);  // int64_t
   EXPECT_EQ(RCUTILS_NS_TO_S(1000000042ll), 1ll);  // int64_t (truncated)
   EXPECT_EQ(RCUTILS_NS_TO_S(-1999999999ll), -1ll);  // int64_t (truncated)
-  EXPECT_EQ(RCUTILS_NS_TO_S(200000000.), 0.2);  // double
-  EXPECT_EQ(RCUTILS_NS_TO_S(1.0 + 1.0), 0.000000002);  // sum of doubles
-  EXPECT_EQ(
-    RCUTILS_NS_TO_S(9007199254740992.),
-    9007199.254740992);  // maximum precision double (53 bits)
 
   // nanoseconds to milliseconds
   EXPECT_EQ(RCUTILS_NS_TO_MS(1000000ll), 1ll);  // int64_t


### PR DESCRIPTION
This Pull Request is done in preparation for [this geometry2 issue](https://github.com/ros2/geometry2/issues/68) which reutilizes logic increasing accuracy in the conversion from nanoseconds to seconds. I assumed we wanted to keep these as Macros opposed to creating functions, but this would mean the Macros continue to take multiple "types" when we just want nanoseconds (int64_t). So should they stay as macros and we just remove all tests which don't take an int64 type and begin enforcing this behavior?