### PR TITLE
an explicit platform split matching the helper header's own condition.

### DIFF
--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,15 @@
 
 #include "rcutils/stdatomic_helper.h"
 
+// The initializer must match the definition of _Atomic in
+// rcutils/stdatomic_helper.h: on MSVC atomics are emulated with a struct
+// (requiring a braced initializer), everywhere else they are real C11
+// atomics (requiring a plain scalar initializer).
+#if defined(_WIN32) && !defined(__MINGW64__)
 static atomic_int_least64_t g_rcutils_fault_injection_count = {-1};
+#else
+static atomic_int_least64_t g_rcutils_fault_injection_count = -1;
+#endif
 
 void rcutils_fault_injection_set_count(int_least64_t count)
 {


### PR DESCRIPTION
## Description

replaces https://github.com/ros2/rcutils/pull/586

note: I first applied ATOMIC_VAR_INIT(-1) as suggested, but when I tested it in C23 mode (gcc -std=gnu2x), it failed — ATOMIC_VAR_INIT is already removed from this toolchain's <stdatomic.h>, producing "implicit declaration of function 'ATOMIC_VAR_INIT'" followed by "initializer element is not constant". which isn't theoretical. I switched to the fallback to have an explicit platform split matching the helper header's own condition.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
