### PR TITLE
Fix glibc detection

### DIFF
--- a/cmake/check_c_compiler_uses_glibc.cmake
+++ b/cmake/check_c_compiler_uses_glibc.cmake
@@ -21,16 +21,17 @@ function(check_c_compiler_uses_glibc result_variable)
   include(CheckCSourceCompiles)
 
   set(GLIBC_TEST_CODE [====[
-    #include <execinfo.h>
+    #include <features.h>
 
+    #if defined(__GLIBC__)
     int main() {
-      void * buffer[1];
-      int size = sizeof(buffer) / sizeof(void *);
-      backtrace(&buffer, size);
       return 0;
     }
+    #else
+    #error
+    #endif
   ]====])
 
   check_c_source_compiles("${GLIBC_TEST_CODE}" ${result_variable})
-  set(${result_variable} ${result_variable} PARENT_SCOPE)
+  set(${result_variable} "${${result_variable}}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
## Summary
- Detect glibc through its `__GLIBC__` identification macro instead of treating the non-unique `backtrace()` API as a proxy.
- Propagate the actual `check_c_source_compiles()` result to the caller rather than the result variable's name.

Closes #574.

## Why
Other C libraries can provide a compatible `backtrace()` implementation, so compiling that call does not prove that the compiler targets glibc. Additionally, the existing `PARENT_SCOPE` assignment stores the literal result variable name, preventing the caller from receiving the boolean compiler-test result.

## Testing
- Used an isolated CMake project with two synthetic libc headers. Before this change, both cases compiled and reported `parent='<RESULT_VARIABLE>'`, including the non-glibc case.
- After this change, the glibc case reports `parent='1', cache='1'`; the non-glibc case reports `parent='', cache=''`.
- Parsed the helper with CMake 3.31.6 using `cmake -P`.
- `git diff origin/rolling...HEAD --check`
- Not run: the full rcutils package build, because this Windows workstation does not have the ROS 2/ament build dependencies installed.
