### PR TITLE
Use less common variable name in macro

### DIFF
--- a/include/rcutils/error_handling.h
+++ b/include/rcutils/error_handling.h
@@ -240,8 +240,9 @@ rcutils_set_error_state(const char * error_string, const char * file, size_t lin
 #define RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(format_string, ...) \
   do { \
     char output_msg[RCUTILS_ERROR_MESSAGE_MAX_LENGTH]; \
-    int ret = rcutils_snprintf(output_msg, sizeof(output_msg), format_string, __VA_ARGS__); \
-    if (ret < 0) { \
+    int __rcutils_snprintf_ret = \
+      rcutils_snprintf(output_msg, sizeof(output_msg), format_string, __VA_ARGS__); \
+    if (__rcutils_snprintf_ret < 0) { \
       RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to call snprintf for error message formatting\n"); \
     } else { \
       RCUTILS_SET_ERROR_MSG(output_msg); \


### PR DESCRIPTION
## Description

Part of https://github.com/ros2/rcl/pull/1312

The variable name `ret` was colliding with other variables named `ret` in the above PR's new macro, and that caused warnings on Windows.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, I used gemini to find this issue

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
