### PR TITLE
address warning: statement with no effect.

### DIFF
--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -475,7 +475,7 @@ bool
 rcutils_dir_iter_next(rcutils_dir_iter_t * iter)
 {
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(iter, false);
-  RCUTILS_CHECK_FOR_NULL_WITH_MSG(iter->state, "iter is invalid", false);
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(iter->state, "iter is invalid", return false);
 
 #ifdef _WIN32
   if (FindNextFile(iter->state->handle, &iter->state->data)) {


### PR DESCRIPTION
## Description

see https://ci.ros2.org/job/ci_linux-aarch64/21795/clang-tidy/folder.-1643903456/source.270fa858-97ec-4b07-9c86-ec11c84b9370/#478

```console
--- stderr: rcutils                                                            
In file included from /root/ros2_ws/colcon_ws/src/ros2/rcutils/src/filesystem.c:42:
/root/ros2_ws/colcon_ws/src/ros2/rcutils/src/filesystem.c: In function ‘rcutils_dir_iter_next’:
/root/ros2_ws/colcon_ws/src/ros2/rcutils/src/filesystem.c:478:67: warning: statement with no effect [-Wunused-value]
  478 |   RCUTILS_CHECK_FOR_NULL_WITH_MSG(iter->state, "iter is invalid", false);
      |                                                                   ^~~~~
/root/ros2_ws/colcon_ws/src/ros2/rcutils/include/rcutils/error_handling.h:215:7: note: in definition of macro ‘RCUTILS_CHECK_FOR_NULL_WITH_MSG’
  215 |       error_statement; \
      |       ^~~~~~~~~~~~~~~
---
```

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

we need to backport this fix to all downstream branches.

<!--
If applicable, provide any additional context or details about the changes.
-->
