### PR TITLE
feat: ability to override the default allocator

### DIFF
--- a/include/rcutils/allocator.h
+++ b/include/rcutils/allocator.h
@@ -108,6 +108,21 @@ RCUTILS_WARN_UNUSED
 rcutils_allocator_t
 rcutils_get_default_allocator(void);
 
+/// Override the default allocator returned by rcutils_get_default_allocator.
+/**
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] override_allocator The allocator to set as the default.
+ */
+RCUTILS_PUBLIC
+void
+rcutils_set_default_allocator(rcutils_allocator_t override_allocator);
+
 /// Return true if the given allocator has non-null function pointers.
 /**
  * \param[in] allocator to be checked by the function

--- a/src/allocator.c
+++ b/src/allocator.c
@@ -69,9 +69,23 @@ rcutils_get_zero_initialized_allocator(void)
   return zero_allocator;
 }
 
+static rcutils_allocator_t rcutils_override_default_allocator = {0};
+
+void
+rcutils_set_default_allocator(rcutils_allocator_t override_allocator)
+{
+  if (rcutils_allocator_is_valid(&override_allocator)) {
+    rcutils_override_default_allocator = override_allocator;
+  }
+}
+
 rcutils_allocator_t
 rcutils_get_default_allocator(void)
 {
+  if (rcutils_allocator_is_valid(&rcutils_override_default_allocator)) {
+    return rcutils_override_default_allocator;
+  }
+
   static rcutils_allocator_t default_allocator = {
     .allocate = __default_allocate,
     .deallocate = __default_deallocate,
@@ -79,6 +93,7 @@ rcutils_get_default_allocator(void)
     .zero_allocate = __default_zero_allocate,
     .state = NULL,
   };
+
   return default_allocator;
 }
 


### PR DESCRIPTION
## Description

Added a function to set the default allocator, and modified the `rcutils_get_default_allocator` function to return it if it is set and valid.

I needed this for use with Unreal Engine in order to expose UE's allocator API to ROS 2 so that the UE garbage cleaner could free ROS 2 objects successfully.

I have also seen references to a similar function in another PR (https://github.com/ros2/rcutils/pull/458/files#diff-8352803836a54313eb08fa96e6b6590eae0cfad976ae3187ae45d322d6f50551R101), so I assume I am not the only one to have added this functionality.

### Is this user-facing behavior change?

Yes, an additional function in the rcutils allocator API.

### Did you use Generative AI?

No.

