### PR TITLE
Reset string array size when allocation fails in init

### DIFF
--- a/src/string_array.c
+++ b/src/string_array.c
@@ -53,6 +53,7 @@ rcutils_string_array_init(
   string_array->data = allocator->zero_allocate(size, sizeof(char *), allocator->state);
   if (NULL == string_array->data && 0 != size) {
     RCUTILS_SET_ERROR_MSG("failed to allocate string array");
+    string_array->size = 0;
     return RCUTILS_RET_BAD_ALLOC;
   }
   string_array->allocator = *allocator;

--- a/test/test_string_array.cpp
+++ b/test/test_string_array.cpp
@@ -73,6 +73,18 @@ TEST(test_string_array, boot_string_array) {
   ASSERT_EQ(RCUTILS_RET_OK, rcutils_string_array_fini(&sa4));
 }
 
+TEST(test_string_array, init_alloc_failure_leaves_array_empty) {
+  auto failing_allocator = get_failing_allocator();
+
+  rcutils_string_array_t sa = rcutils_get_zero_initialized_string_array();
+  EXPECT_EQ(RCUTILS_RET_BAD_ALLOC, rcutils_string_array_init(&sa, 3, &failing_allocator));
+  rcutils_reset_error();
+  // Nothing was allocated, so the array must not advertise entries that cannot be read.
+  EXPECT_EQ(nullptr, sa.data);
+  EXPECT_EQ(0u, sa.size);
+  EXPECT_EQ(RCUTILS_RET_OK, rcutils_string_array_fini(&sa));
+}
+
 TEST(test_string_array, string_array_cmp) {
   auto allocator = rcutils_get_default_allocator();
   rcutils_ret_t ret = RCUTILS_RET_OK;


### PR DESCRIPTION
## Description

`rcutils_string_array_init()` writes the requested size into the array before it tries to allocate:

```c
string_array->size = size;
string_array->data = allocator->zero_allocate(size, sizeof(char *), allocator->state);
if (NULL == string_array->data && 0 != size) {
  RCUTILS_SET_ERROR_MSG("failed to allocate string array");
  return RCUTILS_RET_BAD_ALLOC;
}
```

When the allocation fails, the function returns `RCUTILS_RET_BAD_ALLOC` but leaves `size` set to the requested count while `data` stays `NULL`. The array then advertises entries that cannot be read. A caller that checks the return value is fine, but one that inspects the array afterwards — or passes it to code that iterates `0..size` — walks a null pointer.

This PR sets `size` back to `0` on that error path, so a failed init leaves the array exactly as `rcutils_get_zero_initialized_string_array()` would.

Fixes # (no issue filed; found while reading the allocation failure paths)

### Is this user-facing behavior change?

Only on the failure path. On success nothing changes. After a failed `rcutils_string_array_init()` the array is now consistently empty (`data == NULL`, `size == 0`) instead of reporting a non-zero size with no backing storage, and `rcutils_string_array_fini()` on it returns `RCUTILS_RET_OK`.

### Did you use Generative AI?

Yes. Claude Opus 5, through Claude Code, found the inconsistent error path, wrote the one-line change in `src/string_array.c`, wrote the `init_alloc_failure_leaves_array_empty` test in `test/test_string_array.cpp`, and drafted this description. The build and test verification below was run afterwards and is reported exactly as the container printed it.

### Additional Information

**Verification.** My earlier note said I had no ROS 2 workspace on this machine. That is now done, in the official `ros:rolling-ros-base` image with the test dependencies (`osrf_testing_tools_cpp`, `performance_test_fixture`) installed by `rosdep`. Environment: Ubuntu 26.04.1, ROS 2 Rolling, gcc 15.2.0, cmake 4.2.3. Base: `a4cba34` on `rolling`.

With this change applied, `colcon build --packages-select rcutils` succeeds and the test file passes:

```
build : OK
test_string_array.gtest.xml : total=5 failures=0 errors=0
  init_alloc_failure_leaves_array_empty        passed
```

Then I reverted only `src/string_array.c`, keeping the new test, rebuilt, and it fails on current `rolling`:

```
build : OK
test_string_array.gtest.xml : total=5 failures=1 errors=0
  init_alloc_failure_leaves_array_empty        FAILED
    test_string_array.cpp:84
    Expected equality of these values:
      0u          Which is: 0
      sa.size     Which is: 3
```

The array reports three entries after an allocation that never happened. The other four tests in the file pass on both sides.
