### PR TITLE
Do not export dl in rcutils_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -543,7 +543,7 @@ endif()
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
-ament_export_libraries(${PROJECT_NAME} ${CMAKE_DL_LIBS})
+ament_export_libraries(${PROJECT_NAME})
 
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})


### PR DESCRIPTION
## Description

Fixes #521

### Is this user-facing behavior change?

If someone still uses old-style CMake variables, then the list in `rcutils_LIBRARIES` no longer includes `dl`.

### Did you use Generative AI?

no

### Additional Information

Maybe it's time to drop old-style CMake variables altogether? We've supported modern CMake targets for a long time now.
