### PR TITLE
Fix atomic assignment for clang on MacOS

### DIFF
--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,7 @@
 
 #include "rcutils/stdatomic_helper.h"
 
-static atomic_int_least64_t g_rcutils_fault_injection_count = {-1};
+static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
 
 void rcutils_fault_injection_set_count(int_least64_t count)
 {


### PR DESCRIPTION
## Description

Without this change, I get the following error on MacOS with clang 21.1.8:

    /nix/var/nix/builds/nix-30990-3110187581/rcutils-release-release-lyrical-rcutils-7.1.2-1/src/testing/fault_injection.c:19:63:
    error: illegal initializer type 'atomic_int_least64_t' (aka '_Atomic(int_least64_t)')
       19 | static atomic_int_least64_t g_rcutils_fault_injection_count = {-1};

### Did you use Generative AI?

no

