### PR TITLE
Clean memory in test_process.cpp

### DIFF
--- a/test/test_join.cpp
+++ b/test/test_join.cpp
@@ -89,4 +89,13 @@ TEST(test_join, join) {
   EXPECT_EQ(
     RCUTILS_RET_OK,
     rcutils_string_array_fini(&tokens0));
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_string_array_fini(&tokens1));
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_string_array_fini(&tokens2));
+
 }

--- a/test/test_process.cpp
+++ b/test/test_process.cpp
@@ -83,6 +83,8 @@ TEST(TestProcess, test_process_creation) {
 
   rcutils_process_close(process);
 
+  ret = rcutils_string_array_fini(&args);
+
   // cmake -E cat "file with space.txt" (returns 0)
   ret = rcutils_string_array_resize(&args, 4);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
@@ -99,6 +101,8 @@ TEST(TestProcess, test_process_creation) {
   EXPECT_EQ(0, exit_code);
 
   rcutils_process_close(process);
+
+  ret = rcutils_string_array_fini(&args);
 
   // cmake -E false (returns 1)
   ret = rcutils_string_array_resize(&args, 3);


### PR DESCRIPTION
Related with this build https://ci.ros2.org/view/nightly/job/nightly_linux_address_sanitizer/2219/testReport/junit/(root)/projectroot/test_process/

the array is resize but it's not clean 