### PR TITLE
skip libatomic if mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_libraries(${PROJECT_NAME}
 
 check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
 
-if(HAVE_LIBATOMICS AND NOT WIN32)
+if(HAVE_LIBATOMICS AND NOT WIN32 AND NOT APPLE)
   # Link libatomic into rcutils for fault injection atomic operations.
   # Don't export it - downstream packages get atomic symbols transitively
   # through librcutils.so. See https://github.com/ros2/rcutils/issues/525


### PR DESCRIPTION
## Description

skip libatomic if mac

This check is not correctly stopping -latomic from being used on all apple computers. This causes all downstream libraries to fail to link.

Fixes # (issue)
https://github.com/RoboStack/ros-jazzy/issues/217
### Is this user-facing behavior change?
Building


<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

### Additional Information

