### PR TITLE
Increase timeout repl_str test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_repl_str
     test/test_repl_str.cpp
+    TIMEOUT 300
   )
   if(TARGET test_repl_str)
     target_link_libraries(test_repl_str ${PROJECT_NAME})


### PR DESCRIPTION
`test_repl_str` has a timeout when building the code with address sanitizer. I was able to reproduce this locally, increasing the timeout fix the issue.

CI failured https://ci.ros2.org/view/nightly/job/nightly_linux_address_sanitizer/1845/#showFailuresLink

