### PR TITLE
Fix process exit crash in Clang builds by using RTLD_NODELETE for shared libraries

### DIFF
--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -91,7 +91,10 @@ rcutils_load_shared_library(
   // for further reference.
 
 #ifndef _WIN32
-  lib->lib_pointer = dlopen(library_path, RTLD_LAZY);
+  // RTLD_NODELETE: don't unmap on dlclose. Heap-resident references into the
+  // library (e.g. shared_ptr/weak_ptr control-block vtables) can outlive the
+  // dlopen/dlclose cycle; unmapping would dangle them.
+  lib->lib_pointer = dlopen(library_path, RTLD_LAZY | RTLD_NODELETE);
   if (NULL == lib->lib_pointer) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("dlopen error: %s", dlerror());
     return RCUTILS_RET_ERROR;


### PR DESCRIPTION
## Description

Adds `RTLD_NODELETE` to the `dlopen` call in `rcutils_load_shared_library` so plugin libraries stay mapped after `dlclose`. The refcount still drops normally — only the kernel mapping is preserved.

This fixes a crash where a `pluginlib` plugin that registers a service on the host node causes a segfault at process exit when built with Clang (e.g., when compiling with `export CC=clang` and `export CXX=clang++`). 

This issue is not specific to Kilted and Rolling; it also affects older ROS 2 distributions such as Jazzy.

Original report and reproducer:
- https://robotics.stackexchange.com/questions/118277/ros-2-service-inside-a-plugin-crashes-on-destruction-of-rclcppnode
- https://github.com/kbrameld/plugin_service_bug

This is most likely ignored by most users of clang - but such segmentation faults will cause test failures in CI systems during destruction.

### Is this user-facing behavior change?

* **For GCC builds:** No. GCC-built plugins have effectively always stayed mapped due to implicit `STB_GNU_UNIQUE` behavior.
* **For Clang builds:** Yes, but as a bug fix/stability improvement. Plugin `.so`s will now safely stay mapped for the process lifetime instead of being unmapped on `dlclose`, preventing a latent segmentation fault at shutdown.

### Did you use Generative AI?

Yes — I used Claude Code to help debug the crash, identify the `STB_GNU_UNIQUE` mechanism, and prepare the PR. The patch and PR text were reviewed by me.

---

### Additional Information

#### The Root Cause: Destruction Order & Cross-DSO UAF
The crash is a cross-DSO `shared_ptr` use-after-free (UAF) that occurs due to a common teardown sequence: **the class loader is destructed before the `rclcpp::Node` is.**
1. When a plugin calls `node->create_service<T>(...)`, the resulting control block has its vtable inside the plugin `.so` (the templated factory is instantiated in the plugin's translation unit). 
2. `rclcpp::CallbackGroup` holds a `weak_ptr<ServiceBase>` to that control block.
3. Because the class loader is destroyed first, `dlclose` is invoked and the plugin is unmapped.
4. Finally, during the destructor of the `rclcpp::Node` (`~Node` → `~CallbackGroup` → `~weak_ptr`), a virtual `_M_destroy()` is triggered on the control block. Because the plugin memory has already been unmapped, reading the vtable causes a segmentation fault.

#### Why This Only Happens with Clang
Under GCC, this latent bug is hidden. GCC emits `STB_GNU_UNIQUE` symbols for ordinary template instantiations (which the plugin picks up via `std::variant` in `rclcpp/any_service_callback.hpp`). By default, `glibc` refuses to unmap any DSO containing bound unique symbols. Consequently, GCC-built plugins have effectively been receiving `RTLD_NODELETE` behavior by accident.

Clang does not emit unique symbols by default. Therefore, `dlclose` successfully unmaps the library, reliably triggering the UAF crash at process exit.

#### Verification
Confirmed the fix using the provided reproducer compiled with Clang. The plugin no longer segfaults at exit, and GDB verifies that the plugin pages remain mapped through the entire `~Node` execution.