### PR TITLE
Fix backtrace call and variable setting in CMake

### DIFF
--- a/cmake/check_c_compiler_uses_glibc.cmake
+++ b/cmake/check_c_compiler_uses_glibc.cmake
@@ -26,11 +26,11 @@ function(check_c_compiler_uses_glibc result_variable)
     int main() {
       void * buffer[1];
       int size = sizeof(buffer) / sizeof(void *);
-      backtrace(&buffer, size);
+      backtrace(buffer, size);
       return 0;
     }
   ]====])
 
   check_c_source_compiles("${GLIBC_TEST_CODE}" ${result_variable})
-  set(${result_variable} ${result_variable} PARENT_SCOPE)
+  set(${result_variable} ${${result_variable}} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Description

Two likely issues in `cmake/check_c_compiler_uses_glibc.cmake`:

**1. Type mismatch.** `backtrace(&buffer, size)` passes `void *(*)[1]` where `void **` is expected. On gcc >= 14 (default-error on `-Wincompatible-pointer-types`), the probe fails to compile on glibc. Fix: drop the `&`.

**2. Result not propagated.** `set(${result_variable} ${result_variable} PARENT_SCOPE)` looks like it's missing a `$`. In a small repro, `if(USES_GLIBC)` evaluates truthy regardless of probe outcome. Fix: `${${result_variable}}`.

### Is this user-facing behavior change?

Possibly. `_GNU_SOURCE` would only be defined when glibc is actually detected, and the configure log on gcc >= 14 + glibc would no longer print `Performing Test USES_GLIBC - Failed`.

### Did you use Generative AI?

Yes. Claude Code helped diagnose and verify. I reviewed the changes myself.

### Additional Information

Repro for 1: `gcc -Werror=incompatible-pointer-types` on the extracted snippet. Repro for 2: minimal `CMakeLists.txt` calling the function and printing `${USES_GLIBC}`.