### PR TITLE
Fix bounded concatenation in char arrays

### DIFF
--- a/src/char_array.c
+++ b/src/char_array.c
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include <stdarg.h>
+#include <stdint.h>
 #include "rcutils/error_handling.h"
+#include "rcutils/strnlen.h"
 #include "rcutils/types/char_array.h"
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -220,14 +222,19 @@ rcutils_char_array_strncat(rcutils_char_array_t * char_array, const char * src, 
     // The buffer length always contains the trailing \0, so the strlen is one less than that.
     current_strlen = char_array->buffer_length - 1;
   }
-  size_t new_length = current_strlen + n + 1;
+  size_t copy_length = rcutils_strnlen(src, n);
+  if (copy_length > SIZE_MAX - current_strlen - 1) {
+    RCUTILS_SET_ERROR_MSG("requested size for char_array too large");
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  size_t new_length = current_strlen + copy_length + 1;
   rcutils_ret_t ret = rcutils_char_array_expand_as_needed(char_array, new_length);
   if (ret != RCUTILS_RET_OK) {
     // rcutils_char_array_expand_as_needed already set the error
     return ret;
   }
 
-  memcpy(char_array->buffer + current_strlen, src, n);
+  memcpy(char_array->buffer + current_strlen, src, copy_length);
   char_array->buffer[new_length - 1] = '\0';
 
   char_array->buffer_length = new_length;

--- a/test/test_char_array.cpp
+++ b/test/test_char_array.cpp
@@ -156,7 +156,9 @@ TEST_F(ArrayCharTest, strcat) {
   EXPECT_STREQ("1234", char_array.buffer);
   EXPECT_EQ(5lu, char_array.buffer_length);
 
-  EXPECT_EQ(RCUTILS_RET_OK, rcutils_char_array_strcat(&char_array, "56"));
+  const char source[] = {'5', '6', '\0', 'x', 'x'};
+  EXPECT_EQ(RCUTILS_RET_OK,
+    rcutils_char_array_strncat(&char_array, source, sizeof(source)));
   EXPECT_STREQ("123456", char_array.buffer);
   EXPECT_EQ(7lu, char_array.buffer_length);
 


### PR DESCRIPTION
## Summary

- stop `rcutils_char_array_strncat()` at the source string terminator when it appears before `n`
- calculate capacity and `buffer_length` from the bytes actually copied
- reject destination length arithmetic overflow before resizing or copying

## Testing

- linked a focused C probe against `origin/rolling`: returned success with `buffer_length=10` for a two-character source
- linked the same probe against this change: returned success with `buffer_length=7` and `123456`
- compiled `src/char_array.c` as C11 with Zig
- `git diff --check`