### PR TITLE
Link rcutils against Threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,11 @@ if(BUILD_TESTING AND NOT RCUTILS_DISABLE_FAULT_INJECTION)
 endif()
 
 target_link_libraries(${PROJECT_NAME}
-  ${CMAKE_DL_LIBS}
-  Threads::Threads
-  ament_cmake_ros_core::ament_ros_defaults
+  PUBLIC
+    ${CMAKE_DL_LIBS}
+    ament_cmake_ros_core::ament_ros_defaults
+  PRIVATE
+    Threads::Threads
 )
 
 check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
@@ -102,8 +104,9 @@ if(HAVE_LIBATOMICS AND NOT WIN32 AND NOT APPLE)
   # Don't export it - downstream packages get atomic symbols transitively
   # through librcutils.so. See https://github.com/ros2/rcutils/issues/525
   target_link_libraries(${PROJECT_NAME}
-    atomic
-    ament_cmake_ros_core::ament_ros_defaults
+    PUBLIC
+      atomic
+      ament_cmake_ros_core::ament_ros_defaults
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(CheckLibraryExists)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros_core REQUIRED)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
 if(UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ target_link_libraries(${PROJECT_NAME}
   Threads::Threads
   ament_cmake_ros_core::ament_ros_defaults
 )
-ament_export_dependencies(Threads)
 
 check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ include(CheckLibraryExists)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_ros_core REQUIRED)
+find_package(Threads REQUIRED)
 
 if(UNIX AND NOT APPLE)
   include(cmake/check_c_compiler_uses_glibc.cmake)
@@ -89,8 +90,10 @@ endif()
 
 target_link_libraries(${PROJECT_NAME}
   ${CMAKE_DL_LIBS}
+  Threads::Threads
   ament_cmake_ros_core::ament_ros_defaults
 )
+ament_export_dependencies(Threads)
 
 check_library_exists(atomic __atomic_load_8 "" HAVE_LIBATOMICS)
 


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: `patch/ros-rolling-rcutils.patch`, authored by Daisuke Nishimatsu.

This extracts the thread-linking portion of the downstream patch. `rcutils` uses pthread-backed functionality, for example `pthread_once` in `src/base64.c` and the pthread fallback path for thread-local storage on older iOS. Finding and linking CMake's `Threads::Threads` target makes that dependency explicit, and exporting `Threads` makes the package metadata more conservative for downstream consumers.
