### PR TITLE
Revert "use getenv_s instead of getenv for Windows. (#499)"

### DIFF
--- a/src/env.c
+++ b/src/env.c
@@ -81,27 +81,8 @@ rcutils_get_env(const char * env_name, const char ** env_value)
     return "argument env_value is null";
   }
 
-#ifdef _WIN32
-  size_t requiredSize = 0;
-  char *buffer = NULL;
-  if (getenv_s(&requiredSize, NULL, 0, env_name) == 0 && requiredSize > 0) {
-    buffer = (char *)malloc(requiredSize * sizeof(char));
-    if (buffer != NULL) {
-      if (getenv_s(&requiredSize, buffer, requiredSize, env_name) == 0) {
-        *env_value = buffer;
-      } else {
-        free(buffer);
-        *env_value = NULL;
-      }
-    } else {
-      *env_value = NULL;
-    }
-  } else {
-    *env_value = NULL;
-  }
-#else
+  // TODO(Suyash458): getenv is deprecated on Windows; consider using getenv_s instead
   *env_value = getenv(env_name);
-#endif
 
   if (NULL == *env_value) {
     *env_value = "";


### PR DESCRIPTION
This reverts commit 46ab4d4eeb555a2e9e880157b97f0a867d3a256c, which came from #499 .

The reason I think we should revert this is that the code on Windows breaks the `rcutils_get_env` [contract](https://github.com/ros2/rcutils/blob/cab00ffc009ad11570da6ccdce9b7812aa0e46be/include/rcutils/env.h#L92).  In particular, prior to this change, `rcutils_get_env` never allocated memory.  Now, when calling this on Windows, it allocates memory, but when calling it on Unix, it does not.  Thus without preprocessor tricks, the caller cannot know whether they need to free the result or not.

We could also fix this by doing a `strdup` in the Unix case, which would change the contract of `rcutils_get_env` to always require the caller to free memory. That would require us to check every caller of this API and update them to free it.  Also, the change to `getenv_s` doesn't solve race conditions between `rcutils_get_env` and `rcutils_set_env`.

Thus I don't think this change is worth it; while `getenv` is technically deprecated on Windows, as far as I can tell they are never going to remove it.

@ahcorde @fujitatomoya FYI; please check my logic here and let me know if you agree.