### PR TITLE
Removed warnings - strict-prototypes

### DIFF
--- a/include/rcutils/logging.h
+++ b/include/rcutils/logging.h
@@ -237,7 +237,7 @@ typedef void (* rcutils_logging_output_handler_t)(
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
-rcutils_logging_output_handler_t rcutils_logging_get_output_handler();
+rcutils_logging_output_handler_t rcutils_logging_get_output_handler(void);
 
 /// Set the current output handler.
 /**
@@ -297,7 +297,7 @@ rcutils_ret_t rcutils_logging_format_message(
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
-int rcutils_logging_get_default_logger_level();
+int rcutils_logging_get_default_logger_level(void);
 
 /// Set the default severity level for loggers.
 /**

--- a/include/rcutils/types/hash_map.h
+++ b/include/rcutils/types/hash_map.h
@@ -119,7 +119,7 @@ rcutils_hash_map_string_cmp_func(const void * val1, const void * val2);
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_hash_map_t
-rcutils_get_zero_initialized_hash_map();
+rcutils_get_zero_initialized_hash_map(void);
 
 /// Initialize a rcutils_hash_map_t, allocating space for given capacity.
 /**

--- a/include/rcutils/types/string_map.h
+++ b/include/rcutils/types/string_map.h
@@ -57,7 +57,7 @@ typedef struct RCUTILS_PUBLIC_TYPE rcutils_string_map_s
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_string_map_t
-rcutils_get_zero_initialized_string_map();
+rcutils_get_zero_initialized_string_map(void);
 
 /// Initialize a rcutils_string_map_t, allocating space for given capacity.
 /**

--- a/resource/logging_macros.h.em
+++ b/resource/logging_macros.h.em
@@ -138,7 +138,7 @@ extern "C"
 /**
  * \return true to log the message, false to ignore the message
  */
-typedef bool (* RclLogFilter)();
+typedef bool (* RclLogFilter)(void);
 /**
  * \def RCUTILS_LOG_CONDITION_FUNCTION_BEFORE
  * A macro checking the `function` condition.

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -76,7 +76,7 @@ rcutils_get_zero_initialized_allocator(void)
 }
 
 rcutils_allocator_t
-rcutils_get_default_allocator()
+rcutils_get_default_allocator(void)
 {
   static rcutils_allocator_t default_allocator = {
     .allocate = __default_allocate,

--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -75,7 +75,7 @@ int rcutils_hash_map_string_cmp_func(const void * val1, const void * val2)
 }
 
 rcutils_hash_map_t
-rcutils_get_zero_initialized_hash_map()
+rcutils_get_zero_initialized_hash_map(void)
 {
   static rcutils_hash_map_t zero_initialized_hash_map = {NULL};
   return zero_initialized_hash_map;

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -23,14 +23,14 @@ void rcutils_fault_injection_set_count(int_least64_t count)
   rcutils_atomic_store(&g_rcutils_fault_injection_count, count);
 }
 
-int_least64_t rcutils_fault_injection_get_count()
+int_least64_t rcutils_fault_injection_get_count(void)
 {
   int_least64_t count = 0;
   rcutils_atomic_load(&g_rcutils_fault_injection_count, count);
   return count;
 }
 
-bool rcutils_fault_injection_is_test_complete()
+bool rcutils_fault_injection_is_test_complete(void)
 {
 #ifndef RCUTILS_ENABLE_FAULT_INJECTION
   return true;
@@ -39,7 +39,7 @@ bool rcutils_fault_injection_is_test_complete()
 #endif  // RCUTILS_ENABLE_FAULT_INJECTION
 }
 
-int_least64_t _rcutils_fault_injection_maybe_fail()
+int_least64_t _rcutils_fault_injection_maybe_fail(void)
 {
   bool set_atomic_success = false;
   int_least64_t current_count = rcutils_fault_injection_get_count();

--- a/test/dummy_shared_library/dummy_shared_library.c
+++ b/test/dummy_shared_library/dummy_shared_library.c
@@ -14,7 +14,7 @@
 
 #include "./dummy_shared_library.h" // NOLINT
 
-void print_name()
+void print_name(void)
 {
   printf("print_name\n");
 }

--- a/test/dummy_shared_library/dummy_shared_library.h
+++ b/test/dummy_shared_library/dummy_shared_library.h
@@ -28,6 +28,6 @@
 #include <stdio.h>
 
 DUMMY_SHARED_LIBRARY_PUBLIC
-void print_name();
+void print_name(void);
 
 #endif  // DUMMY_SHARED_LIBRARY__DUMMY_SHARED_LIBRARY_H_

--- a/test/test_atomics.c
+++ b/test/test_atomics.c
@@ -42,8 +42,10 @@
   } while (0)
 
 int
-main()
+main(int argc, char * argv[])
 {
+  (void)argc;
+  (void)argv;
   TEST_ATOMIC_TYPE(_Bool, atomic_bool);
   TEST_ATOMIC_TYPE(char, atomic_char);
   TEST_ATOMIC_TYPE(signed char, atomic_schar);


### PR DESCRIPTION
There are new warnings on CI related with this compiler option `strict-prototypes`

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1860/gcc/new/