### PR TITLE
Add rcutils_raw_steady_time_now method for slew-free clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The API is a combination of parts:
 - Portable implementations of "get system time" and "get steady time":
   - rcutils_system_time_now()
   - rcutils_steady_time_now()
+  - rcutils_raw_steady_time_now()
   - rcutils/time.h
 - Some useful data structures:
   - A "string array" data structure (analogous to `std::vector<std::string>`):

--- a/include/rcutils/time.h
+++ b/include/rcutils/time.h
@@ -104,6 +104,33 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_steady_time_now(rcutils_time_point_value_t * now);
 
+/// Retrieve the current time as a rcutils_time_point_value_t object.
+/**
+ * This function returns the time from a monotonically increasing slew-free clock.
+ *
+ * The resolution (e.g. nanoseconds vs microseconds) is not guaranteed.
+ *
+ * The now argument must point to an allocated rcutils_time_point_value_t object,
+ * as the result is copied into this variable.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[out] now a struct in which the current time is stored
+ * \return #RCUTILS_RET_OK if the current time was successfully obtained, or
+ * \return #RCUTILS_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCUTILS_RET_ERROR if an unspecified error occur.
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t
+rcutils_raw_steady_time_now(rcutils_time_point_value_t * now);
+
 /// Return a time point as nanoseconds in a string.
 /**
  * The number is always fixed width, with left padding zeros up to the maximum

--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -98,3 +98,27 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now)
   *now = RCUTILS_S_TO_NS((int64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCUTILS_RET_OK;
 }
+
+rcutils_ret_t
+rcutils_raw_steady_time_now(rcutils_time_point_value_t * now)
+{
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(now, RCUTILS_RET_INVALID_ARGUMENT);
+  struct timespec timespec_now;
+
+#if defined(CLOCK_MONOTONIC_RAW)
+  clockid_t monotonic_raw_clock = CLOCK_MONOTONIC_RAW;
+#else
+  clockid_t monotonic_raw_clock = CLOCK_MONOTONIC;
+#endif
+
+  if (clock_gettime(monotonic_raw_clock, &timespec_now) < 0) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Failed to get raw steady time: %d", errno);
+    return RCUTILS_RET_ERROR;
+  }
+  if (would_be_negative(&timespec_now)) {
+    RCUTILS_SET_ERROR_MSG("unexpected negative time");
+    return RCUTILS_RET_ERROR;
+  }
+  *now = RCUTILS_S_TO_NS((int64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
+  return RCUTILS_RET_OK;
+}

--- a/src/time_unix.c
+++ b/src/time_unix.c
@@ -16,6 +16,7 @@
 # error time_unix.c is not intended to be used with win32 based systems
 #endif  // defined(_WIN32)
 
+#include "rcutils/logging_macros.h"
 #include "rcutils/time.h"
 
 #if defined(__MACH__) && defined(__APPLE__)
@@ -109,6 +110,9 @@ rcutils_raw_steady_time_now(rcutils_time_point_value_t * now)
   clockid_t monotonic_raw_clock = CLOCK_MONOTONIC_RAW;
 #else
   clockid_t monotonic_raw_clock = CLOCK_MONOTONIC;
+  RCUTILS_LOG_WARN_ONCE(
+    "CLOCK_MONOTONIC_RAW is not supported by the platform, using CLOCK_MONOTONIC "
+    "instead. This may not provide the desired raw steady time behavior.");
 #endif
 
   if (clock_gettime(monotonic_raw_clock, &timespec_now) < 0) {

--- a/src/time_win32.c
+++ b/src/time_win32.c
@@ -84,6 +84,15 @@ rcutils_steady_time_now(rcutils_time_point_value_t * now)
   return RCUTILS_RET_OK;
 }
 
+rcutils_ret_t
+rcutils_raw_steady_time_now(rcutils_time_point_value_t * now)
+{
+  // On Windows, there is no difference between steady and raw steady time.
+  // The QueryPerformanceCounter function provides a high-resolution timer
+  // that is not affected by system clock changes.
+  return rcutils_steady_time_now(now);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
fixes: #488 

This PR adds monotonic slew-free clock implementation that can be used for industrial applications where a slew-free clock plays a very important role when integrating ros2_control with industrial applications to avoid rattling sound in the actuators when there is a time drift