### PR TITLE
fix: typo in parameter documentation for overwrite

### DIFF
--- a/include/rcutils/env.h
+++ b/include/rcutils/env.h
@@ -74,7 +74,7 @@ rcutils_set_env(const char * env_name, const char * env_value);
  * \param[in] env_name Name of the environment variable to modify.
  * \param[in] env_value Value to set the environment variable to, or `NULL` to
  *   un-set.
- * \param[in] overwrite If true, the environemnt variable value will not be overwritten
+ * \param[in] overwrite If false, the environment variable value will not be overwritten
  *   if previously set.
  * \return `true` if success, or
  * \return `false` if env_name is invalid or NULL, or


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

Fixes a typo I discovered while reviewing https://github.com/ros2/rmw_fastrtps/pull/872

The behavior of the `overwrite` parameter in `rcutils_set_env_overwrite` is what one would expect:
* `true` means change value if variable was already set
* `false` means keep value if variable was already set

Surprisingly, the documentation said the opposite.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?
No, but it fixes the documentation to the actual behavior.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

Backporting probably makes sense.
<!--
If applicable, provide any additional context or details about the changes.
-->
