### PR TITLE
Add emscripten guards to shared_library.c's dlopen path

### DIFF
--- a/src/shared_library.c
+++ b/src/shared_library.c
@@ -124,7 +124,13 @@ rcutils_load_shared_library(
     goto fail;
   }
   lib->library_path = rcutils_strdup(image_name, lib->allocator);
-#elif defined(_GNU_SOURCE) && !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__OHOS__)
+  // Emscripten defines _GNU_SOURCE but its dlopen()/dlinfo() are a JS-backed
+  // shim, not glibc's -- RTLD_DI_LINKMAP support (reading back a real
+  // struct link_map) doesn't exist there. A successful dlopen() would
+  // otherwise get treated as a failure once dlinfo() returns -1 below; the
+  // #else branch already covers this correctly (it just reuses the path we
+  // opened the library from, no introspection needed).
+#elif defined(_GNU_SOURCE) && !defined(__QNXNTO__) && !defined(__ANDROID__) && !defined(__OHOS__) && !defined(__EMSCRIPTEN__)
   struct link_map * map = NULL;
   if (dlinfo(lib->lib_pointer, RTLD_DI_LINKMAP, &map) != 0) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("dlinfo error: %s", dlerror());
@@ -291,7 +297,12 @@ rcutils_get_platform_library_name(
 
   int written = 0;
 
-#if defined(__linux__) || defined(__QNXNTO__)
+  // rcl_logging_implementation dlopens its backend (spdlog or noop) by name
+  // at runtime via this function -- with no emscripten case it always falls
+  // through with written == 0 ("failed to format library name"), regardless
+  // of which backend RCL_LOGGING_IMPLEMENTATION selects. wasm32 side modules
+  // use the same "lib<name>.so" naming convention as Linux.
+#if defined(__linux__) || defined(__QNXNTO__) || defined(__EMSCRIPTEN__)
   if (debug) {
     if (buffer_size >= (strlen(library_name) + 8)) {
       written = rcutils_snprintf(


### PR DESCRIPTION
## Summary

Two related gaps in `rcutils_load_shared_library()` / `rcutils_get_platform_library_name()`, found while getting `rcl_logging_implementation`'s dlopen-by-name backend selection working on `emscripten-wasm32`:

- `rcutils_get_platform_library_name()` had no emscripten branch, so it always fell through with `written == 0` ("failed to format library name"), regardless of which `RCL_LOGGING_IMPLEMENTATION` backend was requested. wasm32 side modules use the same `lib<name>.so` naming convention as Linux, so this reuses that branch.
- The post-`dlopen()` path-resolution code took the `_GNU_SOURCE` branch (which emscripten's headers define) and called `dlinfo(..., RTLD_DI_LINKMAP, ...)`. Emscripten's `dlopen()`/`dlinfo()` are a JS-backed shim, not glibc's, and don't support reading back a real `struct link_map` — so a successful `dlopen()` was getting treated as a failure once `dlinfo()` returned -1. The `#else` branch (reuse the path `dlopen()` was given) already covers this platform correctly, so this just excludes emscripten from the glibc-specific branch above it.

Both are narrow, additive `#if`/`#elif` guard changes — no behavior change on any existing platform.

## Test plan

Verified end-to-end on a ROS 2 rolling + `rmw_zenoh_pico` + real-pthreads `emscripten-wasm32` build (companion work in [RoboStack/vinca#154](https://github.com/RoboStack/vinca/pull/154) and [RoboStack/ros-rolling#46](https://github.com/RoboStack/ros-rolling/pull/46)): a wasm32 `rclpy` talker's logging initialization (`rcl_logging_configure` → `rcl_logging_implementation` → this dlopen path) now succeeds instead of aborting with "failed to load any logging implementations", regardless of which backend (`rcl_logging_spdlog` or `rcl_logging_noop`) is selected.

## Full write-up

All the changes this required, across every repo, are documented together in [Tobias-Fischer/ros2-emscripten-zenoh-demo](https://github.com/Tobias-Fischer/ros2-emscripten-zenoh-demo) — including a working `rclc` *and* `rclpy` browser demo verified end-to-end against a native `zenohd` router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
