### PR TITLE
load dll built by MINGW with lib prefix

### DIFF
--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -343,7 +343,7 @@ rcutils_get_platform_library_name(
         library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
     }
   }
-#endif // __MINGW64__
+#endif  // __MINGW64__
 #endif
   if (written <= 0) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(

--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -319,6 +319,19 @@ rcutils_get_platform_library_name(
     }
   }
 #elif _WIN32
+#ifdef __MINGW64__
+  if (debug) {
+    if (buffer_size >= (strlen(library_name) + 9)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 9, "lib%sd.dll", library_name);
+    }
+  } else {
+    if (buffer_size >= (strlen(library_name) + 8)) {
+      written = rcutils_snprintf(
+        library_name_platform, strlen(library_name) + 8, "lib%s.dll", library_name);
+    }
+  }
+#else
   if (debug) {
     if (buffer_size >= (strlen(library_name) + 6)) {
       written = rcutils_snprintf(
@@ -330,6 +343,7 @@ rcutils_get_platform_library_name(
         library_name_platform, strlen(library_name) + 5, "%s.dll", library_name);
     }
   }
+#endif // __MINGW64__
 #endif
   if (written <= 0) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(


### PR DESCRIPTION
Hi,

When a WIN32 shared dll project is built by **MINGW**, the .dll file name will have a prefix of `lib` by cmake default setting, for example, "**lib**rmw_cyclonedds_cpp.dll".

This PR add the support for the case, load the rmw middleware with a **lib** prefix if it's built by MINGW.