### PR TITLE
Add base64 encoding and decoding functions with tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 set(rcutils_sources
   src/allocator.c
   src/array_list.c
+  src/base64.c
   src/char_array.c
   src/cmdline_parser.c
   src/env.c
@@ -539,7 +540,15 @@ if(BUILD_TESTING)
   if(TARGET benchmark_err_handle)
     target_link_libraries(benchmark_err_handle ${PROJECT_NAME})
   endif()
+
+  ament_add_gtest(test_base64
+    test/test_base64.cpp
+  )
+  if(TARGET test_base64)
+    target_link_libraries(test_base64 ${PROJECT_NAME})
+  endif()
 endif()
+
 
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,7 +549,6 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-
 # Export old-style CMake variables
 ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})

--- a/include/rcutils/base64.h
+++ b/include/rcutils/base64.h
@@ -1,0 +1,87 @@
+// Copyright 2026 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCUTILS__BASE64_H_
+#define RCUTILS__BASE64_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcutils/allocator.h"
+#include "rcutils/visibility_control.h"
+#include "rcutils/types.h"
+
+#define DECODE_BASE64_STRING_LENGTH_LIMIT (64 * 1024 * 1024)  // 64 MiB
+
+/**
+ * @brief Decode a base64-encoded string into a byte array.
+ *
+ * This function converts a base64-encoded string into its original binary representation.
+ * Base64 encoding uses 4 ASCII characters to represent 3 bytes of data.
+ *
+ * @param base64_str The null-terminated base64 string to decode.
+ * @param byte_array Pointer to rcutils_uint8_array_t to store the decoded byte array (output).
+ *                   The array must be zero-initialized by rcutils_get_zero_initialized_uint8_array
+ *                   before calling this function.
+ * @param allocator The allocator to use for memory allocation.
+ * @return RCUTILS_RET_OK on success.
+ * @return RCUTILS_RET_INVALID_ARGUMENT if base64_str is NULL, or
+ *                                      if byte_array is NULL, or
+ *                                      if allocator is NULL or invalid, or
+ *                                      if byte_array is not zero-initialized.
+ * @return RCUTILS_RET_ERROR if base64 string length exceeds DECODE_BASE64_STRING_LENGTH_LIMIT, or
+ *                           if base64 string length is not a multiple of 4, or
+ *                           if base64 string contains invalid characters, or
+ *                           if base64 string has invalid padding.
+ * @return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t decode_base64(
+  const char * base64_str,
+  rcutils_uint8_array_t * byte_array,
+  const rcutils_allocator_t * allocator);
+
+/**
+ * @brief Encode a byte array into a base64-encoded string.
+ *
+ * This function converts a binary byte array into its base64-encoded representation.
+ * Base64 encoding uses 4 ASCII characters to represent 3 bytes of data.
+ *
+ * The output string should be freed by the caller using the provided allocator.
+ *
+ * @param byte_array The rcutils_uint8_array_t structure containing the byte array to encode.
+ * @param base64_str Pointer to store the allocated base64 string (output).
+ * @param allocator The allocator to use for memory allocation.
+ * @return RCUTILS_RET_OK on success.
+ * @return RCUTILS_RET_INVALID_ARGUMENT if byte_array is NULL, or
+ *                                      if byte_array->buffer is NULL, or
+ *                                      if byte_array->buffer_length is zero, or
+ *                                      if base64_str is NULL, or
+ *                                      if allocator is NULL or invalid.
+ * @return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
+ */
+RCUTILS_PUBLIC
+RCUTILS_WARN_UNUSED
+rcutils_ret_t encode_base64(
+  const rcutils_uint8_array_t * byte_array,
+  char ** base64_str,
+  const rcutils_allocator_t * allocator);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // RCUTILS__BASE64_H_

--- a/include/rcutils/base64.h
+++ b/include/rcutils/base64.h
@@ -24,59 +24,60 @@ extern "C"
 #include "rcutils/visibility_control.h"
 #include "rcutils/types.h"
 
-#define DECODE_BASE64_STRING_LENGTH_LIMIT (64 * 1024 * 1024)  // 64 MiB
+#define RCUTILS_BASE64_ENCODED_MAX_LENGTH (64 * 1024 * 1024)  // 64 MiB
 
 /**
- * @brief Decode a base64-encoded string into a byte array.
+ * \brief Decode a base64-encoded string into a byte array.
  *
  * This function converts a base64-encoded string into its original binary representation.
  * Base64 encoding uses 4 ASCII characters to represent 3 bytes of data.
  *
- * @param base64_str The null-terminated base64 string to decode.
- * @param byte_array Pointer to rcutils_uint8_array_t to store the decoded byte array (output).
+ * \param base64_str The null-terminated base64 string to decode.
+ * \param byte_array Pointer to rcutils_uint8_array_t to store the decoded byte array (output).
  *                   The array must be zero-initialized by rcutils_get_zero_initialized_uint8_array
  *                   before calling this function.
- * @param allocator The allocator to use for memory allocation.
- * @return RCUTILS_RET_OK on success.
- * @return RCUTILS_RET_INVALID_ARGUMENT if base64_str is NULL, or
+ * \param allocator The allocator to use for memory allocation.
+ * \return RCUTILS_RET_OK on success.
+ * \return RCUTILS_RET_INVALID_ARGUMENT if base64_str is NULL, or
  *                                      if byte_array is NULL, or
  *                                      if allocator is NULL or invalid, or
  *                                      if byte_array is not zero-initialized.
- * @return RCUTILS_RET_ERROR if base64 string length exceeds DECODE_BASE64_STRING_LENGTH_LIMIT, or
+ * \return RCUTILS_RET_ERROR if base64 string length exceeds RCUTILS_BASE64_ENCODED_MAX_LENGTH, or
  *                           if base64 string length is not a multiple of 4, or
  *                           if base64 string contains invalid characters, or
  *                           if base64 string has invalid padding.
- * @return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
+ * \return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
-rcutils_ret_t decode_base64(
+rcutils_ret_t rcutils_decode_base64(
   const char * base64_str,
   rcutils_uint8_array_t * byte_array,
   const rcutils_allocator_t * allocator);
 
 /**
- * @brief Encode a byte array into a base64-encoded string.
+ * \brief Encode a byte array into a base64-encoded string.
  *
  * This function converts a binary byte array into its base64-encoded representation.
  * Base64 encoding uses 4 ASCII characters to represent 3 bytes of data.
  *
  * The output string should be freed by the caller using the provided allocator.
  *
- * @param byte_array The rcutils_uint8_array_t structure containing the byte array to encode.
- * @param base64_str Pointer to store the allocated base64 string (output).
- * @param allocator The allocator to use for memory allocation.
- * @return RCUTILS_RET_OK on success.
- * @return RCUTILS_RET_INVALID_ARGUMENT if byte_array is NULL, or
+ * \param byte_array The rcutils_uint8_array_t structure containing the byte array to encode.
+ * \param base64_str Pointer to store the allocated base64 string (output).
+ * \param allocator The allocator to use for memory allocation.
+ * \return RCUTILS_RET_OK on success.
+ * \return RCUTILS_RET_INVALID_ARGUMENT if byte_array is NULL, or
  *                                      if byte_array->buffer is NULL, or
  *                                      if byte_array->buffer_length is zero, or
  *                                      if base64_str is NULL, or
  *                                      if allocator is NULL or invalid.
- * @return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
+ * \return RCUTILS_RET_ERROR if byte_array length exceeds limit for base64 encoding.
+ * \return RCUTILS_RET_BAD_ALLOC if memory allocation fails.
  */
 RCUTILS_PUBLIC
 RCUTILS_WARN_UNUSED
-rcutils_ret_t encode_base64(
+rcutils_ret_t rcutils_encode_base64(
   const rcutils_uint8_array_t * byte_array,
   char ** base64_str,
   const rcutils_allocator_t * allocator);

--- a/src/base64.c
+++ b/src/base64.c
@@ -17,7 +17,11 @@ extern "C"
 {
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <pthread.h>
+#endif
 #include <stdint.h>
 #include <string.h>
 
@@ -32,7 +36,22 @@ extern "C"
 
 // Initialize the base64 lookup table
 static uint8_t base64_map[256];
+#ifdef _WIN32
+static INIT_ONCE base64_map_initialization_once = INIT_ONCE_STATIC_INIT;
+
+static void initialize_base64_map(void);
+
+BOOL CALLBACK initialize_base64_map_callback(
+  PINIT_ONCE InitOnce,
+  PVOID Parameter,
+  PVOID *lpContext)
+{
+  initialize_base64_map();
+  return TRUE;
+}
+#else
 static pthread_once_t base64_map_initialization_once = PTHREAD_ONCE_INIT;
+#endif
 
 static void initialize_base64_map(void)
 {
@@ -66,7 +85,15 @@ rcutils_ret_t rcutils_decode_base64(
   rcutils_uint8_array_t * byte_array,
   const rcutils_allocator_t * allocator)
 {
+#ifdef _WIN32
+  InitOnceExecuteOnce(
+    &base64_map_initialization_once,
+    initialize_base64_map_callback,
+    NULL,
+    NULL);
+#else
   pthread_once(&base64_map_initialization_once, initialize_base64_map);
+#endif
 
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(base64_str, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(byte_array, RCUTILS_RET_INVALID_ARGUMENT);

--- a/src/base64.c
+++ b/src/base64.c
@@ -17,12 +17,14 @@ extern "C"
 {
 #endif
 
+#include <pthread.h>
 #include <stdint.h>
 #include <string.h>
 
 #include "rcutils/allocator.h"
 #include "rcutils/base64.h"
 #include "rcutils/error_handling.h"
+#include "rcutils/strnlen.h"
 #include "rcutils/types.h"
 #include "rcutils/types/uint8_array.h"
 
@@ -30,14 +32,10 @@ extern "C"
 
 // Initialize the base64 lookup table
 static uint8_t base64_map[256];
-static int base64_map_initialized = 0;
+static pthread_once_t base64_map_initialization_once = PTHREAD_ONCE_INIT;
 
 static void initialize_base64_map(void)
 {
-  if (base64_map_initialized) {
-    return;
-  }
-
   // Initialize all values to invalid
   for (int i = 0; i < 256; i++) {
     base64_map[i] = BASE64_INVALID;
@@ -61,16 +59,14 @@ static void initialize_base64_map(void)
   base64_map['0'] = 52; base64_map['1'] = 53; base64_map['2'] = 54; base64_map['3'] = 55;
   base64_map['4'] = 56; base64_map['5'] = 57; base64_map['6'] = 58; base64_map['7'] = 59;
   base64_map['8'] = 60; base64_map['9'] = 61; base64_map['+'] = 62; base64_map['/'] = 63;
-
-  base64_map_initialized = 1;
 }
 
-rcutils_ret_t decode_base64(
+rcutils_ret_t rcutils_decode_base64(
   const char * base64_str,
   rcutils_uint8_array_t * byte_array,
   const rcutils_allocator_t * allocator)
 {
-  initialize_base64_map();
+  pthread_once(&base64_map_initialization_once, initialize_base64_map);
 
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(base64_str, RCUTILS_RET_INVALID_ARGUMENT);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(byte_array, RCUTILS_RET_INVALID_ARGUMENT);
@@ -87,8 +83,8 @@ rcutils_ret_t decode_base64(
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
 
-  size_t input_str_len = strnlen(base64_str, DECODE_BASE64_STRING_LENGTH_LIMIT);
-  if (DECODE_BASE64_STRING_LENGTH_LIMIT == input_str_len) {
+  size_t input_str_len = rcutils_strnlen(base64_str, RCUTILS_BASE64_ENCODED_MAX_LENGTH);
+  if (RCUTILS_BASE64_ENCODED_MAX_LENGTH == input_str_len) {
     RCUTILS_SET_ERROR_MSG("base64 string length exceeds limit");
     return RCUTILS_RET_ERROR;
   }
@@ -202,7 +198,7 @@ err:
   return RCUTILS_RET_ERROR;
 }
 
-rcutils_ret_t encode_base64(
+rcutils_ret_t rcutils_encode_base64(
   const rcutils_uint8_array_t * byte_array,
   char ** base64_str,
   const rcutils_allocator_t * allocator)
@@ -223,6 +219,15 @@ rcutils_ret_t encode_base64(
     return RCUTILS_RET_INVALID_ARGUMENT);
 
   *base64_str = NULL;
+
+  // Check for input size limit to prevent integer overflow
+  // The maximum input size should ensure the encoded output fits within reasonable limits
+  // Base64 encoding: 3 bytes -> 4 chars, so max input = (LIMIT / 4) * 3
+  size_t max_input_len = (RCUTILS_BASE64_ENCODED_MAX_LENGTH / 4) * 3;
+  if (byte_array->buffer_length > max_input_len) {
+    RCUTILS_SET_ERROR_MSG("byte_array length exceeds limit for base64 encoding");
+    return RCUTILS_RET_ERROR;
+  }
 
   // Calculate the encoded output size
   // Each 3-byte block encodes to 4 characters, plus padding if necessary

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,0 +1,297 @@
+// Copyright 2026 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include "rcutils/allocator.h"
+#include "rcutils/base64.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types.h"
+#include "rcutils/types/uint8_array.h"
+
+#define BASE64_INVALID 255u
+
+// Initialize the base64 lookup table
+static uint8_t base64_map[256];
+static int base64_map_initialized = 0;
+
+static void initialize_base64_map(void)
+{
+  if (base64_map_initialized) {
+    return;
+  }
+
+  // Initialize all values to invalid
+  for (int i = 0; i < 256; i++) {
+    base64_map[i] = BASE64_INVALID;
+  }
+
+  // Set valid base64 characters
+  base64_map['A'] = 0;  base64_map['B'] = 1;  base64_map['C'] = 2;  base64_map['D'] = 3;
+  base64_map['E'] = 4;  base64_map['F'] = 5;  base64_map['G'] = 6;  base64_map['H'] = 7;
+  base64_map['I'] = 8;  base64_map['J'] = 9;  base64_map['K'] = 10; base64_map['L'] = 11;
+  base64_map['M'] = 12; base64_map['N'] = 13; base64_map['O'] = 14; base64_map['P'] = 15;
+  base64_map['Q'] = 16; base64_map['R'] = 17; base64_map['S'] = 18; base64_map['T'] = 19;
+  base64_map['U'] = 20; base64_map['V'] = 21; base64_map['W'] = 22; base64_map['X'] = 23;
+  base64_map['Y'] = 24; base64_map['Z'] = 25;
+  base64_map['a'] = 26; base64_map['b'] = 27; base64_map['c'] = 28; base64_map['d'] = 29;
+  base64_map['e'] = 30; base64_map['f'] = 31; base64_map['g'] = 32; base64_map['h'] = 33;
+  base64_map['i'] = 34; base64_map['j'] = 35; base64_map['k'] = 36; base64_map['l'] = 37;
+  base64_map['m'] = 38; base64_map['n'] = 39; base64_map['o'] = 40; base64_map['p'] = 41;
+  base64_map['q'] = 42; base64_map['r'] = 43; base64_map['s'] = 44; base64_map['t'] = 45;
+  base64_map['u'] = 46; base64_map['v'] = 47; base64_map['w'] = 48; base64_map['x'] = 49;
+  base64_map['y'] = 50; base64_map['z'] = 51;
+  base64_map['0'] = 52; base64_map['1'] = 53; base64_map['2'] = 54; base64_map['3'] = 55;
+  base64_map['4'] = 56; base64_map['5'] = 57; base64_map['6'] = 58; base64_map['7'] = 59;
+  base64_map['8'] = 60; base64_map['9'] = 61; base64_map['+'] = 62; base64_map['/'] = 63;
+
+  base64_map_initialized = 1;
+}
+
+rcutils_ret_t decode_base64(
+  const char * base64_str,
+  rcutils_uint8_array_t * byte_array,
+  const rcutils_allocator_t * allocator)
+{
+  initialize_base64_map();
+
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(base64_str, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(byte_array, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "base64 decode function has no valid allocator",
+    return RCUTILS_RET_INVALID_ARGUMENT);
+
+  // Check that byte_array is zero-initialized
+  if (byte_array->buffer != NULL ||
+    byte_array->buffer_length != 0 ||
+    byte_array->buffer_capacity != 0)
+  {
+    RCUTILS_SET_ERROR_MSG("byte_array must be zero-initialized before decoding");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+
+  size_t input_str_len = strnlen(base64_str, DECODE_BASE64_STRING_LENGTH_LIMIT);
+  if (DECODE_BASE64_STRING_LENGTH_LIMIT == input_str_len) {
+    RCUTILS_SET_ERROR_MSG("base64 string length exceeds limit");
+    return RCUTILS_RET_ERROR;
+  }
+  if (0 == input_str_len) {
+    return RCUTILS_RET_OK;
+  }
+  if (0 != (input_str_len % 4)) {
+    RCUTILS_SET_ERROR_MSG("base64 string length is not a multiple of 4");
+    return RCUTILS_RET_ERROR;
+  }
+
+  // Count padding characters ('=' at the end)
+  // Valid base64 can have 0, 1, or 2 padding characters
+  size_t padding = 0;
+  if ('=' == base64_str[input_str_len - 1]) {
+    padding++;
+    if (input_str_len >= 2 && '=' == base64_str[input_str_len - 2]) {
+      padding++;
+    }
+  }
+
+  if (padding > 2) {
+    RCUTILS_SET_ERROR_MSG("invalid base64 padding");
+    return RCUTILS_RET_ERROR;
+  }
+
+  // Calculate the decoded output size
+  // Each 4-character block decodes to 3 bytes, minus any padding
+  size_t decoded_len_blocks = input_str_len / 4;
+  size_t max_decoded_len = decoded_len_blocks * 3;
+
+  if (padding >= max_decoded_len) {
+    RCUTILS_SET_ERROR_MSG("invalid base64: padding exceeds expected length");
+    return RCUTILS_RET_ERROR;
+  }
+
+  size_t decoded_len = max_decoded_len - padding;
+
+  // Allocate memory for the decoded output
+  rcutils_ret_t ret = rcutils_uint8_array_init(byte_array, decoded_len, allocator);
+  if (ret != RCUTILS_RET_OK) {
+    return ret;
+  }
+  byte_array->buffer_length = decoded_len;
+
+  // Decode the base64 string block by block
+  // Each iteration processes 4 input characters (sextets) to produce 3 output bytes (octets)
+  size_t write_index = 0;
+  for (size_t read_index = 0; read_index < input_str_len; read_index += 4) {
+    // Extract 4 sextets (6-bit values) from the input
+    uint8_t sextets[4] = {0, 0, 0, 0};
+
+    for (size_t i = 0; i < 4; ++i) {
+      char c = base64_str[read_index + i];
+
+      if ('=' == c) {
+        // Padding character validation:
+        // - Must be in the last block (last 2 positions of the string)
+        // - If at position 2, position 3 must also be padding
+        // - Cannot appear at positions 0 or 1 of a block
+        if ((read_index + i) < (input_str_len - 2) || i < 2) {
+          RCUTILS_SET_ERROR_MSG("invalid base64 padding position");
+          goto err;
+        }
+
+        if (i == 2 && base64_str[read_index + 3] != '=') {
+          RCUTILS_SET_ERROR_MSG("invalid base64 padding");
+          goto err;
+        }
+
+        sextets[i] = 0;
+      } else {
+        // Map base64 character to its 6-bit value
+        uint8_t value = base64_map[(uint8_t)c];
+        if (BASE64_INVALID == value) {
+          RCUTILS_SET_ERROR_MSG("invalid base64 character");
+          goto err;
+        }
+        sextets[i] = value;
+      }
+    }
+
+    // Combine the 4 sextets (6 bits each) into a 24-bit block
+    // Sextet 0: bits 23-18 | Sextet 1: bits 17-12 | Sextet 2: bits 11-6 | Sextet 3: bits 5-0
+    uint32_t block =
+      ((uint32_t)sextets[0] << 18) |
+      ((uint32_t)sextets[1] << 12) |
+      ((uint32_t)sextets[2] << 6) |
+      ((uint32_t)sextets[3] << 0);
+
+    // Extract 3 bytes from the 24-bit block
+    // Byte 0: bits 23-16 | Byte 1: bits 15-8 | Byte 2: bits 7-0
+    if (write_index < decoded_len) {
+      byte_array->buffer[write_index++] = (uint8_t)((block >> 16) & 0xFFu);
+    }
+    if (write_index < decoded_len) {
+      byte_array->buffer[write_index++] = (uint8_t)((block >> 8) & 0xFFu);
+    }
+    if (write_index < decoded_len) {
+      byte_array->buffer[write_index++] = (uint8_t)(block & 0xFFu);
+    }
+  }
+
+  return RCUTILS_RET_OK;
+
+err:
+  // Clean up allocated memory on error
+  if (RCUTILS_RET_OK != rcutils_uint8_array_fini(byte_array)) {
+    RCUTILS_SET_ERROR_MSG("failed to finalize byte_array during cleanup");
+  }
+  return RCUTILS_RET_ERROR;
+}
+
+rcutils_ret_t encode_base64(
+  const rcutils_uint8_array_t * byte_array,
+  char ** base64_str,
+  const rcutils_allocator_t * allocator)
+{
+  // Base64 encoding table
+  static const char base64_chars[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(byte_array, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(byte_array->buffer, RCUTILS_RET_INVALID_ARGUMENT);
+  if (byte_array->buffer_length == 0) {
+    RCUTILS_SET_ERROR_MSG("byte_array length is zero");
+    return RCUTILS_RET_INVALID_ARGUMENT;
+  }
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(base64_str, RCUTILS_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "base64 encode function has no valid allocator",
+    return RCUTILS_RET_INVALID_ARGUMENT);
+
+  *base64_str = NULL;
+
+  // Calculate the encoded output size
+  // Each 3-byte block encodes to 4 characters, plus padding if necessary
+  size_t full_blocks = byte_array->buffer_length / 3;
+  size_t remainder = byte_array->buffer_length % 3;
+  size_t encoded_len = full_blocks * 4;
+
+  // Add padding block if there's a remainder
+  if (remainder > 0) {
+    encoded_len += 4;
+  }
+
+  // Allocate memory for the encoded output (plus null terminator)
+  *base64_str = (char *)allocator->allocate(encoded_len + 1, allocator->state);
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    *base64_str,
+    "failed to allocate memory for base64 encode",
+    return RCUTILS_RET_BAD_ALLOC);
+
+  // Encode the byte array block by block
+  // Each iteration processes 3 input bytes (octets) to produce 4 output characters (sextets)
+  size_t read_index = 0;
+  size_t write_index = 0;
+
+  // Process full 3-byte blocks
+  while (read_index + 3 <= byte_array->buffer_length) {
+    // Combine 3 bytes (octets) into a 24-bit block
+    // Byte 0: bits 23-16 | Byte 1: bits 15-8 | Byte 2: bits 7-0
+    uint32_t block =
+      ((uint32_t)byte_array->buffer[read_index] << 16) |
+      ((uint32_t)byte_array->buffer[read_index + 1] << 8) |
+      ((uint32_t)byte_array->buffer[read_index + 2]);
+
+    // Extract 4 sextets (6-bit values) from the 24-bit block
+    // Sextet 0: bits 23-18 | Sextet 1: bits 17-12 | Sextet 2: bits 11-6 | Sextet 3: bits 5-0
+    (*base64_str)[write_index++] = base64_chars[(block >> 18) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[(block >> 12) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[(block >> 6) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[block & 0x3F];
+
+    read_index += 3;
+  }
+
+  // Process the remaining bytes (if any) with padding
+  if (remainder == 1) {
+    // 1 remaining byte: encode to 2 characters + 2 padding characters
+    uint32_t block = (uint32_t)byte_array->buffer[read_index] << 16;
+
+    (*base64_str)[write_index++] = base64_chars[(block >> 18) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[(block >> 12) & 0x3F];
+    (*base64_str)[write_index++] = '=';
+    (*base64_str)[write_index++] = '=';
+  } else if (remainder == 2) {
+    // 2 remaining bytes: encode to 3 characters + 1 padding character
+    uint32_t block =
+      ((uint32_t)byte_array->buffer[read_index] << 16) |
+      ((uint32_t)byte_array->buffer[read_index + 1] << 8);
+
+    (*base64_str)[write_index++] = base64_chars[(block >> 18) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[(block >> 12) & 0x3F];
+    (*base64_str)[write_index++] = base64_chars[(block >> 6) & 0x3F];
+    (*base64_str)[write_index++] = '=';
+  }
+
+  // Null-terminate the string
+  (*base64_str)[write_index] = '\0';
+
+  return RCUTILS_RET_OK;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/test/test_base64.cpp
+++ b/test/test_base64.cpp
@@ -1,0 +1,451 @@
+// Copyright 2026 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "rcutils/allocator.h"
+#include "rcutils/base64.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types/uint8_array.h"
+
+// Test decode_base64 with valid input
+TEST(TestBase64, DecodeBase64Valid) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  // Test case 1: "Hello"
+  const char * base64_str = "SGVsbG8=";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(5u, byte_array.buffer_length);
+  EXPECT_EQ('H', byte_array.buffer[0]);
+  EXPECT_EQ('e', byte_array.buffer[1]);
+  EXPECT_EQ('l', byte_array.buffer[2]);
+  EXPECT_EQ('l', byte_array.buffer[3]);
+  EXPECT_EQ('o', byte_array.buffer[4]);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 2: "Hello World"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "SGVsbG8gV29ybGQ=";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(11u, byte_array.buffer_length);
+  EXPECT_EQ(0, memcmp(byte_array.buffer, "Hello World", 11));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 3: "ABC"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "QUJD";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(3u, byte_array.buffer_length);
+  EXPECT_EQ('A', byte_array.buffer[0]);
+  EXPECT_EQ('B', byte_array.buffer[1]);
+  EXPECT_EQ('C', byte_array.buffer[2]);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 4: Single byte "A"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "QQ==";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(1u, byte_array.buffer_length);
+  EXPECT_EQ('A', byte_array.buffer[0]);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 5: Two bytes "AB"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "QUI=";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(2u, byte_array.buffer_length);
+  EXPECT_EQ('A', byte_array.buffer[0]);
+  EXPECT_EQ('B', byte_array.buffer[1]);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 6: Binary data {0x00, 0xFF, 0x80, 0x7F}
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "AP+Afw==";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(4u, byte_array.buffer_length);
+  EXPECT_EQ(0x00, byte_array.buffer[0]);
+  EXPECT_EQ(0xFF, byte_array.buffer[1]);
+  EXPECT_EQ(0x80, byte_array.buffer[2]);
+  EXPECT_EQ(0x7F, byte_array.buffer[3]);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+}
+
+// Test decode_base64 with empty string
+TEST(TestBase64, DecodeBase64EmptyString) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  const char * base64_str = "";
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(0u, byte_array.buffer_length);
+  EXPECT_EQ(nullptr, byte_array.buffer);
+}
+
+// Test decode_base64 with NULL inputs
+TEST(TestBase64, DecodeBase64NullInputs) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  const char * base64_str = "SGVsbG8=";
+
+  // NULL base64_str
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(nullptr, &byte_array, &allocator));
+  rcutils_reset_error();
+
+  // NULL byte_array
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, nullptr, &allocator));
+  rcutils_reset_error();
+
+  // NULL allocator
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, &byte_array, nullptr));
+  rcutils_reset_error();
+}
+
+// Test decode_base64 with non-zero-initialized byte_array
+TEST(TestBase64, DecodeBase64NonZeroInitializedArray) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  const char * base64_str = "SGVsbG8=";
+
+  // Initialize the byte_array first
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 10, &allocator));
+
+  // This should fail because byte_array is not zero-initialized
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, &byte_array, &allocator));
+  rcutils_reset_error();
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+}
+
+// Test decode_base64 with invalid base64 string length
+TEST(TestBase64, DecodeBase64InvalidLength) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  // Length not multiple of 4
+  const char * base64_str = "SGVsbG";  // Length 6
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(byte_array.buffer, nullptr);
+  EXPECT_EQ(byte_array.buffer_length, 0u);
+  rcutils_reset_error();
+}
+
+// Test decode_base64 with invalid characters
+TEST(TestBase64, DecodeBase64InvalidCharacters) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  // Invalid character '@'
+  const char * base64_str = "SGVs@G8=";
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(byte_array.buffer, nullptr);
+  EXPECT_EQ(byte_array.buffer_length, 0u);
+  rcutils_reset_error();
+
+  // Invalid character with space
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "SGVs bG8=";
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(byte_array.buffer, nullptr);
+  EXPECT_EQ(byte_array.buffer_length, 0u);
+  rcutils_reset_error();
+}
+
+// Test decode_base64 with invalid padding
+TEST(TestBase64, DecodeBase64InvalidPadding) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  // Padding in wrong position
+  const char * base64_str = "SG=sbG8=";
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  rcutils_reset_error();
+
+  // Invalid padding sequence
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "SGVs=G8=";
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(byte_array.buffer, nullptr);
+  EXPECT_EQ(byte_array.buffer_length, 0u);
+  rcutils_reset_error();
+
+  // More than 2 padding characters
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  base64_str = "SGVs===";  // Not valid length anyway
+  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(byte_array.buffer, nullptr);
+  EXPECT_EQ(byte_array.buffer_length, 0u);
+  rcutils_reset_error();
+}
+
+// Test encode_base64 with valid input
+TEST(TestBase64, EncodeBase64Valid) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * base64_str = nullptr;
+
+  // Test case 1: "Hello"
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data1[] = {'H', 'e', 'l', 'l', 'o'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 5, &allocator));
+  memcpy(byte_array.buffer, data1, 5);
+  byte_array.buffer_length = 5;
+
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("SGVsbG8=", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 2: "Hello World"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data2[] = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 11, &allocator));
+  memcpy(byte_array.buffer, data2, 11);
+  byte_array.buffer_length = 11;
+
+  base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("SGVsbG8gV29ybGQ=", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 3: "ABC"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data3[] = {'A', 'B', 'C'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 3, &allocator));
+  memcpy(byte_array.buffer, data3, 3);
+  byte_array.buffer_length = 3;
+
+  base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("QUJD", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 4: Single byte "A"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data4[] = {'A'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 1, &allocator));
+  memcpy(byte_array.buffer, data4, 1);
+  byte_array.buffer_length = 1;
+
+  base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("QQ==", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 5: Two bytes "AB"
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data5[] = {'A', 'B'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 2, &allocator));
+  memcpy(byte_array.buffer, data5, 2);
+  byte_array.buffer_length = 2;
+
+  base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("QUI=", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+
+  // Test case 6: Binary data {0x00, 0xFF, 0x80, 0x7F}
+  byte_array = rcutils_get_zero_initialized_uint8_array();
+  const uint8_t data6[] = {0x00, 0xFF, 0x80, 0x7F};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 4, &allocator));
+  memcpy(byte_array.buffer, data6, 4);
+  byte_array.buffer_length = 4;
+
+  base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_STREQ("AP+Afw==", base64_str);
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+}
+
+// Test encode_base64 with empty array
+TEST(TestBase64, EncodeBase64EmptyArray) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  char * base64_str = nullptr;
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 0, &allocator));
+  byte_array.buffer_length = 0;
+
+  // Empty array (buffer_length = 0) should return error
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, &allocator));
+  rcutils_reset_error();
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+}
+
+// Test encode_base64 with NULL inputs
+TEST(TestBase64, EncodeBase64NullInputs) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  char * base64_str = nullptr;
+
+  const uint8_t data[] = {'A', 'B', 'C'};
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 3, &allocator));
+  memcpy(byte_array.buffer, data, 3);
+  byte_array.buffer_length = 3;
+
+  // NULL byte_array
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(nullptr, &base64_str, &allocator));
+  rcutils_reset_error();
+
+  // NULL base64_str
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, nullptr, &allocator));
+  rcutils_reset_error();
+
+  // NULL allocator
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, nullptr));
+  rcutils_reset_error();
+
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+}
+
+// Test encode_base64 with NULL buffer in byte_array
+TEST(TestBase64, EncodeBase64NullBuffer) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  char * base64_str = nullptr;
+
+  // byte_array with NULL buffer
+  byte_array.buffer = nullptr;
+  byte_array.buffer_length = 5;
+
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, &allocator));
+  rcutils_reset_error();
+}
+
+// Test round-trip encoding and decoding
+TEST(TestBase64, RoundTripEncodeDecode) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Test various data sizes (excluding empty string as encode_base64 requires length > 0)
+  std::vector<std::string> test_strings = {
+    "A",
+    "AB",
+    "ABC",
+    "ABCD",
+    "Hello World!",
+    "The quick brown fox jumps over the lazy dog",
+    "Base64 encoding test with special chars: !@#$%^&*()_+-=[]{}|;:,.<>?",
+  };
+
+  for (const auto & test_str : test_strings) {
+    // Encode
+    rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+    ASSERT_EQ(RCUTILS_RET_OK,
+      rcutils_uint8_array_init(&byte_array, test_str.size(), &allocator));
+    memcpy(byte_array.buffer, test_str.c_str(), test_str.size());
+    byte_array.buffer_length = test_str.size();
+
+    char * base64_str = nullptr;
+    ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+
+    // Decode
+    rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
+    ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
+
+    // Verify
+    EXPECT_EQ(byte_array.buffer_length, decoded_array.buffer_length);
+    EXPECT_EQ(0, memcmp(byte_array.buffer, decoded_array.buffer, byte_array.buffer_length));
+
+    // Cleanup
+    allocator.deallocate(base64_str, allocator.state);
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&decoded_array));
+  }
+}
+
+// Test round-trip with binary data
+TEST(TestBase64, RoundTripBinaryData) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Test with various binary patterns
+  std::vector<std::vector<uint8_t>> test_data = {
+    {0x00},
+    {0xFF},
+    {0x00, 0xFF},
+    {0xFF, 0x00},
+    {0x00, 0x00, 0x00},
+    {0xFF, 0xFF, 0xFF},
+    {0x00, 0x7F, 0x80, 0xFF},
+    {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+  };
+
+  for (const auto & data : test_data) {
+    // Encode
+    rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, data.size(), &allocator));
+    memcpy(byte_array.buffer, data.data(), data.size());
+    byte_array.buffer_length = data.size();
+
+    char * base64_str = nullptr;
+    ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+
+    // Decode
+    rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
+    ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
+
+    // Verify
+    EXPECT_EQ(data.size(), decoded_array.buffer_length);
+    EXPECT_EQ(0, memcmp(data.data(), decoded_array.buffer, data.size()));
+
+    // Cleanup
+    allocator.deallocate(base64_str, allocator.state);
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&decoded_array));
+  }
+}
+
+// Test encode_base64 with large data
+TEST(TestBase64, EncodeDecodeLargeData) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Create large data (1KB)
+  const size_t data_size = 1024;
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, data_size, &allocator));
+
+  // Fill with pattern
+  for (size_t i = 0; i < data_size; ++i) {
+    byte_array.buffer[i] = static_cast<uint8_t>(i % 256);
+  }
+  byte_array.buffer_length = data_size;
+
+  // Encode
+  char * base64_str = nullptr;
+  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+
+  // Verify encoded length
+  size_t expected_encoded_len = ((data_size + 2) / 3) * 4;
+  EXPECT_EQ(expected_encoded_len, strlen(base64_str));
+
+  // Decode
+  rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
+  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
+
+  // Verify
+  EXPECT_EQ(data_size, decoded_array.buffer_length);
+  EXPECT_EQ(0, memcmp(byte_array.buffer, decoded_array.buffer, data_size));
+
+  // Cleanup
+  allocator.deallocate(base64_str, allocator.state);
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&decoded_array));
+}

--- a/test/test_base64.cpp
+++ b/test/test_base64.cpp
@@ -30,7 +30,7 @@ TEST(TestBase64, DecodeBase64Valid) {
 
   // Test case 1: "Hello"
   const char * base64_str = "SGVsbG8=";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(5u, byte_array.buffer_length);
   EXPECT_EQ('H', byte_array.buffer[0]);
   EXPECT_EQ('e', byte_array.buffer[1]);
@@ -42,7 +42,7 @@ TEST(TestBase64, DecodeBase64Valid) {
   // Test case 2: "Hello World"
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "SGVsbG8gV29ybGQ=";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(11u, byte_array.buffer_length);
   EXPECT_EQ(0, memcmp(byte_array.buffer, "Hello World", 11));
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -50,7 +50,7 @@ TEST(TestBase64, DecodeBase64Valid) {
   // Test case 3: "ABC"
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "QUJD";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(3u, byte_array.buffer_length);
   EXPECT_EQ('A', byte_array.buffer[0]);
   EXPECT_EQ('B', byte_array.buffer[1]);
@@ -60,7 +60,7 @@ TEST(TestBase64, DecodeBase64Valid) {
   // Test case 4: Single byte "A"
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "QQ==";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(1u, byte_array.buffer_length);
   EXPECT_EQ('A', byte_array.buffer[0]);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -68,7 +68,7 @@ TEST(TestBase64, DecodeBase64Valid) {
   // Test case 5: Two bytes "AB"
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "QUI=";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(2u, byte_array.buffer_length);
   EXPECT_EQ('A', byte_array.buffer[0]);
   EXPECT_EQ('B', byte_array.buffer[1]);
@@ -77,7 +77,7 @@ TEST(TestBase64, DecodeBase64Valid) {
   // Test case 6: Binary data {0x00, 0xFF, 0x80, 0x7F}
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "AP+Afw==";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   ASSERT_EQ(4u, byte_array.buffer_length);
   EXPECT_EQ(0x00, byte_array.buffer[0]);
   EXPECT_EQ(0xFF, byte_array.buffer[1]);
@@ -92,7 +92,7 @@ TEST(TestBase64, DecodeBase64EmptyString) {
   rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
 
   const char * base64_str = "";
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &byte_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(0u, byte_array.buffer_length);
   EXPECT_EQ(nullptr, byte_array.buffer);
 }
@@ -104,15 +104,15 @@ TEST(TestBase64, DecodeBase64NullInputs) {
   const char * base64_str = "SGVsbG8=";
 
   // NULL base64_str
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(nullptr, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_decode_base64(nullptr, &byte_array, &allocator));
   rcutils_reset_error();
 
   // NULL byte_array
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, nullptr, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_decode_base64(base64_str, nullptr, &allocator));
   rcutils_reset_error();
 
   // NULL allocator
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, &byte_array, nullptr));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_decode_base64(base64_str, &byte_array, nullptr));
   rcutils_reset_error();
 }
 
@@ -126,7 +126,8 @@ TEST(TestBase64, DecodeBase64NonZeroInitializedArray) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_init(&byte_array, 10, &allocator));
 
   // This should fail because byte_array is not zero-initialized
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT,
+    rcutils_decode_base64(base64_str, &byte_array, &allocator));
   rcutils_reset_error();
 
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -139,7 +140,7 @@ TEST(TestBase64, DecodeBase64InvalidLength) {
 
   // Length not multiple of 4
   const char * base64_str = "SGVsbG";  // Length 6
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(byte_array.buffer, nullptr);
   EXPECT_EQ(byte_array.buffer_length, 0u);
   rcutils_reset_error();
@@ -152,7 +153,7 @@ TEST(TestBase64, DecodeBase64InvalidCharacters) {
 
   // Invalid character '@'
   const char * base64_str = "SGVs@G8=";
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(byte_array.buffer, nullptr);
   EXPECT_EQ(byte_array.buffer_length, 0u);
   rcutils_reset_error();
@@ -160,7 +161,7 @@ TEST(TestBase64, DecodeBase64InvalidCharacters) {
   // Invalid character with space
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "SGVs bG8=";
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(byte_array.buffer, nullptr);
   EXPECT_EQ(byte_array.buffer_length, 0u);
   rcutils_reset_error();
@@ -173,13 +174,13 @@ TEST(TestBase64, DecodeBase64InvalidPadding) {
 
   // Padding in wrong position
   const char * base64_str = "SG=sbG8=";
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   rcutils_reset_error();
 
   // Invalid padding sequence
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "SGVs=G8=";
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(byte_array.buffer, nullptr);
   EXPECT_EQ(byte_array.buffer_length, 0u);
   rcutils_reset_error();
@@ -187,7 +188,7 @@ TEST(TestBase64, DecodeBase64InvalidPadding) {
   // More than 2 padding characters
   byte_array = rcutils_get_zero_initialized_uint8_array();
   base64_str = "SGVs===";  // Not valid length anyway
-  EXPECT_EQ(RCUTILS_RET_ERROR, decode_base64(base64_str, &byte_array, &allocator));
+  EXPECT_EQ(RCUTILS_RET_ERROR, rcutils_decode_base64(base64_str, &byte_array, &allocator));
   EXPECT_EQ(byte_array.buffer, nullptr);
   EXPECT_EQ(byte_array.buffer_length, 0u);
   rcutils_reset_error();
@@ -205,7 +206,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   memcpy(byte_array.buffer, data1, 5);
   byte_array.buffer_length = 5;
 
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("SGVsbG8=", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -218,7 +219,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   byte_array.buffer_length = 11;
 
   base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("SGVsbG8gV29ybGQ=", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -231,7 +232,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   byte_array.buffer_length = 3;
 
   base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("QUJD", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -244,7 +245,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   byte_array.buffer_length = 1;
 
   base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("QQ==", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -257,7 +258,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   byte_array.buffer_length = 2;
 
   base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("QUI=", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -270,7 +271,7 @@ TEST(TestBase64, EncodeBase64Valid) {
   byte_array.buffer_length = 4;
 
   base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   EXPECT_STREQ("AP+Afw==", base64_str);
   allocator.deallocate(base64_str, allocator.state);
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -286,7 +287,8 @@ TEST(TestBase64, EncodeBase64EmptyArray) {
   byte_array.buffer_length = 0;
 
   // Empty array (buffer_length = 0) should return error
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT,
+    rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   rcutils_reset_error();
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
 }
@@ -303,15 +305,15 @@ TEST(TestBase64, EncodeBase64NullInputs) {
   byte_array.buffer_length = 3;
 
   // NULL byte_array
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(nullptr, &base64_str, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_encode_base64(nullptr, &base64_str, &allocator));
   rcutils_reset_error();
 
   // NULL base64_str
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, nullptr, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_encode_base64(&byte_array, nullptr, &allocator));
   rcutils_reset_error();
 
   // NULL allocator
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, nullptr));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, rcutils_encode_base64(&byte_array, &base64_str, nullptr));
   rcutils_reset_error();
 
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_uint8_array_fini(&byte_array));
@@ -327,7 +329,8 @@ TEST(TestBase64, EncodeBase64NullBuffer) {
   byte_array.buffer = nullptr;
   byte_array.buffer_length = 5;
 
-  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, encode_base64(&byte_array, &base64_str, &allocator));
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT,
+    rcutils_encode_base64(&byte_array, &base64_str, &allocator));
   rcutils_reset_error();
 }
 
@@ -355,12 +358,11 @@ TEST(TestBase64, RoundTripEncodeDecode) {
     byte_array.buffer_length = test_str.size();
 
     char * base64_str = nullptr;
-    ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
 
     // Decode
     rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
-    ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
-
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &decoded_array, &allocator));
     // Verify
     EXPECT_EQ(byte_array.buffer_length, decoded_array.buffer_length);
     EXPECT_EQ(0, memcmp(byte_array.buffer, decoded_array.buffer, byte_array.buffer_length));
@@ -396,12 +398,11 @@ TEST(TestBase64, RoundTripBinaryData) {
     byte_array.buffer_length = data.size();
 
     char * base64_str = nullptr;
-    ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
 
     // Decode
     rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
-    ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
-
+    ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &decoded_array, &allocator));
     // Verify
     EXPECT_EQ(data.size(), decoded_array.buffer_length);
     EXPECT_EQ(0, memcmp(data.data(), decoded_array.buffer, data.size()));
@@ -430,7 +431,7 @@ TEST(TestBase64, EncodeDecodeLargeData) {
 
   // Encode
   char * base64_str = nullptr;
-  ASSERT_EQ(RCUTILS_RET_OK, encode_base64(&byte_array, &base64_str, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_encode_base64(&byte_array, &base64_str, &allocator));
 
   // Verify encoded length
   size_t expected_encoded_len = ((data_size + 2) / 3) * 4;
@@ -438,7 +439,7 @@ TEST(TestBase64, EncodeDecodeLargeData) {
 
   // Decode
   rcutils_uint8_array_t decoded_array = rcutils_get_zero_initialized_uint8_array();
-  ASSERT_EQ(RCUTILS_RET_OK, decode_base64(base64_str, &decoded_array, &allocator));
+  ASSERT_EQ(RCUTILS_RET_OK, rcutils_decode_base64(base64_str, &decoded_array, &allocator));
 
   // Verify
   EXPECT_EQ(data_size, decoded_array.buffer_length);


### PR DESCRIPTION
## Description

Add base64 encode and decode functionality. This is necessary when configuring binary data in YAML files.

The related issue is ros2/rcl#1256.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Yes.  The GitHub Copilot (Claude Sonnet 4.5) is used to generate code comments, some parts of the code, and test code.

### Additional Information

