### PR TITLE
Normalize extern "C" guards to #ifdef __cplusplus

### DIFF
--- a/include/rcutils/types/char_array.h
+++ b/include/rcutils/types/char_array.h
@@ -17,7 +17,7 @@
 #ifndef RCUTILS__TYPES__CHAR_ARRAY_H_
 #define RCUTILS__TYPES__CHAR_ARRAY_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -239,7 +239,7 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_char_array_strcpy(rcutils_char_array_t * char_array, const char * src);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/rcutils/types/uint8_array.h
+++ b/include/rcutils/types/uint8_array.h
@@ -17,7 +17,7 @@
 #ifndef RCUTILS__TYPES__UINT8_ARRAY_H_
 #define RCUTILS__TYPES__UINT8_ARRAY_H_
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -114,7 +114,7 @@ RCUTILS_WARN_UNUSED
 rcutils_ret_t
 rcutils_uint8_array_resize(rcutils_uint8_array_t * uint8_array, size_t new_size);
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/time.c
+++ b/src/time.c
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if __cplusplus
+#ifdef __cplusplus
 extern "C"
 {
 #endif
@@ -123,6 +123,6 @@ rcutils_time_point_value_as_seconds_string(
   return RCUTILS_RET_OK;
 }
 
-#if __cplusplus
+#ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description

char_array.h, uint8_array.h, and time.c used `#if __cplusplus`, while all other headers use `#ifdef __cplusplus`. Aligns the three outliers to the dominant convention, avoiding the -Wundef diagnostics these guards triggered. No behavioral change.

No associated issue, this is a self-contained consistency fix surfaced by auditing the headers against the repo's dominant `extern "C"` guard convention.

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No, the discrepancy was discovered by running gcc with extra lint flags (`-Wundef`).

### Additional Information

Lint-only, `#if` and `#ifdef` are equivalent for the `__cplusplus` macro, no behavioral change.
