### PR TITLE
Fix missing include for std::get_time

### DIFF
--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -16,6 +16,7 @@
 
 #include <chrono>
 #include <cinttypes>
+#include <iomanip>
 #include <thread>
 
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"


### PR DESCRIPTION
## Description
Uncovered when using system gtest version

Part of https://github.com/ament/googletest/issues/37
### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

no

### Additional Information

Part of removing gtest_vendor and gmock_vendor for ROS Lyrical
