### PR TITLE
Reject overflowing hash map capacities

### DIFF
--- a/src/hash_map.c
+++ b/src/hash_map.c
@@ -19,6 +19,7 @@ extern "C"
 
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
@@ -86,7 +87,10 @@ static rcutils_ret_t hash_map_allocate_new_map(
   rcutils_array_list_t ** map, size_t capacity,
   const rcutils_allocator_t * allocator)
 {
-  *map = allocator->allocate(capacity * sizeof(rcutils_hash_map_impl_t), allocator->state);
+  if (0 == capacity || capacity > SIZE_MAX / sizeof(rcutils_array_list_t)) {
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+  *map = allocator->allocate(capacity * sizeof(rcutils_array_list_t), allocator->state);
   if (NULL == *map) {
     return RCUTILS_RET_BAD_ALLOC;
   }
@@ -240,7 +244,7 @@ static size_t next_power_of_two(size_t v)
     v |= v >> shf;
   }
   v++;
-  return v > 1 ? v : 1;
+  return v;
 }
 
 rcutils_ret_t

--- a/test/test_hash_map.cpp
+++ b/test/test_hash_map.cpp
@@ -107,6 +107,22 @@ TEST_F(HashMapBaseTest, init_map_initial_capacity_not_power_of_two) {
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
 }
 
+TEST_F(HashMapBaseTest, init_map_initial_capacity_overflow_fails) {
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, SIZE_MAX, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, map.impl);
+}
+
+TEST_F(HashMapBaseTest, init_map_allocation_size_overflow_fails) {
+  rcutils_ret_t ret = rcutils_hash_map_init(
+    &map, (SIZE_MAX >> 1) + 1, sizeof(uint32_t), sizeof(uint32_t),
+    test_hash_map_uint32_hash_func, test_uint32_cmp, &allocator);
+  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, ret) << rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, map.impl);
+}
+
 TEST_F(HashMapBaseTest, init_map_key_size_zero_fails) {
   rcutils_ret_t ret = rcutils_hash_map_init(
     &map, 2, 0, sizeof(uint32_t),


### PR DESCRIPTION
## Summary

- preserve an overflowing power-of-two rounding result instead of silently converting it to capacity 1
- reject zero or overflowing bucket-array capacities in the shared allocation path used by initialization and growth
- allocate the bucket array using the actual `rcutils_array_list_t` element size

## Testing

- added focused tests for rounding overflow and bucket-array size overflow
- linked a focused probe against `origin/rolling`: `SIZE_MAX` returned success with `initialized=1`
- linked the same probe against this change: returned `RCUTILS_RET_BAD_ALLOC` with `initialized=0`
- compiled `src/hash_map.c` as C11 with Zig using `-Wall -Wextra -Werror`
- `git diff --check`