### PR TITLE
Fix gcc 15.2.1 warning for discarding 'const' qualifier

### DIFF
--- a/src/strdup.c
+++ b/src/strdup.c
@@ -44,7 +44,7 @@ rcutils_strndup(const char * str, size_t max_length, rcutils_allocator_t allocat
     return NULL;
   }
   RCUTILS_CHECK_ALLOCATOR(&allocator, return NULL);
-  char * p = memchr(str, '\0', max_length);
+  const char * p = memchr(str, '\0', max_length);
   size_t string_length = p == NULL ? max_length : (size_t)(p - str);
   char * new_string = allocator.allocate(string_length + 1, allocator.state);
   if (NULL == new_string) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Compiling with gcc version 15.2.1 generates the following warning

```
external/ros2_rcutils+/src/strdup.c: In function 'rcutils_strndup':
external/ros2_rcutils+/src/strdup.c:47:14: warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
   47 |   char * p = memchr(str, '\0', max_length);
      |              ^~~~~~
```
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
