### PR TITLE
Fix windows failure

### DIFF
--- a/include/rcutils/process.h
+++ b/include/rcutils/process.h
@@ -17,6 +17,12 @@
 #ifndef RCUTILS__PROCESS_H_
 #define RCUTILS__PROCESS_H_
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if defined _WIN32 || defined __CYGWIN__
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -24,13 +30,6 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
-#if defined _WIN32 || defined __CYGWIN__
 // When building with MSVC 19.28.29333.0 on Windows 10 (as of 2020-11-11),
 // there appears to be a problem with winbase.h (which is included by
 // Windows.h). In particular, warnings of the form:

--- a/include/rcutils/process.h
+++ b/include/rcutils/process.h
@@ -17,6 +17,14 @@
 #ifndef RCUTILS__PROCESS_H_
 #define RCUTILS__PROCESS_H_
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
This PR https://github.com/ros2/rcutils/pull/491 is breaking CI when building `rmw_cyclonedds_cpp`, for example https://ci.ros2.org/view/nightly/job/nightly_win_rel/3379/console

This PR should fix this issue