### PR TITLE
Cleanup error handling in rcutils.

### DIFF
--- a/src/char_array.c
+++ b/src/char_array.c
@@ -172,7 +172,7 @@ rcutils_char_array_vsprintf(rcutils_char_array_t * char_array, const char * form
   if (new_size > char_array->buffer_capacity) {
     rcutils_ret_t ret = rcutils_char_array_expand_as_needed(char_array, new_size);
     if (ret != RCUTILS_RET_OK) {
-      RCUTILS_SET_ERROR_MSG("char array failed to expand");
+      // rcutils_char_array_expand_as_needed already set the error
       return ret;
     }
 
@@ -196,7 +196,7 @@ rcutils_char_array_memcpy(rcutils_char_array_t * char_array, const char * src, s
 {
   rcutils_ret_t ret = rcutils_char_array_expand_as_needed(char_array, n);
   if (ret != RCUTILS_RET_OK) {
-    RCUTILS_SET_ERROR_MSG("char array failed to expand");
+    // rcutils_char_array_expand_as needed already set the error
     return ret;
   }
   memcpy(char_array->buffer, src, n);
@@ -223,7 +223,7 @@ rcutils_char_array_strncat(rcutils_char_array_t * char_array, const char * src, 
   size_t new_length = current_strlen + n + 1;
   rcutils_ret_t ret = rcutils_char_array_expand_as_needed(char_array, new_length);
   if (ret != RCUTILS_RET_OK) {
-    RCUTILS_SET_ERROR_MSG("char array failed to expand");
+    // rcutils_char_array_expand_as_needed already set the error
     return ret;
   }
 

--- a/src/logging.c
+++ b/src/logging.c
@@ -748,7 +748,7 @@ rcutils_ret_t rcutils_logging_initialize_with_allocator(rcutils_allocator_t allo
     &g_rcutils_logging_severities_map, 2, sizeof(const char *), sizeof(int),
     rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func, &allocator);
   if (hash_map_ret != RCUTILS_RET_OK) {
-    // If an error message was set it will have been overwritten by rcutils_hash_map_init.
+    rcutils_reset_error();
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Failed to initialize map for logger severities [%s]. Severities will not be configurable.",
       rcutils_get_error_string().str);

--- a/src/split.c
+++ b/src/split.c
@@ -63,8 +63,10 @@ rcutils_split(
       ++array_size;
     }
   }
-  if (rcutils_string_array_init(string_array, array_size, &allocator) != RCUTILS_RET_OK) {
-    goto fail;
+  rcutils_ret_t ret = rcutils_string_array_init(string_array, array_size, &allocator);
+  if (ret != RCUTILS_RET_OK) {
+    // rcutils_string_array_init already set the error
+    return ret;
   }
 
   size_t token_counter = 0;

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -150,6 +150,7 @@ TEST_F(HashMapBaseTest, init_map_failing_allocator) {
     &map, 2, sizeof(uint32_t), sizeof(uint32_t),
     test_hash_map_uint32_hash_func, test_uint32_cmp, &failing_allocator);
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
 
   // Check allocate hash_map->impl->map fails
   set_time_bomb_allocator_malloc_count(failing_allocator, 1);
@@ -157,6 +158,7 @@ TEST_F(HashMapBaseTest, init_map_failing_allocator) {
     &map, 2, sizeof(uint32_t), sizeof(uint32_t),
     test_hash_map_uint32_hash_func, test_uint32_cmp, &failing_allocator);
   EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
+  rcutils_reset_error();
 }
 
 TEST_F(HashMapBaseTest, init_map_success) {

--- a/test/test_logging.cpp
+++ b/test/test_logging.cpp
@@ -42,12 +42,14 @@ TEST(TestLogging, test_logging_initialization) {
   rcutils_allocator_t empty_allocator = rcutils_get_zero_initialized_allocator();
   EXPECT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT, rcutils_logging_initialize_with_allocator(empty_allocator));
+  rcutils_reset_error();
 
   // Testing with a bad allocator fails when allocating internal memory
   // for the string map relating severity level values to string
   rcutils_allocator_t failing_allocator = get_failing_allocator();
   EXPECT_EQ(
     RCUTILS_RET_ERROR, rcutils_logging_initialize_with_allocator(failing_allocator));
+  rcutils_reset_error();
 }
 
 size_t g_log_calls = 0;

--- a/test/test_split.cpp
+++ b/test/test_split.cpp
@@ -56,6 +56,7 @@ TEST(test_split, split) {
   EXPECT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
     rcutils_split("Test", '/', rcutils_get_default_allocator(), NULL));
+  rcutils_reset_error();
 
   // Allocating initial string_array fails
   rcutils_allocator_t time_bomb_allocator = get_time_bomb_allocator();
@@ -63,6 +64,7 @@ TEST(test_split, split) {
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,
     rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
+  rcutils_reset_error();
 
   // Allocating string_array->data fails
   set_time_bomb_allocator_calloc_count(time_bomb_allocator, 1);
@@ -70,6 +72,7 @@ TEST(test_split, split) {
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,
     rcutils_split("Test", '/', time_bomb_allocator, &tokens_fail));
+  rcutils_reset_error();
 
   // Allocating string_array->data[0] fails
   set_time_bomb_allocator_calloc_count(time_bomb_allocator, 1);
@@ -77,6 +80,7 @@ TEST(test_split, split) {
   EXPECT_EQ(
     RCUTILS_RET_BAD_ALLOC,
     rcutils_split("hello/world", '/', time_bomb_allocator, &tokens_fail));
+  rcutils_reset_error();
 
   rcutils_string_array_t tokens0 = test_split("", '/', 0);
   ret = rcutils_string_array_fini(&tokens0);


### PR DESCRIPTION
This gets rid of ugly warnings about overwritten errors, both in the tests and in downstream code.