### PR TITLE
Remove ATOMIC_VAR_INIT

### DIFF
--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,7 @@
 
 #include "rcutils/stdatomic_helper.h"
 
-static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
+static atomic_int_least64_t g_rcutils_fault_injection_count = {-1};
 
 void rcutils_fault_injection_set_count(int_least64_t count)
 {

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,7 @@
 
 #include "rcutils/stdatomic_helper.h"
 
-static atomic_int_least64_t g_rcutils_fault_injection_count = ATOMIC_VAR_INIT(-1);
+static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
 
 void rcutils_fault_injection_set_count(int_least64_t count)
 {


### PR DESCRIPTION
## Description

This fixes a new compile error on Ubuntu Resolute. The `ATOMIC_VAR_INIT` macro was deprecated in C17 and removed in C23. Lyrical targets C17, so I'm not 100% sure why the macro dissapeared. My best guess is CMake decided C23 "satisfies" the [requirement for C17 features](https://github.com/ros2/ament_cmake_ros/blob/875ef9161ac8e5b8544c01a477784c5116414bc2/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake#L19), and is using that.

```
In file included from /workspaces/lyrical/src/ros2/rcutils/src/filesystem.c:42:
/workspaces/lyrical/src/ros2/rcutils/src/filesystem.c: In function ‘rcutils_dir_iter_next’:
/workspaces/lyrical/src/ros2/rcutils/src/filesystem.c:478:67: warning: statement with no effect [-Wunused-value]
  478 |   RCUTILS_CHECK_FOR_NULL_WITH_MSG(iter->state, "iter is invalid", false);
      |                                                                   ^~~~~
/workspaces/lyrical/src/ros2/rcutils/include/rcutils/error_handling.h:215:7: note: in definition of macro ‘RCUTILS_CHECK_FOR_NULL_WITH_MSG’
  215 |       error_statement; \
      |       ^~~~~~~~~~~~~~~
/workspaces/lyrical/src/ros2/rcutils/src/testing/fault_injection.c:19:63: error: implicit declaration of function ‘ATOMIC_VAR_INIT’; did you mean ‘ATOMIC_FLAG_INIT’? [-Wimplicit-function-declaration]
   19 | static atomic_int_least64_t g_rcutils_fault_injection_count = ATOMIC_VAR_INIT(-1);
      |                                                               ^~~~~~~~~~~~~~~
      |                                                               ATOMIC_FLAG_INIT
/workspaces/lyrical/src/ros2/rcutils/src/testing/fault_injection.c:19:63: error: initializer element is not constant
gmake[2]: *** [CMakeFiles/rcutils.dir/build.make:443: CMakeFiles/rcutils.dir/src/testing/fault_injection.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:294: CMakeFiles/rcutils.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

### Is this user-facing behavior change?

no

### Did you use Generative AI?

I used gemini to research the replacement

### Additional Information

Docs that talk about why ATOMIC_VAR_INIT is replaced with normal initialization: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2886.htm