### PR TITLE
Add RCUTILS_ATOMIC_INIT for portable static initialisation

### DIFF
--- a/include/rcutils/stdatomic_helper.h
+++ b/include/rcutils/stdatomic_helper.h
@@ -173,6 +173,18 @@ rcutils_atomic_fetch_add_uint64_t(atomic_uint_least64_t * a_uint64_t, uint64_t a
   return result;
 }
 
+// Static initialisation of an atomic needs a different spelling depending on
+// how _Atomic is defined.  The bundled shims define it as a struct and provide
+// a matching ATOMIC_VAR_INIT; the native <stdatomic.h> defines it as a scalar
+// and, since C23 removed ATOMIC_VAR_INIT, may not provide one at all.  Where
+// the macro is absent the type is the native scalar, which a plain value
+// initialises.  See https://github.com/ros2/rcutils/issues/553.
+#ifdef ATOMIC_VAR_INIT
+#define RCUTILS_ATOMIC_INIT(value) ATOMIC_VAR_INIT(value)
+#else
+#define RCUTILS_ATOMIC_INIT(value) (value)
+#endif
+
 #if !defined(_WIN32)
 # pragma GCC diagnostic pop
 #endif

--- a/src/testing/fault_injection.c
+++ b/src/testing/fault_injection.c
@@ -16,7 +16,7 @@
 
 #include "rcutils/stdatomic_helper.h"
 
-static atomic_int_least64_t g_rcutils_fault_injection_count = {-1};
+static atomic_int_least64_t g_rcutils_fault_injection_count = RCUTILS_ATOMIC_INIT(-1);
 
 void rcutils_fault_injection_set_count(int_least64_t count)
 {


### PR DESCRIPTION
## Description

Apple clang rejects the brace-enclosed initialiser on the fault injection counter:

```
fault_injection.c:19:63: error: illegal initializer type
'atomic_int_least64_t' (aka '_Atomic(int_least64_t)')
```

The counter cannot be statically initialised with one spelling on every platform, because `atomic_int_least64_t` is not the same kind of type everywhere. The bundled shims define `_Atomic(T)` as a struct, so the initialiser has to be brace enclosed; with the native C11 `_Atomic` the type is scalar, and braces there are what clang rejects. Dropping the braces outright fixes clang but breaks MSVC with C2074.

The shims already carry an `ATOMIC_VAR_INIT` matched to their own `_Atomic`, so `RCUTILS_ATOMIC_INIT` just defers to it where it exists:

```c
#ifdef ATOMIC_VAR_INIT
#define RCUTILS_ATOMIC_INIT(value) ATOMIC_VAR_INIT(value)
#else
#define RCUTILS_ATOMIC_INIT(value) (value)
#endif
```

`ATOMIC_VAR_INIT` is only missing on the native header in C23 mode, which is exactly what broke the build in #553 (`implicit declaration of function 'ATOMIC_VAR_INIT'`). In that configuration `_Atomic` is the scalar that a plain value initialises, so the fallback is correct. This leaves both vendored shim headers untouched.

Covers the four configurations:

| header | `_Atomic` | `ATOMIC_VAR_INIT` | expansion |
| --- | --- | --- | --- |
| `win32/stdatomic.h` | struct | yes | `{.__val = (value)}` |
| `gcc/stdatomic.h`, `__CLANG_ATOMICS` | builtin scalar | yes | `(value)` |
| `gcc/stdatomic.h`, otherwise | struct | yes | `{ .__val = (value) }` |
| native `<stdatomic.h>`, C23 | scalar | no | `(value)` |

### Is this user-facing behavior change?

No behaviour change. It does add a macro to a public header.

### Additional Information

Verified the preprocessed expansion on the MSVC path is `{.__val = (-1)}`, and that it builds clean at `/W4 /WX` with MSVC 14.51. The gcc and clang paths need CI.
